### PR TITLE
Alias exporting support

### DIFF
--- a/extensions/powershell/generators/psm1.custom.ts
+++ b/extensions/powershell/generators/psm1.custom.ts
@@ -26,7 +26,7 @@ export async function generatePsm1Custom(project: Project) {
   Export-ModuleMember`);
   psm1.append('LoadScripts', `
   Get-ChildItem -Path $PSScriptRoot -Recurse -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
-  Export-ModuleMember -Function (Get-ScriptCmdlet -ScriptFolder $PSScriptRoot)`);
+  Export-ModuleMember -Function (Get-ScriptCmdlet -ScriptFolder $PSScriptRoot) -Alias (Get-ScriptCmdlet -ScriptFolder $PSScriptRoot -AsAlias)`);
   psm1.trim();
   project.state.writeFile(project.psm1Custom, `${psm1}`, undefined, 'source-file-powershell');
 }

--- a/extensions/powershell/generators/psm1.internal.ts
+++ b/extensions/powershell/generators/psm1.internal.ts
@@ -26,7 +26,7 @@ export async function generatePsm1Internal(project: Project) {
   Export-ModuleMember`);
   psm1.append('LoadScripts', `
   Get-ChildItem -Path $PSScriptRoot -Recurse -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
-  Export-ModuleMember -Function (Get-ScriptCmdlet -ScriptFolder $PSScriptRoot)`);
+  Export-ModuleMember -Function (Get-ScriptCmdlet -ScriptFolder $PSScriptRoot) -Alias (Get-ScriptCmdlet -ScriptFolder $PSScriptRoot -AsAlias)`);
   psm1.trim();
   project.state.writeFile(project.psm1Internal, `${psm1}`, undefined, 'source-file-powershell');
 }

--- a/extensions/powershell/generators/psm1.ts
+++ b/extensions/powershell/generators/psm1.ts
@@ -102,7 +102,7 @@ export async function generatePsm1(project: Project) {
 
   if($exportsPath) {
     Get-ChildItem -Path $exportsPath -Recurse -Filter '*.ps1' -File | ForEach-Object { . $_.FullName }
-    Export-ModuleMember -Function (Get-ScriptCmdlet -ScriptFolder $exportsPath)
+    Export-ModuleMember -Function (Get-ScriptCmdlet -ScriptFolder $exportsPath) -Alias (Get-ScriptCmdlet -ScriptFolder $exportsPath -AsAlias)
   }`);
 
   psm1.append('Finalization', `

--- a/extensions/powershell/resources/runtime/ExportProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/ExportProxyCmdlet.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                     var sb = new StringBuilder();
                     sb.Append(variantGroup.ToHelpCommentOutput());
                     sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
+                    sb.Append(variantGroup.Aliases.ToAliasOutput());
                     sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
                     sb.Append(variantGroup.ToCmdletBindingOutput());
 
@@ -68,7 +69,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                         {
                             sb.Append(parameter.ToParameterOutput(variantGroup.HasMultipleVariants, parameterGroup.HasAllVariants));
                         }
-                        sb.Append(parameterGroup.Alias.ToAliasOutput());
+                        sb.Append(parameterGroup.Aliases.ToAliasOutput(true));
                         sb.Append(parameterGroup.HasValidateNotNull.ToValidateNotNullOutput());
                         sb.Append(parameterGroup.ToArgumentCompleterOutput());
                         sb.Append(parameterGroup.ParameterType.ToParameterTypeOutput());

--- a/extensions/powershell/resources/runtime/PsExtensions.cs
+++ b/extensions/powershell/resources/runtime/PsExtensions.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         public static string ToPsList(this IEnumerable<string> items) => String.Join(", ", items.Select(i => $"'{i}'"));
 
+        public static IEnumerable<string> ToAliasNames(this IEnumerable<Attribute> attributes) => attributes.OfType<AliasAttribute>().SelectMany(aa => aa.AliasNames).Distinct();
+
         public static IEnumerable<T> RunScript<T>(this PSCmdlet cmdlet, string script) where T : class
             => PsHelpers.RunScript<T>(cmdlet.InvokeCommand, script);
 

--- a/extensions/powershell/resources/runtime/PsHelpers.cs
+++ b/extensions/powershell/resources/runtime/PsHelpers.cs
@@ -22,8 +22,9 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         public static IEnumerable<CommandInfo> GetModuleCmdlets(PSCmdlet cmdlet, params string[] modulePaths)
         {
-            var getCmdletsCommand = String.Join(" + ",modulePaths.Select(mp => $"(Get-Command -Module (Import-Module '{mp}' -PassThru))"));
-            return cmdlet?.RunScript<CommandInfo>(getCmdletsCommand) ?? RunScript<CommandInfo>(getCmdletsCommand);
+            var getCmdletsCommand = String.Join(" + ", modulePaths.Select(mp => $"(Get-Command -Module (Import-Module '{mp}' -PassThru))"));
+            return (cmdlet?.RunScript<CommandInfo>(getCmdletsCommand) ?? RunScript<CommandInfo>(getCmdletsCommand))
+                .Where(ci => ci.CommandType != CommandTypes.Alias);
         }
 
         public static IEnumerable<CommandInfo> GetModuleCmdlets(params string[] modulePaths)

--- a/extensions/powershell/resources/runtime/PsProxyOutputs.cs
+++ b/extensions/powershell/resources/runtime/PsProxyOutputs.cs
@@ -67,14 +67,16 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
     internal class AliasOutput
     {
-        public AliasAttribute Alias { get; }
+        public string[] Aliases { get; }
+        public bool IncludeIndent { get; }
 
-        public AliasOutput(AliasAttribute alias)
+        public AliasOutput(string[] aliases, bool includeIndent = false)
         {
-            Alias = alias;
+            Aliases = aliases;
+            IncludeIndent = includeIndent;
         }
 
-        public override string ToString() => Alias != null ? $"{Indent}[Alias({Alias.AliasNames.Select(an => $"'{an}'").JoinIgnoreEmpty(ItemSeparator)})]{Environment.NewLine}" : String.Empty;
+        public override string ToString() => Aliases?.Any() ?? false ? $"{(IncludeIndent ? Indent : String.Empty)}[Alias({Aliases.Select(an => $"'{an}'").JoinIgnoreEmpty(ItemSeparator)})]{Environment.NewLine}" : String.Empty;
     }
 
     internal class ValidateNotNullOutput
@@ -259,7 +261,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         public static ParameterOutput ToParameterOutput(this Parameter parameter, bool hasMultipleVariantsInVariantGroup, bool hasAllVariantsInParameterGroup) => new ParameterOutput(parameter, hasMultipleVariantsInVariantGroup, hasAllVariantsInParameterGroup);
 
-        public static AliasOutput ToAliasOutput(this AliasAttribute alias) => new AliasOutput(alias);
+        public static AliasOutput ToAliasOutput(this string[] aliases, bool includeIndent = false) => new AliasOutput(aliases, includeIndent);
 
         public static ValidateNotNullOutput ToValidateNotNullOutput(this bool hasValidateNotNull) => new ValidateNotNullOutput(hasValidateNotNull);
 

--- a/extensions/powershell/resources/runtime/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/PsProxyTypes.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public string CmdletName { get; }
         public Variant[] Variants { get; }
 
+        public string[] Aliases { get; }
         public PSTypeName[] OutputTypes { get; }
         public bool SupportsShouldProcess { get; }
         public string DefaultParameterSetName { get; }
@@ -43,6 +44,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         {
             CmdletName = cmdletName;
             Variants = variants;
+            Aliases = Variants.SelectMany(v => v.Attributes).ToAliasNames().ToArray();
             OutputTypes = Variants.SelectMany(v => v.Info.OutputType).GroupBy(ot => ot.Type).Select(otg => otg.First()).ToArray();
             SupportsShouldProcess = Variants.Any(v => v.Metadata.SupportsShouldProcess);
             DefaultParameterSetName = DetermineDefaultParameterSetName();
@@ -128,7 +130,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public bool HasAllVariants { get; }
         public Type ParameterType { get; }
 
-        public AliasAttribute Alias { get; }
+        public string[] Aliases { get; }
         public bool HasValidateNotNull { get; }
         public bool HasArgumentCompleter { get; }
         public string HelpMessage { get; }
@@ -143,7 +145,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             HasAllVariants = !AllVariantNames.Except(Parameters.Select(p => p.VariantName)).Any();
             ParameterType = Parameters.Select(p => p.Metadata.ParameterType).First();
 
-            Alias = Parameters.SelectMany(p => p.Attributes.OfType<AliasAttribute>()).FirstOrDefault();
+            Aliases = Parameters.SelectMany(p => p.Attributes).ToAliasNames().ToArray();
             HasValidateNotNull = Parameters.SelectMany(p => p.Attributes.OfType<ValidateNotNullAttribute>()).Any();
             HasArgumentCompleter = Parameters.SelectMany(p => p.Attributes.OfType<ArgumentCompleterAttribute>()).Any();
             HelpMessage = Parameters.Select(p => p.ParameterAttribute.HelpMessage).FirstOrDefault(hm => !String.IsNullOrEmpty(hm));


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.powershell/issues/120

Added alias support for both cmdlets and parameters. Properly exported the aliases from psd1 and psm1 files.