### PR TITLE
Proxy: Profiles and tests

### DIFF
--- a/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         protected override void ProcessRecord()
         {
-            var variantsGroups = CommandInfo
+            var variantGroups = CommandInfo
                 .Select(ci => ci.ToVariant())
                 .GroupBy(v => v.CmdletName)
                 .Select(vg => new VariantGroup(vg.Key, vg.Select(v => v).ToArray()));
 
-            foreach (var variantGroup in variantsGroups)
+            foreach (var variantGroup in variantGroups)
             {
                 var sb = new StringBuilder();
                 sb.Append(variantGroup.ToHelpCommentOutput());

--- a/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/NewProxyCmdlet.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
+using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyTypeExtensions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
@@ -20,50 +21,62 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         protected override void ProcessRecord()
         {
-            var variantGroups = CommandInfo
-                .Select(ci => ci.ToVariant())
-                .GroupBy(v => v.CmdletName)
-                .Select(vg => new VariantGroup(vg.Key, vg.Select(v => v).ToArray()));
+            var variants = CommandInfo.Select(ci => ci.ToVariant()).ToArray();
+            var allProfiles = variants.SelectMany(v => v.Profiles).Distinct().ToArray();
+            var profileGroups = allProfiles.Any()
+                ? variants
+                    .SelectMany(v => (v.Profiles.Any() ? v.Profiles : allProfiles).Select(p => (profile: p, variant: v)))
+                    .GroupBy(pv => pv.profile)
+                    .Select(pvg => new ProfileGroup(pvg.Select(pv => pv.variant).ToArray(), pvg.Key))
+                : new[] { new ProfileGroup(variants) };
 
-            foreach (var variantGroup in variantGroups)
+            foreach (var profileGroup in profileGroups)
             {
-                var sb = new StringBuilder();
-                sb.Append(variantGroup.ToHelpCommentOutput());
-                sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
-                sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
-                sb.Append(variantGroup.ToCmdletBindingOutput());
+                var variantGroups = profileGroup.Variants
+                    .GroupBy(v => v.CmdletName)
+                    .Select(vg => new VariantGroup(vg.Key, vg.Select(v => v).ToArray(), Path.Combine(OutputFolder, profileGroup.ProfileFolder)));
 
-                sb.Append("param(");
-                var allVariantNames = variantGroup.Variants.Select(vg => vg.VariantName).ToArray();
-                var parameterGroups = variantGroup.Variants
-                    .SelectMany(v => v.ToParameters())
-                    .GroupBy(p => p.ParameterName)
-                    .Select(pg => new ParameterGroup(pg.Key, pg.Select(p => p).ToArray(), allVariantNames))
-                    .ToList();
-                sb.Append($"{(parameterGroups.Any() ? Environment.NewLine : String.Empty)}");
-                foreach (var parameterGroup in parameterGroups)
+                foreach (var variantGroup in variantGroups)
                 {
-                    var parameters = parameterGroup.HasAllVariants ? parameterGroup.Parameters.Take(1) : parameterGroup.Parameters;
-                    foreach (var parameter in parameters)
+                    var sb = new StringBuilder();
+                    sb.Append(variantGroup.ToHelpCommentOutput());
+                    sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
+                    sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
+                    sb.Append(variantGroup.ToCmdletBindingOutput());
+
+                    sb.Append("param(");
+                    var allVariantNames = variantGroup.Variants.Select(vg => vg.VariantName).ToArray();
+                    var parameterGroups = variantGroup.Variants
+                        .SelectMany(v => v.ToParameters())
+                        .GroupBy(p => p.ParameterName)
+                        .Select(pg => new ParameterGroup(pg.Key, pg.Select(p => p).ToArray(), allVariantNames))
+                        .ToList();
+                    sb.Append($"{(parameterGroups.Any() ? Environment.NewLine : String.Empty)}");
+                    foreach (var parameterGroup in parameterGroups)
                     {
-                        sb.Append(parameter.ToParameterOutput(variantGroup.HasMultipleVariants, parameterGroup.HasAllVariants));
+                        var parameters = parameterGroup.HasAllVariants ? parameterGroup.Parameters.Take(1) : parameterGroup.Parameters;
+                        foreach (var parameter in parameters)
+                        {
+                            sb.Append(parameter.ToParameterOutput(variantGroup.HasMultipleVariants, parameterGroup.HasAllVariants));
+                        }
+                        sb.Append(parameterGroup.Alias.ToAliasOutput());
+                        sb.Append(parameterGroup.HasValidateNotNull.ToValidateNotNullOutput());
+                        sb.Append(parameterGroup.ToArgumentCompleterOutput());
+                        sb.Append(parameterGroup.ParameterType.ToParameterTypeOutput());
+                        sb.Append(parameterGroup.HelpMessage.ToParameterHelpOutput());
+                        sb.Append(parameterGroup.ParameterName.ToParameterNameOutput(parameterGroups.IndexOf(parameterGroup) == parameterGroups.Count - 1));
                     }
-                    sb.Append(parameterGroup.Alias.ToAliasOutput());
-                    sb.Append(parameterGroup.HasValidateNotNull.ToValidateNotNullOutput());
-                    sb.Append(parameterGroup.ToArgumentCompleterOutput());
-                    sb.Append(parameterGroup.ParameterType.ToParameterTypeOutput());
-                    sb.Append(parameterGroup.HelpMessage.ToParameterHelpOutput());
-                    sb.Append(parameterGroup.ParameterName.ToParameterNameOutput(parameterGroups.IndexOf(parameterGroup) == parameterGroups.Count - 1));
+                    sb.Append($"){Environment.NewLine}{Environment.NewLine}");
+
+                    sb.Append(variantGroup.ToBeginOutput());
+                    sb.Append(variantGroup.ToProcessOutput());
+                    sb.Append(variantGroup.ToEndOutput());
+
+                    sb.Append($"}}{Environment.NewLine}");
+
+                    Directory.CreateDirectory(variantGroup.OutputFolder);
+                    File.WriteAllText(variantGroup.FilePath, sb.ToString());
                 }
-                sb.Append($"){Environment.NewLine}{Environment.NewLine}");
-
-                sb.Append(variantGroup.ToBeginOutput());
-                sb.Append(variantGroup.ToProcessOutput());
-                sb.Append(variantGroup.ToEndOutput());
-
-                sb.Append($"}}{Environment.NewLine}");
-
-                File.WriteAllText(Path.Combine(OutputFolder, $"{variantGroup.CmdletName}.ps1"), sb.ToString());
             }
         }
     }

--- a/extensions/powershell/resources/runtime/NewTestStub.cs
+++ b/extensions/powershell/resources/runtime/NewTestStub.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var variantGroups = CommandInfo
                 .Select(ci => ci.ToVariant())
                 .GroupBy(v => v.CmdletName)
-                .Select(vg => new VariantTestGroup(vg.Key, vg.Select(v => v).ToArray(), Path.Combine(OutputFolder, $"{vg.Key}.Tests.ps1")))
-                .Where(vtg => !File.Exists(vtg.Filename) && !vtg.IsGenerated);
+                .Select(vg => new VariantGroup(vg.Key, vg.Select(v => v).ToArray(), OutputFolder, true))
+                .Where(vtg => !File.Exists(vtg.FilePath) && !vtg.IsGenerated);
 
             foreach (var variantGroup in variantGroups)
             {
@@ -46,7 +46,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 }
                 sb.AppendLine("}");
 
-                File.WriteAllText(variantGroup.Filename, sb.ToString());
+                File.WriteAllText(variantGroup.FilePath, sb.ToString());
             }
         }
     }

--- a/extensions/powershell/resources/runtime/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/PsProxyTypes.cs
@@ -53,6 +53,18 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         }
     }
 
+    internal class VariantTestGroup : VariantGroup
+    {
+        public string Filename { get; }
+        public bool IsGenerated { get; }
+
+        public VariantTestGroup(string cmdletName, Variant[] variants, string filename) : base(cmdletName, variants)
+        {
+            Filename = filename;
+            IsGenerated = Variants.All(v => v.Attributes.OfType<GeneratedAttribute>().Any());
+        }
+    }
+
     internal class Variant
     {
         public string CmdletName { get; }

--- a/extensions/powershell/resources/runtime/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/PsProxyTypes.cs
@@ -1,10 +1,27 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyOutputExtensions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
+    internal class ProfileGroup
+    {
+        public string ProfileName { get; }
+        public Variant[] Variants { get; }
+
+        private const string NoProfiles = "__NoProfiles";
+        public string ProfileFolder { get; }
+
+        public ProfileGroup(Variant[] variants, string profileName = NoProfiles)
+        {
+            ProfileName = profileName;
+            Variants = variants;
+            ProfileFolder = ProfileName != NoProfiles ? ProfileName : String.Empty;
+        }
+    }
+
     internal class VariantGroup
     {
         public string CmdletName { get; }
@@ -16,8 +33,13 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public bool HasMultipleVariants { get; }
         public string ModuleName { get; }
         public string Description { get; }
+        public bool IsGenerated { get; }
 
-        public VariantGroup(string cmdletName, Variant[] variants)
+        public string OutputFolder { get; }
+        public string FileName { get; }
+        public string FilePath { get; }
+
+        public VariantGroup(string cmdletName, Variant[] variants, string outputFolder, bool isTest = false)
         {
             CmdletName = cmdletName;
             Variants = variants;
@@ -27,6 +49,11 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             HasMultipleVariants = Variants.Length > 1;
             ModuleName = Variants.Select(v => v.Info.Source).First();
             Description = Variants.SelectMany(v => v.Attributes).OfType<DescriptionAttribute>().FirstOrDefault()?.Description;
+            IsGenerated = Variants.All(v => v.Attributes.OfType<GeneratedAttribute>().Any());
+
+            OutputFolder = outputFolder;
+            FileName = $"{CmdletName}{(isTest ? ".Tests" : String.Empty)}.ps1";
+            FilePath = Path.Combine(OutputFolder, FileName);
         }
 
         private string DetermineDefaultParameterSetName()
@@ -53,18 +80,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         }
     }
 
-    internal class VariantTestGroup : VariantGroup
-    {
-        public string Filename { get; }
-        public bool IsGenerated { get; }
-
-        public VariantTestGroup(string cmdletName, Variant[] variants, string filename) : base(cmdletName, variants)
-        {
-            Filename = filename;
-            IsGenerated = Variants.All(v => v.Attributes.OfType<GeneratedAttribute>().Any());
-        }
-    }
-
     internal class Variant
     {
         public string CmdletName { get; }
@@ -75,6 +90,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public Attribute[] Attributes { get; }
         public Parameter[] Parameters { get; }
         public Parameter[] CmdletOnlyParameters { get; }
+        public string[] Profiles { get; }
 
         public Variant(string cmdletName, string variantName, CommandInfo info, CommandMetadata metadata)
         {
@@ -87,6 +103,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             CmdletOnlyParameters = Parameters.Where(p => !p.Metadata.Attributes.OfType<CategoryAttribute>().Any(a =>
                 a.Categories.Contains(ParameterCategory.Azure) ||
                 a.Categories.Contains(ParameterCategory.Runtime))).ToArray();
+            Profiles = Attributes.OfType<ProfileAttribute>().SelectMany(pa => pa.Profiles).ToArray();
         }
     }
 

--- a/extensions/powershell/src/plugin-powershell.ts
+++ b/extensions/powershell/src/plugin-powershell.ts
@@ -61,9 +61,6 @@ async function copyRequiredFiles(service: Host, project: Project) {
   // Runtime files
   await copyResources(join(resources, 'runtime'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, sourceFileCSharp), project.overrides);
 
-  // Example : copy Binary files
-  // await copyBinaryResources(join(resources, 'binaries'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, 'binary-file'));
-
   // platyPS files
   await copyBinaryResources(join(resources, 'platyPS'), async (fname, content) => service.WriteFile(join(`${project.moduleFolder}/platyPS`, fname), content, undefined, 'binary-file'));
 }


### PR DESCRIPTION
- Added support for Profile attribute
  - If profiles exist in any variants, will create 'profile' folders and any un-profiled variants are applied to all profiles
  - If profiles don't exist on any variants, will do the same thing as the current proxy generator
- Module exports (psm1) will load 'latest' profile if there are directories in the `exports` folder
  - 'latest' is the last directory in the folder
  - If there are no directories, the files are flat in `exports` and will be loaded the same as it currently is loaded
- Updated tests to only generate stubs for non-generated variants/cmdlets