### PR TITLE
Object cmdlet name fix

### DIFF
--- a/extensions/powershell/model-cmdlet.ts
+++ b/extensions/powershell/model-cmdlet.ts
@@ -23,7 +23,7 @@ export class ModelCmdlet extends Class {
   // protected processRecord: Method;
 
   constructor(namespace: Namespace, schema: Schema, state: State, objectInitializer?: Partial<ModelCmdlet>) {
-    const variantName = `${state.project.prefix}${schema.details.csharp.name}Object_${schema.details.csharp.apiname}`;
+    const variantName = `${state.project.prefix}${schema.details.csharp.name}Object${schema.details.csharp.apiname ? `_${schema.details.csharp.apiname}` : ''}`;
     const name = `New${variantName}`;
     super(namespace, name, PSCmdlet);
     this.state = state;


### PR DESCRIPTION
If you don't use --enable-multi-api, the object cmdlet names were generated incorrectly.