### PR TITLE
fix for unknown responseCodes

### DIFF
--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -301,7 +301,7 @@ export class CallMethod extends Method {
             for (const { key: responseCode, value: responses } of items(opMethod.operation.responses)) {
               if (responseCode !== 'default') {
                 // will use enum when it can, fall back to casting int when it can't
-                yield Case(System.Net.HttpStatusCode[responseCode].value || `(${System.Net.HttpStatusCode.declaration})${responseCode}`, $this.responsesEmitter($this, opMethod, responses, eventListener));
+                yield Case(System.Net.HttpStatusCode[responseCode] ? System.Net.HttpStatusCode[responseCode].value : `(${System.Net.HttpStatusCode.declaration})${responseCode}`, $this.responsesEmitter($this, opMethod, responses, eventListener));
               } else {
                 yield DefaultCase($this.responsesEmitter($this, opMethod, responses, eventListener));
               }

--- a/extensions/csharp-v2/plugin-namer.ts
+++ b/extensions/csharp-v2/plugin-namer.ts
@@ -211,8 +211,7 @@ async function setOperationNames(state: State, resolver: SchemaDefinitionResolve
       for (const response of values(responses)) {
         const responseTypeDefinition = response.schema ? resolver.resolveTypeDeclaration(<any>response.schema, true, state.path('schemas', response.schema.details.default.name)) : undefined;
         const headerTypeDefinition = response.headerSchema ? resolver.resolveTypeDeclaration(<any>response.headerSchema, true, state.path('schemas', response.headerSchema.details.default.name)) : undefined;
-
-        const code = (System.Net.HttpStatusCode[response.responseCode].value || '').replace('global::System.Net.HttpStatusCode', '') || response.responseCode;
+        const code = (System.Net.HttpStatusCode[response.responseCode] ? System.Net.HttpStatusCode[response.responseCode].value : response.responseCode).replace('global::System.Net.HttpStatusCode', '');
         let rawValue = code.replace(/\./, '');
         if (rawValue === 'default') {
           rawValue = `any response code not handled elsewhere`;


### PR DESCRIPTION
Addresses: https://github.com/Azure/autorest.powershell/issues/222

With this fix it does not fail in the same place. However, another issue with a file name being too long occurs:

 Error: ENOENT: no such file or directory, open 'C:\azure-powershell\src\AppService\AppService\generated\cmdlets\SyncAzAppServiceWebAppFunctionTriggerSlot_ResourceGroupNameSlotSubscriptionIdEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtcEtc.cs'

