### PR TITLE
Proxy attributes

### DIFF
--- a/extensions/csharp-v2/src/clientruntime.ts
+++ b/extensions/csharp-v2/src/clientruntime.ts
@@ -20,6 +20,7 @@ const jsonArray = new ClassType(carbon, 'JsonArray');
 const jsonObject = new ClassType(carbon, 'JsonObject');
 
 export const ClientRuntime = intersect(clientRuntimeNamespace, {
+  AttachDebugger: new ClassType(clientRuntimeNamespace, 'AttachDebugger'),
   Method: intersect(method, {
     Get: new LiteralExpression(`${method.declaration}.Get`),
     Put: new LiteralExpression(`${method.declaration}.Put`),

--- a/extensions/csharp-v2/src/project.ts
+++ b/extensions/csharp-v2/src/project.ts
@@ -40,8 +40,8 @@ export class Project extends codeDomProject {
 
       'Carbon.Json': `${this.projectNamespace}.Runtime.Json`,
       'Microsoft.Rest.ClientRuntime': `${this.projectNamespace}.Runtime`,
+      'Microsoft.Rest': this.projectNamespace
     };
-
   }
 
   public async init(): Promise<this> {

--- a/extensions/powershell/resources/assets/build-module.ps1
+++ b/extensions/powershell/resources/assets/build-module.ps1
@@ -1,4 +1,4 @@
-param([Switch]$isolated, [Switch]$test, [Switch]$code)
+param([Switch]$isolated, [Switch]$test, [Switch]$code, [Switch]$Release)
 Push-Location $PSScriptRoot
 $ErrorActionPreference = "Stop"
 
@@ -38,7 +38,10 @@ if(-not $isolated) {
     Pop-Location
     return
 }
-
+$dotnetcfg = 'debug'
+if($Release) {
+  $dotnetcfg = 'release'
+}
 Write-Host -Fore green "Cleaning folders..."
 @('./obj', './bin') |% { $null = Remove-Item -Recurse -ea 0 $_ }
 $null = (Get-ChildItem -Path 'exports' -Recurse -Exclude 'readme.md' | Remove-Item -Recurse -ea 0)
@@ -49,10 +52,10 @@ if(Test-Path ./bin) {
 }
 
 Write-Host -Fore green "Compiling private module code"
-$null = dotnet publish --configuration Release --output bin
+$null = dotnet publish --configuration $dotnetcfg --output bin
 if( $lastExitCode -ne 0 ) {
     # if it fails, let's do it again so the output comes out nicely.
-    dotnet publish --configuration Release --output bin
+    dotnet publish --configuration $dotnetcfg --output bin
     Pop-Location
     Write-Error "Compilation failed"
 }

--- a/extensions/powershell/resources/runtime/Debugging.cs
+++ b/extensions/powershell/resources/runtime/Debugging.cs
@@ -1,8 +1,8 @@
-namespace System
+namespace Microsoft.Rest.ClientRuntime
 {
-    public static class AttachDebugger
+    internal static class AttachDebugger
     {
-        public static void Break()
+        internal static void Break()
         {
             while (!System.Diagnostics.Debugger.IsAttached)
             {

--- a/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
-using static Microsoft.Rest.ClientRuntime.PowerShell.PsExtensions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
@@ -19,140 +18,52 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         [ValidateNotNullOrEmpty]
         public string OutputFolder { get; set; }
 
-        private const string Indent = "    ";
-
         protected override void ProcessRecord()
         {
-            var cmdletGroups = CommandInfo
-                .Select(ci => {
-                    var metadata = new CommandMetadata(ci);
-                    var parts = metadata.Name.Split('_');
-                    return (name: parts[0], variant: parts.Length > 1 ? parts[1] : UnnamedVariant, info: ci, metadata: metadata);
-                })
-                .GroupBy(cg => cg.name);
-            foreach (var cmdletGroup in cmdletGroups)
+            var variantsGroups = CommandInfo
+                .Select(ci => ci.ToVariant())
+                .GroupBy(v => v.CmdletName)
+                .Select(vg => new VariantGroup(vg.Key, vg.Select(v => v).ToArray()));
+
+            foreach (var variantGroup in variantsGroups)
             {
-                var cmdletName = cmdletGroup.Key;
                 var sb = new StringBuilder();
-                sb.AppendLine($"function {cmdletName} {{");
-
-                var outputType = cmdletGroup.SelectMany(cg => cg.info.OutputType).FirstOrDefault();
-                var outputTypeText = outputType != null ? $"[OutputType('{outputType}')]{Environment.NewLine}" : String.Empty;
-                sb.Append(outputTypeText);
-
-                bool IsDontShow(ParameterMetadata pm) => pm.Attributes.OfType<ParameterAttribute>().Any(p => p.DontShow);
-                var variantParamCountGroups = cmdletGroup
-                    .Select(cg => (
-                        variant: cg.variant,
-                        paramCount: cg.metadata.Parameters.Count(p => !IsDontShow(p.Value) && p.Key != "DefaultProfile"),
-                        isSimple: cg.metadata.Parameters.Where(p => !IsDontShow(p.Value) && p.Key != "DefaultProfile").All(p => p.Value.ParameterType.IsPsSimple())))
-                    .GroupBy(vpc => vpc.isSimple)
-                    .ToArray();
-                var variantParameterCounts = (variantParamCountGroups.Any(g => g.Key) ? variantParamCountGroups.Where(g => g.Key) : variantParamCountGroups).SelectMany(g => g).ToArray();
-                var smallestParameterCount = variantParameterCounts.Min(vpc => vpc.paramCount);
-                var defaultParameterSet = variantParameterCounts.First(vpc => vpc.paramCount == smallestParameterCount).variant;
-
-                var dpsText = defaultParameterSet != UnnamedVariant ? $"DefaultParameterSetName='{defaultParameterSet}'" : String.Empty;
-                var supportsShouldProcess = cmdletGroup.Any(cg => cg.metadata.SupportsShouldProcess);
-                var hasMultipleVariants = cmdletGroup.Count() > 1;
-                var sspText = supportsShouldProcess ? $"{(hasMultipleVariants ? ", " : String.Empty)}SupportsShouldProcess={true.ToPsBool()}, ConfirmImpact='Medium'" : String.Empty;
-                sb.AppendLine($"[CmdletBinding({dpsText}{sspText})]");
+                sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
+                sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
+                sb.Append(variantGroup.ToCmdletBindingOutput());
 
                 sb.Append("param(");
-                var allVariants = cmdletGroup.Select(cg => cg.variant).ToArray();
-                var parameterGroups = cmdletGroup
-                    .SelectMany(cg => cg.metadata.Parameters.Select(p => (variant: cg.variant, parameter: p)))
-                    .GroupBy(p => p.parameter.Key) // Parameter key is the Parameter name
+                var allVariantNames = variantGroup.Variants.Select(vg => vg.VariantName).ToArray();
+                var parameterGroups = variantGroup.Variants
+                    .SelectMany(v => v.ToParameters())
+                    .GroupBy(p => p.ParameterName)
+                    .Select(pg => new ParameterGroup(pg.Key, pg.Select(p => p).ToArray(), allVariantNames))
                     .ToList();
                 sb.Append($"{(parameterGroups.Any() ? Environment.NewLine : String.Empty)}");
                 foreach (var parameterGroup in parameterGroups)
                 {
-                    var hasAllVariants = !allVariants.Except(parameterGroup.Select(pg => pg.variant)).Any();
-                    var filteredParameterGroup = hasAllVariants ? parameterGroup.Take(1) : parameterGroup;
-                    foreach (var variantGroup in filteredParameterGroup)
+                    var parameters = parameterGroup.HasAllVariants ? parameterGroup.Parameters.Take(1) : parameterGroup.Parameters;
+                    foreach (var parameter in parameters)
                     {
-                        var paramMetadata = variantGroup.parameter.Value;
-                        var paramAttribute = paramMetadata.Attributes.OfType<ParameterAttribute>().First();
-
-                        var psnText = hasMultipleVariants && !hasAllVariants ? $"ParameterSetName='{variantGroup.variant}', " : String.Empty;
-                        var mandatoryText = paramAttribute.Mandatory ? $"Mandatory={paramAttribute.Mandatory.ToPsBool()}, " : String.Empty;
-                        var dontShowText = paramAttribute.DontShow ? $"DontShow={paramAttribute.DontShow.ToPsBool()}, " : String.Empty;
-                        var vfpText = paramAttribute.ValueFromPipeline ? $"ValueFromPipeline={paramAttribute.ValueFromPipeline.ToPsBool()}, " : String.Empty;
-                        var helpText = $"HelpMessage='{paramAttribute.HelpMessage.ToPsStringLiteral()}'";
-                        sb.AppendLine($"{Indent}[Parameter({psnText}{mandatoryText}{dontShowText}{vfpText}{helpText})]");
+                        sb.Append(parameter.ToParameterOutput(variantGroup.HasMultipleVariants, parameterGroup.HasAllVariants));
                     }
-                    var aliases = parameterGroup.SelectMany(pg => pg.parameter.Value.Attributes.OfType<AliasAttribute>()).FirstOrDefault();
-                    var aliasText = aliases != null ? $"{Indent}[Alias({String.Join(",", aliases.AliasNames.Select(an => $"'{an}'"))})]{Environment.NewLine}" : String.Empty;
-                    sb.Append(aliasText);
-
-                    var hasVnn = parameterGroup.SelectMany(pg => pg.parameter.Value.Attributes.OfType<ValidateNotNullAttribute>()).Any();
-                    var vnnText = hasVnn ? $"{Indent}[ValidateNotNull()]{Environment.NewLine}" : String.Empty;
-                    sb.Append(vnnText);
-
-                    var parameterTypeText = parameterGroup.Select(pg => pg.parameter.Value.ParameterType).First().ToPsType();
-                    var hasArgumentCompleter = parameterGroup.SelectMany(pg => pg.parameter.Value.Attributes.OfType<ArgumentCompleterAttribute>()).Any();
-                    var acText = hasArgumentCompleter ? $"{Indent}[ArgumentCompleter([{parameterTypeText}])]{Environment.NewLine}" : String.Empty;
-                    sb.Append(acText);
-
-                    sb.AppendLine($"{Indent}[{parameterTypeText}]");
-
-                    var parameterName = parameterGroup.Key;
-                    var parameterSeparator = parameterGroups.IndexOf(parameterGroup) == parameterGroups.Count - 1 ? String.Empty : $",{Environment.NewLine}";
-                    sb.AppendLine($"{Indent}${{{parameterName}}}{parameterSeparator}");
+                    sb.Append(parameterGroup.Alias.ToAliasOutput());
+                    sb.Append(parameterGroup.HasValidateNotNull.ToValidateNotNullOutput());
+                    sb.Append(parameterGroup.ToArgumentCompleterOutput());
+                    sb.Append(parameterGroup.ParameterType.ToParameterTypeOutput());
+                    sb.Append(parameterGroup.ParameterName.ToParameterNameOutput(parameterGroups.IndexOf(parameterGroup) == parameterGroups.Count - 1));
                 }
-                sb.AppendLine($"){Environment.NewLine}");
+                sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
-                sb.AppendLine("begin {");
-                var sourceText = cmdletGroup.Select(cg => cg.info.Source).First();
-                var beginText = $@"{Indent}try {{
-{Indent}{Indent}$outBuffer = $null
-{Indent}{Indent}if ($PSBoundParameters.TryGetValue('OutBuffer', [ref]$outBuffer)) {{
-{Indent}{Indent}{Indent}$PSBoundParameters['OutBuffer'] = 1
-{Indent}{Indent}}}
-{Indent}{Indent}$parameterSet = $PsCmdlet.ParameterSetName
-{Indent}{Indent}$variantSuffix = ""_$parameterSet""
-{Indent}{Indent}if (""$parameterSet"" -eq '{UnnamedVariant}' -or ""$parameterSet"" -eq '{AllParameterSets}') {{
-{Indent}{Indent}{Indent}$variantSuffix = ''
-{Indent}{Indent}}}
-{Indent}{Indent}$wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand(""{sourceText}\{cmdletName}$variantSuffix"", [System.Management.Automation.CommandTypes]::Cmdlet)
-{Indent}{Indent}$scriptCmd = {{& $wrappedCmd @PSBoundParameters}}
-{Indent}{Indent}$steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
-{Indent}{Indent}$steppablePipeline.Begin($PSCmdlet)
-{Indent}}} catch {{
-{Indent}{Indent}throw
-{Indent}}}";
-                sb.AppendLine(beginText);
-                sb.AppendLine($"}}{Environment.NewLine}");
+                sb.Append(variantGroup.ToBeginOutput());
+                sb.Append(variantGroup.ToProcessOutput());
+                sb.Append(variantGroup.ToEndOutput());
 
-                sb.AppendLine("process {");
-                var processText = $@"{Indent}try {{
-{Indent}{Indent}$steppablePipeline.Process($_)
-{Indent}}} catch {{
-{Indent}{Indent}throw
-{Indent}}}";
-                sb.AppendLine(processText);
-                sb.AppendLine($"}}{Environment.NewLine}");
+                sb.Append(variantGroup.ToHelpCommentOutput());
 
-                sb.AppendLine("end {");
-                var endText = $@"{Indent}try {{
-{Indent}{Indent}$steppablePipeline.End()
-{Indent}}} catch {{
-{Indent}{Indent}throw
-{Indent}}}";
-                sb.AppendLine(endText);
-                sb.AppendLine($"}}{Environment.NewLine}");
+                sb.Append($"}}{Environment.NewLine}");
 
-                sb.AppendLine("<#");
-                var helpVariantText = hasMultipleVariants ? $"_{defaultParameterSet}" : String.Empty;
-                sb.AppendLine($".ForwardHelpTargetName {sourceText}\\{cmdletName}{helpVariantText}");
-                sb.AppendLine(".ForwardHelpCategory Cmdlet");
-                var cmdletDescription = cmdletGroup.Select(cg => cg.metadata.HelpUri).FirstOrDefault();
-                sb.AppendLine($".Description{Environment.NewLine}{cmdletDescription}");
-                sb.AppendLine("#>");
-
-                sb.AppendLine("}");
-
-                File.WriteAllText(Path.Combine(OutputFolder, $"{cmdletName}.ps1"), sb.ToString());
+                File.WriteAllText(Path.Combine(OutputFolder, $"{variantGroup.CmdletName}.ps1"), sb.ToString());
             }
         }
     }

--- a/extensions/powershell/resources/runtime/NewTestStub.cs
+++ b/extensions/powershell/resources/runtime/NewTestStub.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
-using static Microsoft.Rest.ClientRuntime.PowerShell.PsExtensions;
+using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyOutputExtensions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
@@ -27,7 +27,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 .Select(ci => {
                     var metadata = new CommandMetadata(ci);
                     var parts = metadata.Name.Split('_');
-                    return (name: parts[0], variant: parts.Length > 1 ? parts[1] : UnnamedVariant, info: ci, metadata: metadata);
+                    return (name: parts[0], variant: parts.Length > 1 ? parts[1] : NoParameters, info: ci, metadata: metadata);
                 })
                 .GroupBy(cg => cg.name)
                 .Select(cg => (cmdletGroup: cg, filename: Path.Combine(OutputFolder, $"{cg.Key}.Tests.ps1")))

--- a/extensions/powershell/resources/runtime/PsAttributes.cs
+++ b/extensions/powershell/resources/runtime/PsAttributes.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace Microsoft.Rest
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DescriptionAttribute : Attribute
+    {
+        public string Description { get; }
+
+        public DescriptionAttribute(string description)
+        {
+            Description = description;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class DoNotExportAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class GeneratedAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ProfileAttribute : Attribute
+    {
+        public string[] Profiles { get; }
+
+        public ProfileAttribute(params string[] profiles)
+        {
+            Profiles = profiles;
+        }
+    }
+
+
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class CategoryAttribute : Attribute
+    {
+        public ParameterCategory[] Categories { get; }
+
+        public CategoryAttribute(params ParameterCategory[] categories)
+        {
+            Categories = categories;
+        }
+    }
+
+    public enum ParameterCategory
+    {
+        Azure,
+        Runtime
+    }
+}

--- a/extensions/powershell/resources/runtime/PsExtensions.cs
+++ b/extensions/powershell/resources/runtime/PsExtensions.cs
@@ -7,12 +7,8 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
-    public static class PsExtensions
+    internal static class PsExtensions
     {
-        public const string UnnamedVariant = "__Generic";
-
-        public const string AllParameterSets = "__AllParameterSets";
-
         public static string ToPsBool(this bool value) => $"${value.ToString().ToLowerInvariant()}";
 
         public static string ToPsType(this Type type)

--- a/extensions/powershell/resources/runtime/PsProxyOutputs.cs
+++ b/extensions/powershell/resources/runtime/PsProxyOutputs.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyOutputExtensions;
+
+namespace Microsoft.Rest.ClientRuntime.PowerShell
+{
+    internal class OutputTypeOutput
+    {
+        public PSTypeName[] OutputTypes { get; }
+
+        public OutputTypeOutput(IEnumerable<PSTypeName> outputTypes)
+        {
+            OutputTypes = outputTypes.ToArray();
+        }
+
+        public override string ToString() => OutputTypes != null && OutputTypes.Any() ? $"[OutputType({String.Join(", ", OutputTypes.Select(ot => $"'{ot}'"))})]{Environment.NewLine}" : String.Empty;
+    }
+
+    internal class CmdletBindingOutput
+    {
+        public VariantGroup VariantGroup { get; }
+
+        public CmdletBindingOutput(VariantGroup variantGroup)
+        {
+            VariantGroup = variantGroup;
+        }
+
+        public override string ToString()
+        {
+            var isValidDpsn = VariantGroup.DefaultParameterSetName.IsValidParameterSetName();
+            var dpsText = isValidDpsn ? $"DefaultParameterSetName='{VariantGroup.DefaultParameterSetName}'" : String.Empty;
+            var sspText = VariantGroup.SupportsShouldProcess ? $"{(isValidDpsn ? ", " : String.Empty)}SupportsShouldProcess={true.ToPsBool()}, ConfirmImpact='Medium'" : String.Empty;
+            return $"[CmdletBinding({dpsText}{sspText})]{Environment.NewLine}";
+        }
+    }
+
+    internal class ParameterOutput
+    {
+        public Parameter Parameter { get; }
+        public bool HasMultipleVariantsInVariantGroup { get; }
+        public bool HasAllVariantsInParameterGroup { get; }
+
+        public ParameterOutput(Parameter parameter, bool hasMultipleVariantsInVariantGroup, bool hasAllVariantsInParameterGroup)
+        {
+            Parameter = parameter;
+            HasMultipleVariantsInVariantGroup = hasMultipleVariantsInVariantGroup;
+            HasAllVariantsInParameterGroup = hasAllVariantsInParameterGroup;
+        }
+
+        public override string ToString()
+        {
+            var pa = Parameter.ParameterAttribute;
+            var psnText = HasMultipleVariantsInVariantGroup && !HasAllVariantsInParameterGroup ? $"ParameterSetName='{Parameter.VariantName}', " : String.Empty;
+            var mandatoryText = pa.Mandatory ? $"Mandatory={pa.Mandatory.ToPsBool()}, " : String.Empty;
+            var dontShowText = pa.DontShow ? $"DontShow={pa.DontShow.ToPsBool()}, " : String.Empty;
+            var vfpText = pa.ValueFromPipeline ? $"ValueFromPipeline={pa.ValueFromPipeline.ToPsBool()}, " : String.Empty;
+            var helpText = $"HelpMessage='{pa.HelpMessage.ToPsStringLiteral()}'";
+            return $"{Indent}[Parameter({psnText}{mandatoryText}{dontShowText}{vfpText}{helpText})]{Environment.NewLine}";
+        }
+    }
+
+    internal class AliasOutput
+    {
+        public AliasAttribute Alias { get; }
+
+        public AliasOutput(AliasAttribute alias)
+        {
+            Alias = alias;
+        }
+
+        public override string ToString() => Alias != null ? $"{Indent}[Alias({String.Join(",", Alias.AliasNames.Select(an => $"'{an}'"))})]{Environment.NewLine}" : String.Empty;
+    }
+
+    internal class ValidateNotNullOutput
+    {
+        public bool HasValidateNotNull { get; }
+
+        public ValidateNotNullOutput(bool hasValidateNotNull)
+        {
+            HasValidateNotNull = hasValidateNotNull;
+        }
+
+        public override string ToString() => HasValidateNotNull ? $"{Indent}[ValidateNotNull()]{Environment.NewLine}" : String.Empty;
+    }
+
+    internal class ArgumentCompleterOutput
+    {
+        public bool HasArgumentCompleter { get; }
+        public Type ParameterType { get; }
+
+        public ArgumentCompleterOutput(ParameterGroup parameterGroup)
+        {
+            HasArgumentCompleter = parameterGroup.HasArgumentCompleter;
+            ParameterType = parameterGroup.ParameterType;
+        }
+
+        public override string ToString() => HasArgumentCompleter ? $"{Indent}[ArgumentCompleter([{ParameterType.ToPsType()}])]{Environment.NewLine}" : String.Empty;
+    }
+
+    internal class ParameterTypeOutput
+    {
+        public Type ParameterType { get; }
+
+        public ParameterTypeOutput(Type parameterType)
+        {
+            ParameterType = parameterType;
+        }
+
+        public override string ToString() => $"{Indent}[{ParameterType.ToPsType()}]{Environment.NewLine}";
+    }
+
+    internal class ParameterNameOutput
+    {
+        public string ParameterName { get; }
+        public bool IsLast { get; }
+
+        public ParameterNameOutput(string parameterName, bool isLast)
+        {
+            ParameterName = parameterName;
+            IsLast = isLast;
+        }
+
+        public override string ToString() => $"{Indent}${{{ParameterName}}}{(IsLast ? String.Empty : $",{Environment.NewLine}")}{Environment.NewLine}";
+    }
+
+    internal class BeginOutput
+    {
+        public VariantGroup VariantGroup { get; }
+
+        public BeginOutput(VariantGroup variantGroup)
+        {
+            VariantGroup = variantGroup;
+        }
+
+        public override string ToString() => $@"begin {{
+{Indent}try {{
+{Indent}{Indent}$outBuffer = $null
+{Indent}{Indent}if ($PSBoundParameters.TryGetValue('OutBuffer', [ref]$outBuffer)) {{
+{Indent}{Indent}{Indent}$PSBoundParameters['OutBuffer'] = 1
+{Indent}{Indent}}}
+{Indent}{Indent}$parameterSet = $PsCmdlet.ParameterSetName
+{Indent}{Indent}$variantSuffix = ""_$parameterSet""
+{Indent}{Indent}if (""$parameterSet"" -eq '{NoParameters}' -or ""$parameterSet"" -eq '{AllParameterSets}') {{
+{Indent}{Indent}{Indent}$variantSuffix = ''
+{Indent}{Indent}}}
+{Indent}{Indent}$wrappedCmd = $ExecutionContext.InvokeCommand.GetCommand(""{VariantGroup.ModuleName}\{VariantGroup.CmdletName}$variantSuffix"", [System.Management.Automation.CommandTypes]::Cmdlet)
+{Indent}{Indent}$scriptCmd = {{& $wrappedCmd @PSBoundParameters}}
+{Indent}{Indent}$steppablePipeline = $scriptCmd.GetSteppablePipeline($myInvocation.CommandOrigin)
+{Indent}{Indent}$steppablePipeline.Begin($PSCmdlet)
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
+    internal class ProcessOutput
+    {
+        public override string ToString() => $@"process {{
+{Indent}try {{
+{Indent}{Indent}$steppablePipeline.Process($_)
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
+    internal class EndOutput
+    {
+        public override string ToString() => $@"end {{
+{Indent}try {{
+{Indent}{Indent}$steppablePipeline.End()
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
+    internal class HelpCommentOutput
+    {
+        public VariantGroup VariantGroup { get; }
+
+        public HelpCommentOutput(VariantGroup variantGroup)
+        {
+            VariantGroup = variantGroup;
+        }
+
+        public override string ToString() => $@"<#
+.ForwardHelpTargetName {VariantGroup.ModuleName}\{VariantGroup.CmdletName}{(VariantGroup.DefaultParameterSetName.IsValidParameterSetName() ? $"_{VariantGroup.DefaultParameterSetName}" : String.Empty)}
+.ForwardHelpCategory Cmdlet
+.Description
+{VariantGroup.Description}
+#>
+";
+    }
+
+    internal static class PsProxyOutputExtensions
+    {
+        public const string NoParameters = "__NoParameters";
+
+        public const string AllParameterSets = "__AllParameterSets";
+
+        public const string Indent = "    ";
+
+        public static OutputTypeOutput ToOutputTypeOutput(this IEnumerable<PSTypeName> outputTypes) => new OutputTypeOutput(outputTypes);
+
+        public static CmdletBindingOutput ToCmdletBindingOutput(this VariantGroup variantGroup) => new CmdletBindingOutput(variantGroup);
+
+        public static ParameterOutput ToParameterOutput(this Parameter parameter, bool hasMultipleVariantsInVariantGroup, bool hasAllVariantsInParameterGroup) => new ParameterOutput(parameter, hasMultipleVariantsInVariantGroup, hasAllVariantsInParameterGroup);
+
+        public static AliasOutput ToAliasOutput(this AliasAttribute alias) => new AliasOutput(alias);
+
+        public static ValidateNotNullOutput ToValidateNotNullOutput(this bool hasValidateNotNull) => new ValidateNotNullOutput(hasValidateNotNull);
+
+        public static ArgumentCompleterOutput ToArgumentCompleterOutput(this ParameterGroup parameterGroup) => new ArgumentCompleterOutput(parameterGroup);
+
+        public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
+
+        public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
+
+        public static ProcessOutput ToProcessOutput(this VariantGroup variantGroup) => new ProcessOutput();
+
+        public static EndOutput ToEndOutput(this VariantGroup variantGroup) => new EndOutput();
+
+        public static HelpCommentOutput ToHelpCommentOutput(this VariantGroup variantGroup) => new HelpCommentOutput(variantGroup);
+    }
+}

--- a/extensions/powershell/resources/runtime/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/PsProxyTypes.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Linq;
+using System.Management.Automation;
+using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyOutputExtensions;
+
+namespace Microsoft.Rest.ClientRuntime.PowerShell
+{
+    internal class VariantGroup
+    {
+        public string CmdletName { get; }
+        public Variant[] Variants { get; }
+
+        public PSTypeName[] OutputTypes { get; }
+        public bool SupportsShouldProcess { get; }
+        public string DefaultParameterSetName { get; }
+        public bool HasMultipleVariants { get; }
+        public string ModuleName { get; }
+        public string Description { get; }
+
+        public VariantGroup(string cmdletName, Variant[] variants)
+        {
+            CmdletName = cmdletName;
+            Variants = variants;
+            OutputTypes = Variants.SelectMany(v => v.Info.OutputType).GroupBy(ot => ot.Type).Select(otg => otg.First()).ToArray();
+            SupportsShouldProcess = Variants.Any(v => v.Metadata.SupportsShouldProcess);
+            DefaultParameterSetName = DetermineDefaultParameterSetName();
+            HasMultipleVariants = Variants.Length > 1;
+            ModuleName = Variants.Select(v => v.Info.Source).First();
+            Description = Variants.SelectMany(v => v.Attributes).OfType<DescriptionAttribute>().FirstOrDefault()?.Description;
+        }
+
+        private string DetermineDefaultParameterSetName()
+        {
+            var defaultParameterSet = Variants
+                .Select(v => v.Metadata.DefaultParameterSetName)
+                .FirstOrDefault(dpsn => dpsn.IsValidParameterSetName());
+
+            if (String.IsNullOrEmpty(defaultParameterSet))
+            {
+                var variantParamCountGroups = Variants
+                    .Select(v => (
+                        variant: v.VariantName,
+                        paramCount: v.CmdletOnlyParameters.Length,
+                        isSimple: v.CmdletOnlyParameters.All(p => p.Metadata.ParameterType.IsPsSimple())))
+                    .GroupBy(vpc => vpc.isSimple)
+                    .ToArray();
+                var variantParameterCounts = (variantParamCountGroups.Any(g => g.Key) ? variantParamCountGroups.Where(g => g.Key) : variantParamCountGroups).SelectMany(g => g).ToArray();
+                var smallestParameterCount = variantParameterCounts.Min(vpc => vpc.paramCount);
+                defaultParameterSet = variantParameterCounts.First(vpc => vpc.paramCount == smallestParameterCount).variant;
+            }
+
+            return defaultParameterSet;
+        }
+    }
+
+    internal class Variant
+    {
+        public string CmdletName { get; }
+        public string VariantName { get; }
+        public CommandInfo Info { get; }
+        public CommandMetadata Metadata { get; }
+
+        public Attribute[] Attributes { get; }
+        public Parameter[] Parameters { get; }
+        public Parameter[] CmdletOnlyParameters { get; }
+
+        public Variant(string cmdletName, string variantName, CommandInfo info, CommandMetadata metadata)
+        {
+            CmdletName = cmdletName;
+            VariantName = variantName;
+            Info = info;
+            Metadata = metadata;
+            Attributes = Metadata.CommandType.GetCustomAttributes(false).Cast<Attribute>().ToArray();
+            Parameters = this.ToParameters();
+            CmdletOnlyParameters = Parameters.Where(p => !p.Metadata.Attributes.OfType<CategoryAttribute>().Any(a =>
+                a.Categories.Contains(ParameterCategory.Azure) ||
+                a.Categories.Contains(ParameterCategory.Runtime))).ToArray();
+        }
+    }
+
+    internal class ParameterGroup
+    {
+        public string ParameterName { get; }
+        public Parameter[] Parameters { get; }
+
+        public string[] AllVariantNames { get; }
+        public bool HasAllVariants { get; }
+        public Type ParameterType { get; }
+
+        public AliasAttribute Alias { get; }
+        public bool HasValidateNotNull { get; }
+        public bool HasArgumentCompleter { get; }
+
+        public ParameterGroup(string parameterName, Parameter[] parameters, string[] allVariantNames)
+        {
+            ParameterName = parameterName;
+            Parameters = parameters;
+
+            AllVariantNames = allVariantNames;
+            HasAllVariants = !AllVariantNames.Except(Parameters.Select(p => p.VariantName)).Any();
+            ParameterType = Parameters.Select(p => p.Metadata.ParameterType).First();
+
+            Alias = Parameters.SelectMany(p => p.Attributes.OfType<AliasAttribute>()).FirstOrDefault();
+            HasValidateNotNull = Parameters.SelectMany(p => p.Attributes.OfType<ValidateNotNullAttribute>()).Any();
+            HasArgumentCompleter = Parameters.SelectMany(p => p.Attributes.OfType<ArgumentCompleterAttribute>()).Any();
+        }
+    }
+
+    internal class Parameter
+    {
+        public string VariantName { get; }
+        public string ParameterName { get; }
+        public ParameterMetadata Metadata { get; }
+
+        public Attribute[] Attributes { get; }
+        public ParameterAttribute ParameterAttribute { get; }
+
+        public Parameter(string variantName, string parameterName, ParameterMetadata metadata)
+        {
+            VariantName = variantName;
+            ParameterName = parameterName;
+            Metadata = metadata;
+            Attributes = Metadata.Attributes.ToArray();
+            ParameterAttribute = Attributes.OfType<ParameterAttribute>().First();
+        }
+    }
+
+    internal static class PsProxyTypeExtensions
+    {
+        public static bool IsValidParameterSetName(this string parameterSetName) =>
+            !String.IsNullOrEmpty(parameterSetName)
+            && parameterSetName != NoParameters
+            && parameterSetName != AllParameterSets;
+
+        public static Variant ToVariant(this CommandInfo info)
+        {
+            var metadata = new CommandMetadata(info);
+            var parts = metadata.Name.Split('_');
+            return new Variant(parts[0], parts.Length > 1 ? parts[1] : NoParameters, info, metadata);
+        }
+
+        public static Parameter[] ToParameters(this Variant variant) => variant.Metadata.Parameters.Select(p => new Parameter(variant.VariantName, p.Key, p.Value)).ToArray();
+    }
+}

--- a/extensions/powershell/src/cmdlet-class.ts
+++ b/extensions/powershell/src/cmdlet-class.ts
@@ -14,7 +14,7 @@ import {
 import { ClientRuntime, EventListener, Schema, ArrayOf } from '@microsoft.azure/autorest.csharp-v2';
 
 import { addPowershellParameters } from './model-cmdlet';
-import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum } from './powershell-declarations';
+import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, CategoryAttribute, ParameterCategory } from './powershell-declarations';
 import { State } from './state';
 
 export class CmdletClass extends Class {
@@ -100,32 +100,39 @@ export class CmdletClass extends Class {
 
     // debugging
     const brk = this.add(new Property('Break', SwitchParameter, { attributes: [], description: `Wait for .NET debugger to attach` }));
-    brk.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow= true`, `HelpMessage = "Wait for .NET debugger to attach"`] }));
+    brk.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow = true`, `HelpMessage = "Wait for .NET debugger to attach"`] }));
+    brk.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
 
     // Cmdlet Parameters for pipeline manipulations.
     const prepend = this.add(new Property('HttpPipelinePrepend', ClientRuntime.SendAsyncStep, { attributes: [], description: `SendAsync Pipeline Steps to be prepended to the front of the pipeline` }));
-    prepend.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow= true`, `HelpMessage = "SendAsync Pipeline Steps to be prepended to the front of the pipeline"`] }));
+    prepend.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow = true`, `HelpMessage = "SendAsync Pipeline Steps to be prepended to the front of the pipeline"`] }));
     prepend.add(new Attribute(ValidateNotNull));
+    prepend.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
 
     const append = this.add(new Property('HttpPipelineAppend', ClientRuntime.SendAsyncStep, { attributes: [], description: `SendAsync Pipeline Steps to be appended to the front of the pipeline` }));
-    append.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow= true`, `HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline"`] }));
+    append.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow = true`, `HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline"`] }));
     append.add(new Attribute(ValidateNotNull));
+    append.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
 
     const proxyCredential = this.add(new Property('ProxyCredential', PSCredential, { attributes: [], description: `Credentials for a proxy server to use for the remote call` }));
-    proxyCredential.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow= true`, `HelpMessage = "Credentials for a proxy server to use for the remote call"`] }));
+    proxyCredential.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow = true`, `HelpMessage = "Credentials for a proxy server to use for the remote call"`] }));
     proxyCredential.add(new Attribute(ValidateNotNull));
+    proxyCredential.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
 
     const useDefaultCreds = this.add(new Property('ProxyUseDefaultCredentials ', SwitchParameter, { attributes: [], description: `Use the default credentials for the proxy` }));
-    useDefaultCreds.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow= true`, `HelpMessage = "Use the default credentials for the proxy"`] }));
+    useDefaultCreds.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow = true`, `HelpMessage = "Use the default credentials for the proxy"`] }));
+    useDefaultCreds.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
 
     const proxyUri = this.add(new Property('Proxy', System.Uri, { attributes: [], description: `The URI for the proxy server to use` }));
-    proxyUri.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow= true`, `HelpMessage = "The URI for the proxy server to use"`] }));
+    proxyUri.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `DontShow = true`, `HelpMessage = "The URI for the proxy server to use"`] }));
+    proxyUri.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
 
     if (this.state.project.azure) {
       const defaultProfile = this.add(new Property('DefaultProfile', dotnet.Object, { description: `The credentials, account, tenant, and subscription used for communication with Azure` }));
       defaultProfile.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `HelpMessage = "The credentials, account, tenant, and subscription used for communication with Azure."`] }));
       defaultProfile.add(new Attribute(ValidateNotNull));
       defaultProfile.add(new Attribute(Alias, { parameters: ['"AzureRMContext"', '"AzureCredential"'] }));
+      defaultProfile.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
     }
 
     this.add(new Method('StopProcessing', dotnet.Void, { access: Access.Protected, override: Modifier.Override, description: `Interrupts currently running code within the command.` })).add(function* () {
@@ -644,7 +651,7 @@ export class CmdletClass extends Class {
 
   private addClassAttributes(operation: command.CommandOperation, variantName: string) {
 
-    const cmdletAttribParams: Array<ExpressionOrLiteral> = [verbEnum(operation.category, operation.verb), new StringExpression(variantName), `HelpUri = "${this.description}"`];
+    const cmdletAttribParams: Array<ExpressionOrLiteral> = [verbEnum(operation.category, operation.verb), new StringExpression(variantName)];
     if (this.isWritableCmdlet(operation)) {
       cmdletAttribParams.push(`SupportsShouldProcess = true`);
     }
@@ -690,6 +697,9 @@ export class CmdletClass extends Class {
         const passThru = this.add(new Property('PassThru', SwitchParameter, { description: messageAndDescription }));
         passThru.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', `HelpMessage = "${messageAndDescription}"`] }));
       }
+
+      this.add(new Attribute(DescriptionAttribute, { parameters: [new StringExpression(this.description)] }))
+      this.add(new Attribute(GeneratedAttribute));
     }
   }
 }

--- a/extensions/powershell/src/cmdlet-class.ts
+++ b/extensions/powershell/src/cmdlet-class.ts
@@ -52,7 +52,7 @@ export class CmdletClass extends Class {
       description: `(overrides the default BeginProcessing method in ${PSCmdlet})`,
       *body() {
         yield `Module.Instance.SetProxyConfiguration(Proxy, ProxyCredential, ProxyUseDefaultCredentials);`;
-        yield If($this.$<Property>('Break'), 'System.AttachDebugger.Break();');
+        yield If($this.$<Property>('Break'), 'AttachDebugger.Break();');
 
         yield $this.eventListener.syncSignal(Events.CmdletBeginProcessing);
       }

--- a/extensions/powershell/src/cmdlet-class.ts
+++ b/extensions/powershell/src/cmdlet-class.ts
@@ -52,7 +52,7 @@ export class CmdletClass extends Class {
       description: `(overrides the default BeginProcessing method in ${PSCmdlet})`,
       *body() {
         yield `Module.Instance.SetProxyConfiguration(Proxy, ProxyCredential, ProxyUseDefaultCredentials);`;
-        yield If($this.$<Property>('Break'), 'AttachDebugger.Break();');
+        yield If($this.$<Property>('Break'), `${ClientRuntime.AttachDebugger}.Break();`);
 
         yield $this.eventListener.syncSignal(Events.CmdletBeginProcessing);
       }

--- a/extensions/powershell/src/model-cmdlet.ts
+++ b/extensions/powershell/src/model-cmdlet.ts
@@ -9,7 +9,7 @@ import { escapeString, items, length, pascalCase, values } from '@microsoft.azur
 import { Binary, Schema } from '@microsoft.azure/autorest.csharp-v2';
 import { Access, Attribute, Class, ImplementedProperty, InitializedField, LiteralExpression, MemberVariable, Method, Modifier, Namespace, Statements, StringExpression, System, valueOf, Variable, } from '@microsoft.azure/codegen-csharp';
 
-import { ArgumentCompleterAttribute, CmdletAttribute, OutputTypeAttribute, ParameterAttribute, PSCmdlet, SwitchParameter } from './powershell-declarations';
+import { ArgumentCompleterAttribute, CmdletAttribute, OutputTypeAttribute, ParameterAttribute, PSCmdlet, SwitchParameter, DescriptionAttribute, GeneratedAttribute } from './powershell-declarations';
 import { State } from './state';
 
 export interface WithState extends Class {
@@ -42,8 +42,10 @@ export class ModelCmdlet extends Class {
 
 function addClassAttributes($class: WithState, schema: Schema, name: string) {
   const td = $class.state.project.schemaDefinitionResolver.resolveTypeDeclaration(schema, true, $class.state);
-  $class.add(new Attribute(CmdletAttribute, { parameters: [`System.Management.Automation.VerbsCommon.New`, new StringExpression(`${$class.state.project.nounPrefix}${schema.details.csharp.name || ''}Object`), `HelpUri = "Cmdlet to create an in-memory instance of the ${schema.details.csharp.name} object."`] }));
+  $class.add(new Attribute(CmdletAttribute, { parameters: [`System.Management.Automation.VerbsCommon.New`, new StringExpression(`${$class.state.project.nounPrefix}${schema.details.csharp.name || ''}Object`)] }));
   $class.add(new Attribute(OutputTypeAttribute, { parameters: [`typeof(${td.declaration})`] }));
+  $class.add(new Attribute(DescriptionAttribute, { parameters: [new StringExpression(`Cmdlet to create an in-memory instance of the ${schema.details.csharp.name} object.`)] }))
+  $class.add(new Attribute(GeneratedAttribute));
 }
 
 export function addPowershellParameters($class: WithState, schema: Schema, prop: Variable, ensureMemberIsCreated: Statements | undefined = undefined, expandName = false) {

--- a/extensions/powershell/src/powershell-declarations.ts
+++ b/extensions/powershell/src/powershell-declarations.ts
@@ -10,6 +10,7 @@ import { ClientRuntime } from '@microsoft.azure/autorest.csharp-v2';
 import { IInterface } from '@microsoft.azure/codegen-csharp';
 
 const sma = new Namespace(`System.Management.Automation`);
+const rest = new Namespace(`Microsoft.Rest`);
 
 export const PSCmdlet = new Class(new Namespace('System.Management.Automation'), 'PSCmdlet');
 export const PSCredential: TypeDeclaration = new ClassType(sma, `PSCredential`);
@@ -35,6 +36,13 @@ export const ArgumentCompleterAttribute: TypeDeclaration = new ClassType(sma, `A
 
 export const AsyncCommandRuntime = new ClassType(ClientRuntime, `PowerShell.AsyncCommandRuntime`);
 export const AsyncJob = new ClassType(ClientRuntime, `PowerShell.AsyncJob`);
+
+export const DescriptionAttribute: TypeDeclaration = new ClassType(rest, `Description`);
+export const DoNotExportAttribute: TypeDeclaration = new ClassType(rest, `DoNotExport`);
+export const GeneratedAttribute: TypeDeclaration = new ClassType(rest, `Generated`);
+export const ProfileAttribute: TypeDeclaration = new ClassType(rest, `Profile`);
+export const CategoryAttribute: TypeDeclaration = new ClassType(rest, `Category`);
+export const ParameterCategory: TypeDeclaration = new ClassType(rest, `ParameterCategory`);
 
 export function ErrorCategory(category: string): Expression {
   return new LiteralExpression(`${sma}.ErrorCategory.${category}`);

--- a/extensions/powershell/src/project.ts
+++ b/extensions/powershell/src/project.ts
@@ -52,6 +52,7 @@ export class Project extends codeDomProject {
       'Carbon.Json.Parser': `${this.projectNamespace}.Runtime.Json`,
       'Carbon.Json': `${this.projectNamespace}.Runtime.Json`,
       'Microsoft.Rest.ClientRuntime': `${this.projectNamespace}.Runtime`,
+      'Microsoft.Rest': `${this.projectNamespace}`,
     };
   }
 


### PR DESCRIPTION
Added additional attributes to be used by the proxy generator. Updated implementation of proxy generator to have meta types that wrap the PowerShell types. They also have output types that tell them out to output into the script. Added new attributes to the generated cmdlets where appropriate. Fixed a bug with the help comment generation. Allowed output types to use all available distinct types.