### PR TITLE
Configuration scaffolding

### DIFF
--- a/extensions/csharp-v2/src/model/namespace.ts
+++ b/extensions/csharp-v2/src/model/namespace.ts
@@ -24,6 +24,10 @@ class ApiVersionNamespace extends Namespace {
     this.apply(objectInitializer);
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
   }
+
+  get outputFolder() {
+    return this.name.replace(/^.*\.Models/g, 'Models').replace(/\./g, '/');
+  }
 }
 
 export class ModelsNamespace extends Namespace {
@@ -51,6 +55,10 @@ export class ModelsNamespace extends Namespace {
       }
       this.resolveTypeDeclaration(schema, true, state);
     }
+  }
+
+  get outputFolder() {
+    return 'Models';
   }
 
   public resolveTypeDeclaration(schema: Schema | undefined, required: boolean, state: State): EnhancedTypeDeclaration {

--- a/extensions/csharp-v2/src/operation/namespace.ts
+++ b/extensions/csharp-v2/src/operation/namespace.ts
@@ -14,4 +14,8 @@ export class ServiceNamespace extends Namespace {
     this.apply(objectInitializer);
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
   }
+
+  get outputFolder() {
+    return '';
+  }
 }

--- a/extensions/csharp-v2/src/support/namespace.ts
+++ b/extensions/csharp-v2/src/support/namespace.ts
@@ -11,4 +11,8 @@ export class SupportNamespace extends Namespace {
     super('Support', parent);
     this.apply(objectInitializer);
   }
+
+  get outputFolder() {
+    return 'Support';
+  }
 }

--- a/extensions/powershell/README.md
+++ b/extensions/powershell/README.md
@@ -20,26 +20,69 @@ AutoRest needs the below config to pick this up as a plug-in - see https://githu
 
 #### PowerShell
 
-> Requires remodeler and csharpv2
+> Requires
 ``` yaml 
 use-extension:
   "@microsoft.azure/autorest.remodeler": "beta"
   "@microsoft.azure/autorest.csharp-v2": "beta"
 ```
 
-> forces multi-api mode 
+> Multi-Api Mode
 ``` yaml
 enable-multi-api: true
 load-priority: 1001
 ```
 
-# Pipeline Configuration
+> Folder Structure
 ``` yaml
 use-namespace-folders: false
+module-folder: $(output-folder)/generated
+cmdlet-folder: $(module-folder)/cmdlets
+model-cmdlet-folder: $(module-folder)/model-cmdlets
+custom-cmdlet-folder: $(output-folder)/custom
+internal-cmdlet-folder: $(output-folder)/internal
+test-folder: $(output-folder)/test
+runtime-folder: $(module-folder)/runtime
+api-folder: $(module-folder)/api
+api-extensions-folder: $(module-folder)/api-extensions
+bin-folder: $(output-folder)/bin
+obj-folder: $(output-folder)/obj
+exports-folder: $(output-folder)/exports
+docs-folder: $(output-folder)/docs
+dependency-module-folder: $(module-folder)/modules
+examples-folder: $(output-folder)/examples
+```
 
-api-folder: generated/api
-runtime-folder: generated/runtime
+> Values
+``` yaml
+module-version: 0.1.0
+skip-model-cmdlets: false
+azure: false
+```
 
+> Names
+``` yaml
+prefix: ''
+service-name: $(title)
+subject-prefix: ''
+module-name: $(service-name)
+dll-name: $(module-name).private
+```
+
+> File Paths
+``` yaml
+csproj: $(output-folder)/$(module-name).csproj
+dll: $(bin-folder)/$(dll-name).dll
+psd1: $(output-folder)/$(module-name).psd1
+psm1: $(output-folder)/$(module-name).psm1
+psm1-custom: $(custom-folder)/$(module-name).custom.psm1
+psm1-internal: $(internal-folder)/$(module-name).internal.psm1
+format-ps1xml: $(output-folder)/$(module-name).format.ps1xml
+nuspec: $(output-folder)/$(module-name).nuspec
+```
+
+# Pipeline Configuration
+``` yaml
 pipeline:
 # --- extension remodeler --- 
 
@@ -121,7 +164,7 @@ The following verb-mapping is used as an aid to infer cmdlet-verbs. Every entry 
 Note: It is not necessary to have an entry for every method because AutoRest will still be able to infer a verb by examining the operationId. However, if an entry is added in the configuration, it is guaranteed that the cmdlet created will get the cmdlet-verb from the operationId-method -> cmdlet verb mapping.
 
 ``` yaml
-verb-mapping: 
+verb-mapping:
   Access: Get
   Acquire: Get
   Activate: Initialize

--- a/extensions/powershell/README.md
+++ b/extensions/powershell/README.md
@@ -36,21 +36,21 @@ load-priority: 1001
 > Folder Structure
 ``` yaml
 use-namespace-folders: false
-module-folder: $(output-folder)/generated
+module-folder: generated
 cmdlet-folder: $(module-folder)/cmdlets
 model-cmdlet-folder: $(module-folder)/model-cmdlets
-custom-cmdlet-folder: $(output-folder)/custom
-internal-cmdlet-folder: $(output-folder)/internal
-test-folder: $(output-folder)/test
+custom-cmdlet-folder: custom
+internal-cmdlet-folder: internal
+test-folder: test
 runtime-folder: $(module-folder)/runtime
 api-folder: $(module-folder)/api
 api-extensions-folder: $(module-folder)/api-extensions
-bin-folder: $(output-folder)/bin
-obj-folder: $(output-folder)/obj
-exports-folder: $(output-folder)/exports
-docs-folder: $(output-folder)/docs
+bin-folder: bin
+obj-folder: obj
+exports-folder: exports
+docs-folder: docs
 dependency-module-folder: $(module-folder)/modules
-examples-folder: $(output-folder)/examples
+examples-folder: examples
 ```
 
 > Values
@@ -71,14 +71,14 @@ dll-name: $(module-name).private
 
 > File Paths
 ``` yaml
-csproj: $(output-folder)/$(module-name).csproj
+csproj: $(module-name).csproj
 dll: $(bin-folder)/$(dll-name).dll
-psd1: $(output-folder)/$(module-name).psd1
-psm1: $(output-folder)/$(module-name).psm1
-psm1-custom: $(custom-folder)/$(module-name).custom.psm1
-psm1-internal: $(internal-folder)/$(module-name).internal.psm1
-format-ps1xml: $(output-folder)/$(module-name).format.ps1xml
-nuspec: $(output-folder)/$(module-name).nuspec
+psd1: $(module-name).psd1
+psm1: $(module-name).psm1
+psm1-custom: $(custom-cmdlet-folder)/$(module-name).custom.psm1
+psm1-internal: $(internal-cmdlet-folder)/$(module-name).internal.psm1
+format-ps1xml: $(module-name).format.ps1xml
+nuspec: $(module-name).nuspec
 ```
 
 # Pipeline Configuration

--- a/extensions/powershell/README.md
+++ b/extensions/powershell/README.md
@@ -33,26 +33,6 @@ enable-multi-api: true
 load-priority: 1001
 ```
 
-> Folder Structure
-``` yaml
-use-namespace-folders: false
-module-folder: generated
-cmdlet-folder: $(module-folder)/cmdlets
-model-cmdlet-folder: $(module-folder)/model-cmdlets
-custom-cmdlet-folder: custom
-internal-cmdlet-folder: internal
-test-folder: test
-runtime-folder: $(module-folder)/runtime
-api-folder: $(module-folder)/api
-api-extensions-folder: $(module-folder)/api-extensions
-bin-folder: bin
-obj-folder: obj
-exports-folder: exports
-docs-folder: docs
-dependency-module-folder: $(module-folder)/modules
-examples-folder: examples
-```
-
 > Values
 ``` yaml
 module-version: 0.1.0
@@ -69,16 +49,37 @@ module-name: $(service-name)
 dll-name: $(module-name).private
 ```
 
+> Folders
+``` yaml
+use-namespace-folders: false
+current-folder: .
+module-folder: $(current-folder)/generated
+cmdlet-folder: $(module-folder)/cmdlets
+model-cmdlet-folder: $(module-folder)/model-cmdlets
+custom-cmdlet-folder: $(current-folder)/custom
+internal-cmdlet-folder: $(current-folder)/internal
+test-folder: $(current-folder)/test
+runtime-folder: $(module-folder)/runtime
+api-folder: $(module-folder)/api
+api-extensions-folder: $(module-folder)/api-extensions
+bin-folder: $(current-folder)/bin
+obj-folder: $(current-folder)/obj
+exports-folder: $(current-folder)/exports
+docs-folder: $(current-folder)/docs
+dependency-module-folder: $(module-folder)/modules
+examples-folder: $(current-folder)/examples
+```
+
 > File Paths
 ``` yaml
-csproj: $(module-name).csproj
+csproj: $(current-folder)/$(module-name).csproj
 dll: $(bin-folder)/$(dll-name).dll
-psd1: $(module-name).psd1
-psm1: $(module-name).psm1
+psd1: $(current-folder)/$(module-name).psd1
+psm1: $(current-folder)/$(module-name).psm1
 psm1-custom: $(custom-cmdlet-folder)/$(module-name).custom.psm1
 psm1-internal: $(internal-cmdlet-folder)/$(module-name).internal.psm1
-format-ps1xml: $(module-name).format.ps1xml
-nuspec: $(module-name).nuspec
+format-ps1xml: $(current-folder)/$(module-name).format.ps1xml
+nuspec: $(current-folder)/$(module-name).nuspec
 ```
 
 # Pipeline Configuration

--- a/extensions/powershell/generators/nuspec.ts
+++ b/extensions/powershell/generators/nuspec.ts
@@ -40,7 +40,7 @@ export async function generateNuspec(service: Host, project: Project) {
     <!-- https://github.com/NuGet/Home/issues/3584 -->
     <file src="${removeCd(project.dll)}" target="${removeCd(project.binFolder)}" />
     <file src="${removeCd(project.binFolder)}/${project.dllName}.deps.json" target="${removeCd(project.binFolder)}" />
-    <file src="${removeCd(project.internalFolder)}/**/*.*" />
+    <file src="${removeCd(project.internalFolder)}/**/*.*" exclude="${removeCd(project.internalFolder)}/readme.md" />
     <file src="${removeCd(project.customFolder)}/**/*.*" exclude="${removeCd(project.customFolder)}/readme.md;${removeCd(project.customFolder)}/**/*.cs" />
     <file src="${removeCd(project.docsFolder)}/**/*.md" exclude="${removeCd(project.docsFolder)}/readme.md" />
     <file src="${removeCd(project.exportsFolder)}/**/*.ps1" />

--- a/extensions/powershell/namespaces/model-extensions.ts
+++ b/extensions/powershell/namespaces/model-extensions.ts
@@ -7,6 +7,7 @@ import { Catch, Try, Else, ElseIf, If, Interface, Attribute, Parameter, Modifier
 import { Schema, ClientRuntime, SchemaDefinitionResolver, ObjectImplementation } from '@microsoft.azure/autorest.csharp-v2';
 import { State } from '../state';
 import { PSObject, PSTypeConverter, TypeConverterAttribute } from '../powershell-declarations';
+import { join } from 'path';
 
 class ApiVersionModelExtensionsNamespace extends Namespace {
   public get outputFolder(): string {
@@ -22,7 +23,7 @@ export class ModelExtensionsNamespace extends Namespace {
   private subNamespaces = new Dictionary<Namespace>();
 
   public get outputFolder(): string {
-    return this.state.project.apiExtensionsFolder;
+    return join(this.state.project.apiExtensionsFolder, 'Models');
   }
   resolver = new SchemaDefinitionResolver();
 
@@ -51,7 +52,7 @@ export class ModelExtensionsNamespace extends Namespace {
 
         // get the actual full namespace for the schema
         const fullname = schema.details.csharp.namespace || this.fullName;
-        const ns = this.subNamespaces[fullname] || this.add(new ApiVersionModelExtensionsNamespace(this.state.project.apiExtensionsFolder, fullname));
+        const ns = this.subNamespaces[fullname] || this.add(new ApiVersionModelExtensionsNamespace(this.outputFolder, fullname));
 
         // create the model extensions for each object model
         // 2. A partial interface with the type converter attribute

--- a/extensions/powershell/namespaces/support.ts
+++ b/extensions/powershell/namespaces/support.ts
@@ -7,10 +7,11 @@ import { EnumDetails } from '@microsoft.azure/autorest.codemodel-v3';
 import { If, Parameter, Method, Namespace, System, Struct } from '@microsoft.azure/codegen-csharp';
 import { State } from '../state';
 import { IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType } from '../powershell-declarations';
+import { join } from 'path';
 
 export class SupportNamespace extends Namespace {
   public get outputFolder(): string {
-    return this.state.project.apiExtensionsFolder;
+    return join(this.state.project.apiExtensionsFolder, 'Support');
   }
 
   constructor(parent: Namespace, public state: State, objectInitializer?: Partial<SupportNamespace>) {

--- a/extensions/powershell/plugin-create-commands.ts
+++ b/extensions/powershell/plugin-create-commands.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { processCodeModel, codemodel, components, command, http, getAllProperties, } from '@microsoft.azure/autorest.codemodel-v3';
+import { processCodeModel, codemodel, components, command, http, getAllProperties, JsonType } from '@microsoft.azure/autorest.codemodel-v3';
 import { deconstruct, fixLeadingNumber, pascalCase, items, length, values, EnglishPluralizationService } from '@microsoft.azure/codegen';
 import { Schema } from '@microsoft.azure/autorest.csharp-v2';
 import { Channel, Host } from '@microsoft.azure/autorest-extension-base';

--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -12,7 +12,7 @@ import { ModelExtensionsNamespace } from './namespaces/model-extensions'
 import { ModelCmdletNamespace } from './namespaces/model-cmdlet'
 import { ServiceNamespace } from './namespaces/service'
 import { CmdletNamespace } from './namespaces/cmdlet'
-import { Channel } from '@microsoft.azure/autorest-extension-base';
+import { Host } from '@microsoft.azure/autorest-extension-base';
 import { Model } from '@microsoft.azure/autorest.codemodel-v3/dist/code-model/code-model';
 import { IAutoRestPluginInitiator } from '@microsoft.azure/autorest-extension-base/dist/lib/extension-base';
 
@@ -47,7 +47,6 @@ export class Project extends codeDomProject {
   public baseFolder!: string;
   public moduleFolder!: string;
   public schemaDefinitionResolver: SchemaDefinitionResolver;
-  public maxInlinedParameters!: number;
   public moduleVersion!: string;
   public profiles!: string[];
   public skipModelCmdlets!: boolean;
@@ -96,54 +95,49 @@ export class Project extends codeDomProject {
     await super.init();
 
     // Values
-    this.maxInlinedParameters = await this.getConfigValue('max-inlined-parameters', 4);
-    this.moduleVersion = await this.getConfigValue('module-version', '0.1.0');
-    this.profiles = await this.getConfigValue('profile', <string[]>[]);
+    this.moduleVersion = await Project.getConfigValue(this.service, 'module-version');
+    this.profiles = await Project.getConfigValue(this.service, 'profile', <string[]>[]);
     this.accountsVersionMinimum = '1.4.0';
     this.platyPsVersionMinimum = '0.13.1';
 
     // Flags
-    this.skipModelCmdlets = await this.getConfigValue('skip-model-cmdlets', false);
+    this.skipModelCmdlets = await Project.getConfigValue(this.service, 'skip-model-cmdlets');
     this.azure = this.model.details.default.isAzure;
 
     // Names
     this.prefix = this.model.details.default.prefix;
     this.serviceName = this.model.details.default.serviceName;
     this.subjectPrefix = this.model.details.default.subjectPrefix;
-
-    // Add subjectPrefix to the model so it can be used by the plugin-create-commands plugin.
-    this.model.details.default.subjectPrefix = this.subjectPrefix;
-
-    this.moduleName = await this.getConfigValue('module-name', !!this.prefix ? `${this.prefix}.${this.serviceName}` : this.serviceName);
-    this.dllName = await this.getConfigValue('dll-name', `${this.moduleName}.private`);
+    this.moduleName = await Project.getConfigValue(this.service, 'module-name');
+    this.dllName = await Project.getConfigValue(this.service, 'dll-name');
 
     // Folders
-    this.baseFolder = await this.getConfigValue('base-folder', '.');
-    this.moduleFolder = await this.getConfigValue('module-folder', `${this.baseFolder}/generated`);
-    this.cmdletFolder = await this.getConfigValue('cmdlet-folder', `${this.moduleFolder}/cmdlets`);
-    this.modelCmdletFolder = await this.getConfigValue('model-cmdlet-folder', `${this.moduleFolder}/model-cmdlets`);
-    this.customFolder = await this.getConfigValue('custom-cmdlet-folder', `${this.baseFolder}/custom`);
-    this.internalFolder = await this.getConfigValue('internal-cmdlet-folder', `${this.baseFolder}/internal`);
-    this.testFolder = await this.getConfigValue('test-folder', `${this.baseFolder}/test`);
-    this.runtimeFolder = await this.getConfigValue('runtime-folder', `${this.moduleFolder}/runtime`);
-    this.apiFolder = await this.getConfigValue('api-folder', `${this.moduleFolder}/api`);
-    this.apiExtensionsFolder = await this.getConfigValue('api-extensions-folder', `${this.moduleFolder}/api-extensions`);
-    this.binFolder = await this.getConfigValue('bin-folder', `${this.baseFolder}/bin`);
-    this.objFolder = await this.getConfigValue('obj-folder', `${this.baseFolder}/obj`);
-    this.exportsFolder = await this.getConfigValue('exports-folder', `${this.baseFolder}/exports`);
-    this.docsFolder = await this.getConfigValue('docs-folder', `${this.baseFolder}/docs`);
-    this.dependencyModuleFolder = await this.getConfigValue('dependency-module-folder', `${this.moduleFolder}/modules`);
-    this.examplesFolder = await this.getConfigValue('examples-folder', `${this.baseFolder}/examples`);
+    this.baseFolder = await Project.getConfigValue(this.service, 'output-folder');
+    this.moduleFolder = await Project.getConfigValue(this.service, 'module-folder');
+    this.cmdletFolder = await Project.getConfigValue(this.service, 'cmdlet-folder');
+    this.modelCmdletFolder = await Project.getConfigValue(this.service, 'model-cmdlet-folder');
+    this.customFolder = await Project.getConfigValue(this.service, 'custom-cmdlet-folder');
+    this.internalFolder = await Project.getConfigValue(this.service, 'internal-cmdlet-folder');
+    this.testFolder = await Project.getConfigValue(this.service, 'test-folder');
+    this.runtimeFolder = await Project.getConfigValue(this.service, 'runtime-folder');
+    this.apiFolder = await Project.getConfigValue(this.service, 'api-folder');
+    this.apiExtensionsFolder = await Project.getConfigValue(this.service, 'api-extensions-folder');
+    this.binFolder = await Project.getConfigValue(this.service, 'bin-folder');
+    this.objFolder = await Project.getConfigValue(this.service, 'obj-folder');
+    this.exportsFolder = await Project.getConfigValue(this.service, 'exports-folder');
+    this.docsFolder = await Project.getConfigValue(this.service, 'docs-folder');
+    this.dependencyModuleFolder = await Project.getConfigValue(this.service, 'dependency-module-folder');
+    this.examplesFolder = await Project.getConfigValue(this.service, 'examples-folder');
 
     // File paths
-    this.csproj = await this.getConfigValue('csproj', `${this.baseFolder}/${this.moduleName}.csproj`);
-    this.dll = await this.getConfigValue('dll', `${this.binFolder}/${this.dllName}.dll`);
-    this.psd1 = await this.getConfigValue('psd1', `${this.baseFolder}/${this.moduleName}.psd1`);
-    this.psm1 = await this.getConfigValue('psm1', `${this.baseFolder}/${this.moduleName}.psm1`);
-    this.psm1Custom = await this.getConfigValue('psm1-custom', `${this.customFolder}/${this.moduleName}.custom.psm1`);
-    this.psm1Internal = await this.getConfigValue('psm1-internal', `${this.internalFolder}/${this.moduleName}.internal.psm1`);
-    this.formatPs1xml = await this.getConfigValue('format-ps1xml', `${this.baseFolder}/${this.moduleName}.format.ps1xml`);
-    this.nuspec = await this.getConfigValue('nuspec', `${this.baseFolder}/${this.moduleName}.nuspec`);
+    this.csproj = await Project.getConfigValue(this.service, 'csproj');
+    this.dll = await Project.getConfigValue(this.service, 'dll');
+    this.psd1 = await Project.getConfigValue(this.service, 'psd1');
+    this.psm1 = await Project.getConfigValue(this.service, 'psm1');
+    this.psm1Custom = await Project.getConfigValue(this.service, 'psm1-custom');
+    this.psm1Internal = await Project.getConfigValue(this.service, 'psm1-internal');
+    this.formatPs1xml = await Project.getConfigValue(this.service, 'format-ps1xml');
+    this.nuspec = await Project.getConfigValue(this.service, 'nuspec');
     this.gitIgnore = `${this.baseFolder}/.gitignore`;
     this.gitAttributes = `${this.baseFolder}/.gitattributes`;
 
@@ -164,9 +158,12 @@ export class Project extends codeDomProject {
     return this;
   }
 
-  private async getConfigValue<T>(key: string, defaultValue: T): Promise<T> {
+  public static async getConfigValue<T>(service: Host, key: string, defaultValue?: T): Promise<T> {
+    const value = await service.GetValue(key);
     // GetValue returns null when values are not found.
-    const value = await this.service.GetValue(key);
-    return value !== null ? <T>value : defaultValue;
+    if (defaultValue === undefined && value === null) {
+      throw new Error(`No value for configuration key '${key}' was provided`);
+    }
+    return <T>(value !== null ? value : defaultValue);
   }
 }

--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -112,7 +112,7 @@ export class Project extends codeDomProject {
     this.dllName = await Project.getConfigValue(this.service, 'dll-name');
 
     // Folders
-    this.baseFolder = '.';
+    this.baseFolder = await Project.getConfigValue(this.service, 'current-folder');
     this.moduleFolder = await Project.getConfigValue(this.service, 'module-folder');
     this.cmdletFolder = await Project.getConfigValue(this.service, 'cmdlet-folder');
     this.modelCmdletFolder = await Project.getConfigValue(this.service, 'model-cmdlet-folder');

--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -112,7 +112,7 @@ export class Project extends codeDomProject {
     this.dllName = await Project.getConfigValue(this.service, 'dll-name');
 
     // Folders
-    this.baseFolder = await Project.getConfigValue(this.service, 'output-folder');
+    this.baseFolder = '.';
     this.moduleFolder = await Project.getConfigValue(this.service, 'module-folder');
     this.cmdletFolder = await Project.getConfigValue(this.service, 'cmdlet-folder');
     this.modelCmdletFolder = await Project.getConfigValue(this.service, 'model-cmdlet-folder');

--- a/extensions/powershell/test/test-service-name.ts
+++ b/extensions/powershell/test/test-service-name.ts
@@ -7,7 +7,7 @@ import { suite, test } from "mocha-typescript";
 import * as assert from "assert";
 import * as aio from "@microsoft.azure/async-io"
 import { values } from '@microsoft.azure/codegen';
-import { titleToServiceName } from "../plugin-create-commands";
+import { titleToAzureServiceName } from "../plugin-create-commands";
 
 @suite class TestServiceName {
 
@@ -18,7 +18,7 @@ import { titleToServiceName } from "../plugin-create-commands";
     assert(titlesFile != null);
     assert(serviceNamesFile != null);
 
-    const serviceNames = TestServiceName.normalizeEndlines(titlesFile, tl => `${tl} => ${titleToServiceName(tl)}`);
+    const serviceNames = TestServiceName.normalizeEndlines(titlesFile, tl => `${tl} => ${titleToAzureServiceName(tl)}`);
 
     //console.log(serviceNames);
     const normalizedServiceNamesFile = TestServiceName.normalizeEndlines(serviceNamesFile, tl => tl);


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.powershell/issues/169
Fixes: https://github.com/Azure/autorest.powershell/issues/152
Fixes: https://github.com/Azure/autorest.powershell/issues/118

This moves the configuration defaults out of the project.ts and moves them into the readme for the PowerShell extension. 

Azure-specific defaults will be handled in a readme.azure.md in the Azure PowerShell repo.