### PR TITLE
Psd1 fix and misc dev experience

### DIFF
--- a/extensions/powershell/file-formats/psd-file.ts
+++ b/extensions/powershell/file-formats/psd-file.ts
@@ -5,7 +5,8 @@ export class PsdFile extends TextWithRegions {
   private footer: string;
   constructor(content?: TextPossibilities, objectIntializer?: Partial<PsdFile>) {
     content = content || '@{}';
-    const [, header, contents, footer] = /(^.*?@{)(.*)(}\s*)/.exec(new Text(content).text.replace(/[\r?\n]/g, '«').replace(/^«*/, '').replace(/«*$/, '')) || [, '@{', '', '}'];
+    // https://stackoverflow.com/a/10805292/294804
+    const [, header, contents, footer] = /(^.*?@{)(.*)(}\s*)/.exec(new Text(content).text.replace(/\r?\n|\r/g, '«').replace(/^«*/, '').replace(/«*$/, '')) || [, '@{', '', '}'];
     super((contents || '').replace(/«/g, '\n'));
     this.header = header || '';
     this.footer = footer || '';

--- a/extensions/powershell/generators/csproj.ts
+++ b/extensions/powershell/generators/csproj.ts
@@ -7,16 +7,13 @@ import { Host } from '@microsoft.azure/autorest-extension-base';
 import { Project } from '../project';
 
 export async function generateCsproj(service: Host, project: Project) {
-  // write out the csproj file if it's not there.
-  if (!await service.ReadFile(project.csproj)) {
-
-    const release = project.azure ? `    <SignAssembly>true</SignAssembly>
+  const release = project.azure ? `    <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <DefineConstants>TRACE;RELEASE;NETSTANDARD;SIGN</DefineConstants>` :
-      `    <DefineConstants>TRACE;RELEASE;NETSTANDARD</DefineConstants>`;
+    `    <DefineConstants>TRACE;RELEASE;NETSTANDARD</DefineConstants>`;
 
-    service.WriteFile(project.csproj, `<Project Sdk="Microsoft.NET.Sdk">
+  service.WriteFile(project.csproj, `<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Version>${project.moduleVersion}</Version>
@@ -52,5 +49,4 @@ ${release}
   </ItemGroup>
 
 </Project>`, undefined, 'source-file-csharp');
-  }
 }

--- a/extensions/powershell/generators/nuspec.ts
+++ b/extensions/powershell/generators/nuspec.ts
@@ -7,11 +7,6 @@ import { Host } from '@microsoft.azure/autorest-extension-base';
 import { Project } from '../project';
 
 export async function generateNuspec(service: Host, project: Project) {
-  // If the file is already there, don't write a new one.
-  if (await service.ReadFile(project.nuspec)) {
-    return;
-  }
-
   const authorsOwners = project.azure ? 'Microsoft Corporation' : '';
   const licenseUrl = project.azure ? `https://aka.ms/azps-license` : '';
   const projectUrl = project.azure ? `https://github.com/Azure/azure-powershell` : '';

--- a/extensions/powershell/generators/psd1.ts
+++ b/extensions/powershell/generators/psd1.ts
@@ -12,50 +12,51 @@ export async function generatePsd1(service: Host, project: Project) {
   setIndentation(2);
   const psd1 = new PsdFile(await service.ReadFile(project.psd1));
 
-  if (!psd1.has('definition')) {
-    psd1.append('definition', function* () {
-      yield indent(`RootModule = '${project.psm1}'`);
-      yield indent(`ModuleVersion = '${project.moduleVersion}'`);
-      yield indent(`CompatiblePSEditions = 'Core', 'Desktop'`);
+  psd1.setRegion('definition', function* () {
+    yield indent(`RootModule = '${project.psm1}'`);
+    yield indent(`ModuleVersion = '${project.moduleVersion}'`);
+    yield indent(`CompatiblePSEditions = 'Core', 'Desktop'`);
+    const author = project.azure ? 'Microsoft Corporation' : '';
+    yield indent(`Author = '${author}'`);
+    const companyName = project.azure ? 'Microsoft Corporation' : '';
+    yield indent(`CompanyName = '${companyName}'`);
+    const copyright = project.azure ? 'Microsoft Corporation. All rights reserved.' : '';
+    yield indent(`Copyright = '${copyright}'`);
+    const description = project.azure ? `Microsoft Azure PowerShell: ${project.serviceName} cmdlets` : '';
+    yield indent(`Description = '${description}'`);
+    yield indent(`PowerShellVersion = '5.1'`);
+    yield indent(`DotNetFrameworkVersion = '4.7.2'`);
+    yield indent(`RequiredAssemblies = '${project.dll}'`);
+    yield indent(`FormatsToProcess = '${project.formatPs1xml}'`);
+  }, false);
+
+  if (!psd1.has('persistent data')) {
+    psd1.setRegion('persistent data', function* () {
       yield indent(`GUID = '${guid()}'`);
-      const author = project.azure ? 'Microsoft Corporation' : '';
-      yield indent(`Author = '${author}'`);
-      const companyName = project.azure ? 'Microsoft Corporation' : '';
-      yield indent(`CompanyName = '${companyName}'`);
-      const copyright = project.azure ? 'Microsoft Corporation. All rights reserved.' : '';
-      yield indent(`Copyright = '${copyright}'`);
-      const description = project.azure ? `Microsoft Azure PowerShell: ${project.serviceName} cmdlets` : '';
-      yield indent(`Description = '${description}'`);
-      yield indent(`PowerShellVersion = '5.1'`);
-      yield indent(`DotNetFrameworkVersion = '4.7.2'`);
-      yield indent(`RequiredAssemblies = '${project.dll}'`);
-      yield indent(`FormatsToProcess = '${project.formatPs1xml}'`);
-    });
+    }, false);
   }
 
-  if (!psd1.has('private data')) {
-    psd1.append('private data', function* () {
-      yield indent(`PrivateData = @{`);
-      yield indent(`PSData = @{`, 2);
+  psd1.setRegion('private data', function* () {
+    yield indent(`PrivateData = @{`);
+    yield indent(`PSData = @{`, 2);
 
-      const tags = project.azure ? `'Azure', 'ResourceManager', 'ARM', '${project.serviceName}'` : `''`;
-      yield indent(`Tags = ${tags}`, 3);
-      const licenseUri = project.azure ? `https://aka.ms/azps-license` : '';
-      yield indent(`LicenseUri = '${licenseUri}'`, 3);
-      const projectUri = project.azure ? `https://github.com/Azure/azure-powershell` : '';
-      yield indent(`ProjectUri = '${projectUri}'`, 3);
-      yield indent(`ReleaseNotes = ''`, 3);
-      if (project.azure && project.profiles.length) {
-        const profiles = values(project.profiles)
-          .linq.select(p => `'${p}'`)
-          .linq.toArray().join(', ');
-        yield indent(`Profiles = ${profiles}`, 3);
-      }
+    const tags = project.azure ? `'Azure', 'ResourceManager', 'ARM', '${project.serviceName}'` : `''`;
+    yield indent(`Tags = ${tags}`, 3);
+    const licenseUri = project.azure ? `https://aka.ms/azps-license` : '';
+    yield indent(`LicenseUri = '${licenseUri}'`, 3);
+    const projectUri = project.azure ? `https://github.com/Azure/azure-powershell` : '';
+    yield indent(`ProjectUri = '${projectUri}'`, 3);
+    yield indent(`ReleaseNotes = ''`, 3);
+    if (project.azure && project.profiles.length) {
+      const profiles = values(project.profiles)
+        .linq.select(p => `'${p}'`)
+        .linq.toArray().join(', ');
+      yield indent(`Profiles = ${profiles}`, 3);
+    }
 
-      yield indent(`}`, 2);
-      yield indent(`}`);
-    });
-  }
+    yield indent(`}`, 2);
+    yield indent(`}`);
+  }, false);
 
   service.WriteFile(project.psd1, psd1.text, undefined, 'source-file-powershell');
 }

--- a/extensions/powershell/plugin-powershell.ts
+++ b/extensions/powershell/plugin-powershell.ts
@@ -39,10 +39,11 @@ export async function powershell(service: Host) {
 
     await project.writeFiles(async (filename, content) => service.WriteFile(filename, applyOverrides(content, project.overrides), undefined, sourceFileCSharp));
 
-    await service.ProtectFiles(project.csproj);
+    await service.ProtectFiles(project.psd1);
     await service.ProtectFiles(project.customFolder);
     await service.ProtectFiles(project.testFolder);
     await service.ProtectFiles(project.docsFolder);
+    await service.ProtectFiles(project.examplesFolder);
 
     // wait for all the generation to be done
     await copyRequiredFiles(service, project);

--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -28,6 +28,7 @@ export class Project extends codeDomProject {
   public objFolder!: string;
   public exportsFolder!: string;
   public docsFolder!: string;
+  public examplesFolder!: string;
   public serviceName!: string;
   public moduleName!: string;
   public csproj!: string;
@@ -126,6 +127,7 @@ export class Project extends codeDomProject {
     this.exportsFolder = await this.getConfigValue('exports-folder', `${this.baseFolder}/exports`);
     this.docsFolder = await this.getConfigValue('docs-folder', `${this.baseFolder}/docs`);
     this.dependencyModuleFolder = await this.getConfigValue('dependency-module-folder', `${this.moduleFolder}/modules`);
+    this.examplesFolder = await this.getConfigValue('examples-folder', `${this.baseFolder}/examples`);
 
     // File paths
     this.csproj = await this.getConfigValue('csproj', `${this.baseFolder}/${this.moduleName}.csproj`);

--- a/extensions/powershell/resources/assets/.gitignore
+++ b/extensions/powershell/resources/assets/.gitignore
@@ -4,5 +4,16 @@ obj
 generated
 internal
 exports
-!exports/readme.md
+examples/readme.md
+docs/readme.md
+custom/readme.md
+custom/*.psm1
+test/readme.md
 test/*-TestResults.xml
+/*.ps1
+/*.ps1xml
+/*.psm1
+/*.snk
+/*.md
+/*.csproj
+/*.nuspec


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest/issues/3175

Added fix for psd1 generating newlines on non-edit content. Properly represented the update/replace schema for root level files (psd1, csproj, nuspec). Properly excluded generated/build files for commit of module to a repo.