### PR TITLE
PassThru Implemetation, and OutputType fixes.

### DIFF
--- a/extensions/csharp-v2/src/exports.ts
+++ b/extensions/csharp-v2/src/exports.ts
@@ -1,5 +1,6 @@
 export * from './clientruntime';
 export * from './code-model';
+export * from './schema/array';
 export { EventListener } from './operation/method';
 export * from './schema/binary';
 export * from './schema/object';

--- a/extensions/csharp-v2/src/schema/array.ts
+++ b/extensions/csharp-v2/src/schema/array.ts
@@ -35,6 +35,10 @@ export class ArrayOf implements EnhancedTypeDeclaration {
   protected get serializedName(): string | undefined {
     return this.schema.xml ? this.schema.xml.name : undefined;
   }
+  get elementTypeDeclaration(): string {
+    return this.elementType.declaration;
+  }
+
   get declaration(): string {
     return `${this.elementType.declaration}[]`;
   }


### PR DESCRIPTION
- Fixes Issue: Any cmdlets that do not return a value should implement `PassThru` (https://github.com/Azure/autorest/issues/3082)
- Fixes Issue: OutputType for cmdlets should always be singular (non-collection) (https://github.com/Azure/autorest/issues/3085) 
- Also, fix for cmdlets that have multiple output types. Now, instead of stacking multiple OutputType attributes, it inserts an array of output types in one OutputType attribute.