### PR TITLE
Proxy generator, help cleanup

### DIFF
--- a/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                     sb.Append(parameterGroup.HasValidateNotNull.ToValidateNotNullOutput());
                     sb.Append(parameterGroup.ToArgumentCompleterOutput());
                     sb.Append(parameterGroup.ParameterType.ToParameterTypeOutput());
+                    sb.Append(parameterGroup.HelpMessage.ToParameterHelpOutput());
                     sb.Append(parameterGroup.ParameterName.ToParameterNameOutput(parameterGroups.IndexOf(parameterGroup) == parameterGroups.Count - 1));
                 }
                 sb.Append($"){Environment.NewLine}{Environment.NewLine}");

--- a/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             foreach (var variantGroup in variantsGroups)
             {
                 var sb = new StringBuilder();
+                sb.Append(variantGroup.ToHelpCommentOutput());
                 sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
                 sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
                 sb.Append(variantGroup.ToCmdletBindingOutput());
@@ -58,8 +59,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 sb.Append(variantGroup.ToBeginOutput());
                 sb.Append(variantGroup.ToProcessOutput());
                 sb.Append(variantGroup.ToEndOutput());
-
-                sb.Append(variantGroup.ToHelpCommentOutput());
 
                 sb.Append($"}}{Environment.NewLine}");
 

--- a/extensions/powershell/resources/runtime/PsExtensions.cs
+++ b/extensions/powershell/resources/runtime/PsExtensions.cs
@@ -3,23 +3,11 @@ using System.Collections;
 using System.Linq;
 using System.Management.Automation;
 using System.Reflection;
-using System.Text.RegularExpressions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
     internal static class PsExtensions
     {
-        public static string ToPsBool(this bool value) => $"${value.ToString().ToLowerInvariant()}";
-
-        public static string ToPsType(this Type type)
-        {
-            var regex = new Regex(@"^(.*)`{1}\d+(.*)$");
-            var match = regex.Match(type.ToString());
-            return match.Success ? $"{match.Groups[1]}{match.Groups[2]}" : type.ToString();
-        }
-
-        public static string ToPsStringLiteral(this string value) => value?.Replace("'", "''");
-
         // https://stackoverflow.com/a/863944/294804
         private static bool IsSimple(this Type type)
         {

--- a/extensions/powershell/resources/runtime/PsProxyOutputs.cs
+++ b/extensions/powershell/resources/runtime/PsProxyOutputs.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             HelpMessage = helpMessage;
         }
 
-        public override string ToString() => !String.IsNullOrEmpty(HelpMessage) ? $"{Indent}# {HelpMessage.ToPsStringLiteral()}{Environment.NewLine}" : String.Empty;
+        public override string ToString() => !String.IsNullOrEmpty(HelpMessage) ? $"{Indent}# {HelpMessage}{Environment.NewLine}" : String.Empty;
     }
 
     internal static class PsProxyOutputExtensions

--- a/extensions/powershell/resources/runtime/PsProxyOutputs.cs
+++ b/extensions/powershell/resources/runtime/PsProxyOutputs.cs
@@ -193,8 +193,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         }
 
         public override string ToString() => $@"<#
-.ForwardHelpTargetName {VariantGroup.ModuleName}\{VariantGroup.CmdletName}{(VariantGroup.DefaultParameterSetName.IsValidParameterSetName() ? $"_{VariantGroup.DefaultParameterSetName}" : String.Empty)}
-.ForwardHelpCategory Cmdlet
 .Description
 {VariantGroup.Description}
 #>

--- a/extensions/powershell/resources/runtime/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/PsProxyTypes.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public AliasAttribute Alias { get; }
         public bool HasValidateNotNull { get; }
         public bool HasArgumentCompleter { get; }
+        public string HelpMessage { get; }
 
         public ParameterGroup(string parameterName, Parameter[] parameters, string[] allVariantNames)
         {
@@ -103,6 +104,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             Alias = Parameters.SelectMany(p => p.Attributes.OfType<AliasAttribute>()).FirstOrDefault();
             HasValidateNotNull = Parameters.SelectMany(p => p.Attributes.OfType<ValidateNotNullAttribute>()).Any();
             HasArgumentCompleter = Parameters.SelectMany(p => p.Attributes.OfType<ArgumentCompleterAttribute>()).Any();
+            HelpMessage = Parameters.Select(p => p.ParameterAttribute.HelpMessage).FirstOrDefault(hm => !String.IsNullOrEmpty(hm));
         }
     }
 


### PR DESCRIPTION
- Collapsed parameter HelpMessage into a help comment (valid for script cmdlets)
- Removed `=$true` for boolean properties (not required)
- Moved cmdlet help comment to the top of the script
- Removed help forwarding from cmdlet help comment
- Normalized comma separated values