### PR TITLE
Duplicate interface properties fix

### DIFF
--- a/extensions/csharp-v2/model/model-class-dictionary.ts
+++ b/extensions/csharp-v2/model/model-class-dictionary.ts
@@ -25,6 +25,7 @@ export class DictionaryImplementation extends Class {
         this.ownsDictionary = true;
         this.valueType = this.schema.additionalProperties === true ? System.Object : this.state.project.modelsNamespace.resolveTypeDeclaration(this.schema.additionalProperties, true, this.state)
         this.modelClass.modelInterface.interfaces.push(this.implementIDictionary(this, 'additionalProperties', System.String, this.valueType));
+        this.modelClass.modelInterface.reevaluateProperties();
       }
     }
 

--- a/extensions/csharp-v2/model/model-class.ts
+++ b/extensions/csharp-v2/model/model-class.ts
@@ -295,6 +295,7 @@ export class ModelClass extends Class implements EnhancedTypeDeclaration {
       this.validationStatements.add(td.validateValue(this.validationEventListener, backingField));
 
       this.modelInterface.interfaces.push(iface);
+      this.modelInterface.reevaluateProperties();
 
       //
       const addlPropType = this.additionalPropertiesType(aSchema);


### PR DESCRIPTION
When interfaces are added to modelInterfaces, now filtering out properties that already exist in implemented interfaces for that interface.