### PR TITLE
Clean up build scripts + add Pester testing

### DIFF
--- a/extensions/powershell/resources/assets/.gitignore
+++ b/extensions/powershell/resources/assets/.gitignore
@@ -2,4 +2,4 @@ bin
 obj
 generated
 node_modules
-test/results
+test/*-TestResults.xml

--- a/extensions/powershell/resources/assets/.gitignore
+++ b/extensions/powershell/resources/assets/.gitignore
@@ -2,3 +2,4 @@ bin
 obj
 generated
 node_modules
+test/results

--- a/extensions/powershell/resources/assets/build-module.ps1
+++ b/extensions/powershell/resources/assets/build-module.ps1
@@ -15,6 +15,14 @@ if(-not $Isolated) {
     return
   }
 
+  if($Test) {
+    . (Join-Path $PSScriptRoot 'test-module.ps1')
+    if($LastExitCode -ne 0) {
+      # Tests failed. Don't attempt to run the module.
+      return
+    }
+  }
+
   if($Code) {
     . (Join-Path $PSScriptRoot 'run-module.ps1') -Code
   } elseif($Run) {

--- a/extensions/powershell/resources/assets/build-module.ps1
+++ b/extensions/powershell/resources/assets/build-module.ps1
@@ -1,91 +1,88 @@
-param([Switch]$isolated, [Switch]$test, [Switch]$code, [Switch]$Release)
-Push-Location $PSScriptRoot
-$ErrorActionPreference = "Stop"
+param([Switch]$Isolated, [Switch]$Run, [Switch]$Test, [Switch]$Code, [Switch]$Release)
+$ErrorActionPreference = 'Stop'
 
-if($PSVersionTable.PSVersion.Major -lt 6) {
-  Pop-Location
-  Write-Error "This script requires PowerShell Core (don't worry: generated cmdlets can work in PowerShell Core or Windows Powershell)" 
+if($PSEdition -ne 'Core') {
+  Write-Error 'This script requires PowerShell Core to execute. [Note] Generated cmdlets will work in both PowerShell Core or Windows PowerShell.'
 }
 
-if(-not $isolated) {
-  # this ensures that we can run the script repeatedly without worrying about locked files/folders
-  Write-Host -ForegroundColor Green "Spawning in isolated process." 
+if(-not $Isolated) {
+  Write-Host -ForegroundColor Green 'Creating isolated process...'
   $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
-  & $pwsh -Command $MyInvocation.MyCommand.Path -Isolated
+  & $pwsh -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
 
-  if($lastExitCode -ne 0) {
-    Pop-Location
-    return;
+  if($LastExitCode -ne 0) {
+    return
   }
 
-  if($test) {
-    $mpath = $(( dir ./*.psd1)[0].fullname)
-    $mname = $(( dir ./*.psd1)[0].basename)
-    $testCommandExtra = ''
-    if($code) {
-      # add a .vscode/launch.json folder 
-      $launch = "$PSScriptRoot/.vscode/launch.json"
-      $null = New-Item -Type Directory -Path "$PSScriptRoot/.vscode" -ErrorAction SilentlyContinue
-      set-content -path $launch -value '{ "version": "0.2.0", "configurations" : [{ "name" : "Attach to PowerShell", "type":"coreclr", "request":"attach", "processId":"#PID","justMyCode": false  }] }'
-      $testCommandExtra = " Set-Content -Path $launch -value ((Get-Content -Path $launch -Raw ) -replace '#PID',([System.Diagnostics.Process]::GetCurrentProcess().id)  )  ; code $PSScriptRoot ;"
-    }
-    & $pwsh -NoExit -Command "function prompt { `$ESC = [char]27 ; Write-host -nonewline -ForegroundColor Green ('PS ' + `$(get-location) ) ;  Write-Host (' ['+ `$ESC +'[02;46m testing $mname '+ `$ESC +'[0m] >') -NoNewline -ForegroundColor White ; Write-host -ForegroundColor White -NoNewline '' ;  return ' ' } ;$testCommandExtra Import-Module '$mpath' "
+  if($Code) {
+    . (Join-Path $PSScriptRoot 'run-module.ps1') -Code
+  } elseif($Run) {
+    . (Join-Path $PSScriptRoot 'run-module.ps1')
   } else {
-    Write-Host -ForegroundColor Cyan "To test this module in a new powershell process, run `n"
-    Write-Host -ForegroundColor White " & '$([System.Diagnostics.Process]::GetCurrentProcess().Path)' -NoExit -Command Import-Module '$( (dir ./*.psd1)[0].fullname )' "
-    Write-Host -ForegroundColor Cyan "`nor use -test with this script`n"
+    Write-Host -ForegroundColor Cyan 'To run this module in an isolated PowerShell session, run ''./run-module.ps1'' or provide the ''-Run'' parameter to this script.'
   }
-  Pop-Location
+
   return
 }
-$dotnetcfg = 'debug'
+
+Write-Host -ForegroundColor Green 'Cleaning build folders...'
+$binFolder = (Join-Path $PSScriptRoot 'bin')
+$objFolder = (Join-Path $PSScriptRoot 'obj')
+$null = Remove-Item -Recurse -ErrorAction SilentlyContinue -Path $binFolder, $objFolder
+$null = Get-ChildItem -Path 'exports' -Recurse -Exclude 'readme.md' | Remove-Item -Recurse -ErrorAction SilentlyContinue
+
+if((Test-Path $binFolder) -or (Test-Path $objFolder)) {
+  Write-Error 'Unable to clean ''bin'' or ''obj'' folder. A process may have an open handle.'
+}
+
+Write-Host -ForegroundColor Green 'Compiling module...'
+$buildConfig = 'Debug'
 if($Release) {
-  $dotnetcfg = 'release'
-}
-Write-Host -ForegroundColor Green "Cleaning folders..."
-@('./obj', './bin') |% { $null = Remove-Item -Recurse -ErrorAction SilentlyContinue $_ }
-$null = (Get-ChildItem -Path 'exports' -Recurse -Exclude 'readme.md' | Remove-Item -Recurse -ErrorAction SilentlyContinue)
-
-if(Test-Path ./bin) {
-  Pop-Location
-  Write-Error "Unable to clean binary folder. (a process may have an open handle.)"
+  $buildConfig = 'Release'
 }
 
-Write-Host -ForegroundColor Green "Compiling private module code"
-$null = dotnet publish --configuration $dotnetcfg --output bin
-if( $lastExitCode -ne 0 ) {
+$buildOutput = dotnet publish --configuration $buildConfig --output bin
+if($LastExitCode -ne 0) {
   # if it fails, let's do it again so the output comes out nicely.
-  dotnet publish --configuration $dotnetcfg --output bin
-  Pop-Location
-  Write-Error "Compilation failed"
+#   dotnet publish --configuration $buildConfig --output bin
+  Write-Host $buildOutput
+  Write-Error 'Compilation failed'
 }
 
-@('./bin/Debug','./bin/Release') |% { $null = Remove-Item -Recurse -ErrorAction SilentlyContinue $_ }
-$dll = (Get-ChildItem bin\*.private.dll)[0]
+$null = Remove-Item -Recurse -ErrorAction SilentlyContinue -Path (Join-Path $binFolder 'Debug'), (Join-Path $binFolder 'Release')
+# $dll = (Get-ChildItem bin\*.private.dll)[0]
+$dll = Get-Item -Path (Join-Path $binFolder '*.private.dll') | Select-Object -First 1
 
-if( -not (Test-Path $dll) ) {
-  Pop-Location
-  Write-Error "Unable to find output assembly."
+if(-not (Test-Path $dll)) {
+  Write-Error "Unable to find output assembly in '$binFolder'."
 }
 
 $commands = Get-Command -Module (Import-Module $dll -PassThru)
-Write-Host -ForegroundColor gray "Private Module loaded ($dll)."
+Write-Host -ForegroundColor Gray "Module DLL Loaded [$dll]"
 
-# merge scripts into one file
-$modulename = (Get-ChildItem *.psd1)[0].Name -replace ".psd1",""
-$scriptmodule = $dll -replace ".private.",".scripts." -replace ".dll",".psm1"
-$scriptfile = ""; 
-Get-ChildItem -Recurse custom\*.ps1 |% { $scriptfile = $scriptfile +"`n`n# Included from: $(Resolve-Path -Relative $_)`n" + (Get-Content -raw $_) } ; 
-Set-Content $scriptmodule -Value $scriptfile
-if( $scriptfile -ne '' ) {
-  $commands = $commands + (Get-Command -module (Import-Module $scriptmodule -PassThru))
-  Write-Host -ForegroundColor gray "Private Scripts Module loaded ($scriptmodule)."
+# https://stackoverflow.com/a/40969712/294804
+$currentFunctions = Get-ChildItem function:
+$scriptsPath = Join-Path $PSScriptRoot 'custom' '*.ps1'
+Get-ChildItem -Recurse $scriptsPath | ForEach-Object { . $_.FullName }
+$scriptFunctions = Get-ChildItem function: | Where-Object { $currentFunctions -notcontains $_ }
+if(($scriptFunctions | Measure-Object).Count -gt 0) {
+  $commands = $commands + ($scriptFunctions | ForEach-Object { Get-Command -Name $_.Name })
+  Write-Host -ForegroundColor Gray 'Custom Scripts Loaded'
 }
 
-# No commands?
-if( $commands.length -eq 0 ) {
-  Pop-Location
-  Write-Error "Unable get commands from private module."
+# merge scripts into one file
+# $modulename = (Get-ChildItem *.psd1)[0].Name -replace ".psd1",""
+# $scriptmodule = $dll -replace ".private.",".scripts." -replace ".dll",".psm1"
+# $scriptfile = ""; 
+# Get-ChildItem -Recurse custom\*.ps1 |% { $scriptfile = $scriptfile +"`n`n# Included from: $(Resolve-Path -Relative $_)`n" + (Get-Content -raw $_) } ; 
+# Set-Content $scriptmodule -Value $scriptfile
+# if( $scriptfile -ne '' ) {
+#   $commands = $commands + (Get-Command -Module (Import-Module $scriptmodule -PassThru))
+#   Write-Host -ForegroundColor Gray "Private Scripts Module loaded ($scriptmodule)."
+# }
+
+if(($commands | Measure-Object).Count -eq 0) {
+  Write-Error 'Unable to locate any cmdlets.'
 }
 
 $commands = $commands | Where-Object { $_.Name -ne 'New-ProxyCmdlet' -and $_.Name -ne 'New-TestStub'}
@@ -98,6 +95,29 @@ $testPath = Join-Path $PSScriptRoot 'test'
 $null = New-Item -ItemType Directory -Force -Path $testPath
 New-TestStub -CommandInfo $commands -OutputFolder $testPath
 
-Pop-Location
-Write-Host -ForegroundColor Green "Done."
-Write-Host -ForegroundColor Green "-------------------------------"
+Write-Host -ForegroundColor Green '-------------Done-------------'
+
+# # $runCommand = "& ""$(Join-Path $PSScriptRoot 'run-module.ps1')"" -Isolated"
+# if($Code) {
+# #   $mpath = $(( dir ./*.psd1)[0].fullname)
+# #   $mname = $(( dir ./*.psd1)[0].basename)
+# #   $testCommandExtra = ''
+# #   if($code) {
+# #     # add a .vscode/launch.json folder 
+# #     $vscodeDirectory = New-Item -ItemType Directory -Force -Path (Join-Path $PSScriptRoot '.vscode')
+# #     $launchJson = Join-Path $vscodeDirectory 'launch.json'
+# #     Set-Content -Path $launchJson -Value '{ "version": "0.2.0", "configurations":[{ "name":"Attach to PowerShell", "type":"coreclr", "request":"attach", "processId":"#PID", "justMyCode":false }] }'
+# #     $testCommandExtra = " Set-Content -Path $launch -value ((Get-Content -Path $launch -Raw ) -replace '#PID',([System.Diagnostics.Process]::GetCurrentProcess().id)  )  ; code $PSScriptRoot ;"
+# #   }
+# #   & $pwsh -NoExit -Command "function prompt { `$ESC = [char]27 ; Write-host -nonewline -ForegroundColor Green ('PS ' + `$(get-location) ) ;  Write-Host (' ['+ `$ESC +'[02;46m testing $mname '+ `$ESC +'[0m] >') -NoNewline -ForegroundColor White ; Write-host -ForegroundColor White -NoNewline '' ;  return ' ' } ;$testCommandExtra Import-Module '$mpath' "
+# #   & (Join-Path $PSScriptRoot 'run-module.ps1') -Isolated -Command ((Get-Command Get-CodeParameter).Definition)
+# #   $runCommand = "$runCommand -Command $((Get-Command Get-CodeParameter).Definition)"
+# #   Invoke-Expression $runCommand
+# . (Join-Path $PSScriptRoot 'run-module.ps1') -Isolated -Command ((Get-Command Get-CodeParameter).Definition)
+# } elseif($Run) {
+# #   & (Join-Path $PSScriptRoot 'run-module.ps1') -Isolated
+# #   Invoke-Expression $runCommand
+# . (Join-Path $PSScriptRoot 'run-module.ps1') -Isolated
+# } else {
+#   Write-Host -ForegroundColor Cyan 'To run this module in an isolated PowerShell session, run ''./run-module.ps1'' or provide the ''-Run'' parameter to this script.'
+# }

--- a/extensions/powershell/resources/assets/build-module.ps1
+++ b/extensions/powershell/resources/assets/build-module.ps1
@@ -8,7 +8,7 @@ if($PSEdition -ne 'Core') {
 if(-not $Isolated) {
   Write-Host -ForegroundColor Green 'Creating isolated process...'
   $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
-  & "$pwsh" -NoLogo -NoProfile -NonInteractive -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
+  & "$pwsh" -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
 
   if($LastExitCode -ne 0) {
     # Build failed. Don't attempt to run the module.

--- a/extensions/powershell/resources/assets/generate-help.ps1
+++ b/extensions/powershell/resources/assets/generate-help.ps1
@@ -1,12 +1,10 @@
 param([Switch]$Isolated)
-Push-Location $PSScriptRoot
 $ErrorActionPreference = 'Stop'
 
 $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
 if(-not $Isolated) {
   Write-Host -ForegroundColor Green 'Creating isolated process...'
-  & $pwsh -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path -Isolated
-  Pop-Location
+  & "$pwsh" -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path -Isolated
   return
 }
 
@@ -14,7 +12,7 @@ $WarningPreference = 'SilentlyContinue'
 $docsPath = Join-Path $PSScriptRoot 'docs'
 $null = New-Item -ItemType Directory -Force -Path $docsPath -ErrorAction SilentlyContinue
 
-$modulePsd1 = Get-Item -Path *.psd1 | Select-Object -First 1
+$modulePsd1 = Get-Item -Path (Join-Path $PSScriptRoot '*.psd1') | Select-Object -First 1
 $modulePath = $modulePsd1.FullName
 $moduleName = $modulePsd1.BaseName
 $platyPS = Join-Path $PSScriptRoot 'generated' 'platyPS'
@@ -50,6 +48,4 @@ Get-Item -Path (Join-Path $docsPath '*.md') | ForEach-Object {
 # Generate -help.xml
 New-ExternalHelp -Path $docsPath -OutputPath $PSScriptRoot -Force
 
-Pop-Location
-Write-Host -ForegroundColor Green 'Done.'
-Write-Host -ForegroundColor Green '-------------------------------'
+Write-Host -ForegroundColor Green '-------------Done-------------'

--- a/extensions/powershell/resources/assets/generate-help.ps1
+++ b/extensions/powershell/resources/assets/generate-help.ps1
@@ -2,16 +2,12 @@ param([Switch]$Isolated)
 Push-Location $PSScriptRoot
 $ErrorActionPreference = 'Stop'
 
-if($PSEdition -ne 'Core') {
-  Write-Error 'This script requires PowerShell Core. Note: Generated cmdlets will work in PowerShell Core or Windows Powershell.'
-}
-
 $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
 if(-not $Isolated) {
-  Write-Host -ForegroundColor Green "Spawning in isolated process."
-  & $pwsh -NonInteractive -NoLogo -NoProfile -Command $MyInvocation.MyCommand.Path -Isolated
+  Write-Host -ForegroundColor Green 'Creating isolated process...'
+  & $pwsh -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path -Isolated
   Pop-Location
-  return;
+  return
 }
 
 $WarningPreference = 'SilentlyContinue'

--- a/extensions/powershell/resources/assets/run-module.ps1
+++ b/extensions/powershell/resources/assets/run-module.ps1
@@ -1,19 +1,14 @@
 param([Switch]$Isolated, [Switch]$Code)
-Push-Location $PSScriptRoot
 $ErrorActionPreference = 'Stop'
 
 if(-not $Isolated) {
   Write-Host -ForegroundColor Green 'Creating isolated process...'
   $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
-  & $pwsh -NoExit -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
-  Pop-Location
+  & "$pwsh" -NoExit -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
   return
 }
 
-$modulePsd1 = Get-Item -Path *.psd1 | Select-Object -First 1
-if(-not $modulePsd1) {
-  Write-Error 'Module has not been built. Run ''./build-module.ps1'' to build the module.'
-}
+$modulePsd1 = Get-Item -Path (Join-Path $PSScriptRoot '*.psd1') | Select-Object -First 1
 $modulePath = $modulePsd1.FullName
 $moduleName = $modulePsd1.BaseName
 

--- a/extensions/powershell/resources/assets/run-module.ps1
+++ b/extensions/powershell/resources/assets/run-module.ps1
@@ -1,0 +1,35 @@
+param([Switch]$Isolated, [Switch]$Code)
+Push-Location $PSScriptRoot
+$ErrorActionPreference = 'Stop'
+
+if(-not $Isolated) {
+  Write-Host -ForegroundColor Green 'Creating isolated process...'
+  $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
+  & $pwsh -NoExit -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
+  Pop-Location
+  return
+}
+
+$modulePsd1 = Get-Item -Path *.psd1 | Select-Object -First 1
+if(-not $modulePsd1) {
+  Write-Error 'Module has not been built. Run ''./build-module.ps1'' to build the module.'
+}
+$modulePath = $modulePsd1.FullName
+$moduleName = $modulePsd1.BaseName
+
+function Prompt {
+  Write-Host -NoNewline -ForegroundColor Green "PS $(Get-Location)"
+  Write-Host -NoNewline -ForegroundColor Gray ' ['
+  Write-Host -NoNewline -ForegroundColor White -BackgroundColor DarkCyan $moduleName
+  ']> '
+}
+
+if($Code) {
+  $vscodeDirectory = New-Item -ItemType Directory -Force -Path (Join-Path $PSScriptRoot '.vscode')
+  $launchJson = Join-Path $vscodeDirectory 'launch.json'
+  $launchContent = '{ "version": "0.2.0", "configurations":[{ "name":"Attach to PowerShell", "type":"coreclr", "request":"attach", "processId":"' + ([System.Diagnostics.Process]::GetCurrentProcess().Id) + '", "justMyCode":false }] }'
+  Set-Content -Path $launchJson -Value $launchContent
+  code $PSScriptRoot
+}
+
+Import-Module -Name $modulePath

--- a/extensions/powershell/resources/assets/test-module.ps1
+++ b/extensions/powershell/resources/assets/test-module.ps1
@@ -20,4 +20,4 @@ $moduleName = $modulePsd1.BaseName
 Import-Module -Name Pester
 Import-Module $modulePath
 
-Invoke-Pester -Script @{ Path = (Join-Path $PSScriptRoot 'test') }
+Invoke-Pester -Script @{ Path = (Join-Path $PSScriptRoot 'test') } -EnableExit

--- a/extensions/powershell/resources/assets/test-module.ps1
+++ b/extensions/powershell/resources/assets/test-module.ps1
@@ -20,4 +20,5 @@ $moduleName = $modulePsd1.BaseName
 Import-Module -Name Pester
 Import-Module $modulePath
 
-Invoke-Pester -Script @{ Path = (Join-Path $PSScriptRoot 'test') } -EnableExit
+$testFolder = (Join-Path $PSScriptRoot 'test')
+Invoke-Pester -Script @{ Path = $testFolder } -EnableExit -OutputFile (Join-Path $testFolder "$moduleName-TestResults.xml")

--- a/extensions/powershell/resources/assets/test-module.ps1
+++ b/extensions/powershell/resources/assets/test-module.ps1
@@ -1,1 +1,1 @@
-Write-Error 'Unimplemented'
+

--- a/extensions/powershell/resources/assets/test-module.ps1
+++ b/extensions/powershell/resources/assets/test-module.ps1
@@ -1,1 +1,23 @@
+param([Switch]$Isolated)
+$ErrorActionPreference = 'Stop'
 
+$pester = Get-Module -ListAvailable -Name Pester
+if (-not $pester) {
+  Write-Error 'Pester is required to run tests. Please run ''Install-Module -Name Pester'' to install Pester.'
+}
+
+if(-not $Isolated) {
+  Write-Host -ForegroundColor Green 'Creating isolated process...'
+  $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
+  & "$pwsh" -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
+  return
+}
+
+$modulePsd1 = Get-Item -Path (Join-Path $PSScriptRoot '*.psd1') | Select-Object -First 1
+$modulePath = $modulePsd1.FullName
+$moduleName = $modulePsd1.BaseName
+
+Import-Module -Name Pester
+Import-Module $modulePath
+
+Invoke-Pester -Script @{ Path = (Join-Path $PSScriptRoot 'test') }

--- a/extensions/powershell/resources/runtime/NewTestStub.cs
+++ b/extensions/powershell/resources/runtime/NewTestStub.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             foreach (var variantGroup in variantGroups)
             {
                 var sb = new StringBuilder();
-                sb.AppendLine($@". ""$PSScriptRoot/HttpPipelineMocking.ps1""{Environment.NewLine}");
+                sb.AppendLine($@". (Join-Path $PSScriptRoot 'HttpPipelineMocking.ps1'){Environment.NewLine}");
 
                 sb.AppendLine($"Describe '{variantGroup.CmdletName}' {{");
                 var variants = variantGroup.Variants

--- a/extensions/powershell/src/generators/psm1.ts
+++ b/extensions/powershell/src/generators/psm1.ts
@@ -75,6 +75,7 @@ export async function generatePsm1(service: Host, project: Project) {
   psm1.append('Finalization', `
     # finish initialization of this module
     $instance.Init();
+  Write-Host "Loaded Module '$($instance.Name)'"
 `);
 
   psm1.trim();


### PR DESCRIPTION
This should be merged first: https://github.com/Azure/autorest.powershell/pull/78
PR in conjunction with: https://github.com/Azure/autorest/pull/3156

- Separates run isolation into a `run-module.ps1` script
  - Allows someone to run the module isolated independent of building it
  - Reused running called by `build-module.ps1`
  - Removed dos-style coloring behavior
  - Simplified calling so `run-module.ps1` simply runs itself isolated (instead of using `-Command` with a long string script)
  - Running for `build-module.ps1` is now the `-Run` flag instead of `-Test`
- Fixed `pwsh` calling pattern to use `-File` instead of `-Command`
- **Custom script loading currently doesn't work** (will be fixed in follow-up PR)
- Removed `Push/Pop-Location` pattern to allow for easy configuration path loading (when https://github.com/Azure/autorest/issues/3154 is implemented)
- Added `test-module.ps1` implementation
  - Runs tests in the `test` folder
  - Outputs test results to `test/<ModuleName>-TestResults.xml`
  - For `build-module.ps1`, uses the `-Test` flag to run `test-module.ps1`