### PR TITLE
Ternary fix

### DIFF
--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -96,10 +96,10 @@ export class Project extends codeDomProject {
     this.azure = await service.GetValue('azure') || await service.GetValue('azure-arm') || false;
 
     // Names
-    this.prefix = await service.GetValue('prefix') || this.azure ? 'Az' : ``;
+    this.prefix = await service.GetValue('prefix') || (this.azure ? 'Az' : ``);
     this.serviceName = await service.GetValue('service-name') || (this.azure ? Project.titleToServiceName(model.info.title) : model.info.title);
-    this.nounPrefix = await service.GetValue('noun-prefix') || this.azure ? this.serviceName : ``;
-    this.moduleName = await service.GetValue('module-name') || !!this.prefix ? `${this.prefix}.${this.serviceName}` : this.serviceName;
+    this.nounPrefix = await service.GetValue('noun-prefix') || (this.azure ? this.serviceName : ``);
+    this.moduleName = await service.GetValue('module-name') || (!!this.prefix ? `${this.prefix}.${this.serviceName}` : this.serviceName);
     this.dllName = await service.GetValue('dll-name') || `${this.moduleName}.private`;
 
     // Folders


### PR DESCRIPTION
This was a bug where, the || operator was evaluating like this:
```
(await service.GetValue('prefix') || this.azure) ? 'Az' : ``
```
instead of like this:
```
await service.GetValue('prefix') || (this.azure ? 'Az' : ``)
```