### PR TITLE
Possible to configure additional metadata about the module. 

### DIFF
--- a/extensions/powershell/generators/nuspec.ts
+++ b/extensions/powershell/generators/nuspec.ts
@@ -7,12 +7,14 @@ import { Host } from '@microsoft.azure/autorest-extension-base';
 import { Project } from '../project';
 
 export async function generateNuspec(project: Project) {
-  const authorsOwners = project.azure ? 'Microsoft Corporation' : '';
-  const licenseUrl = project.azure ? `https://aka.ms/azps-license` : '';
-  const projectUrl = project.azure ? `https://github.com/Azure/azure-powershell` : '';
-  const description = project.azure ? `Microsoft Azure PowerShell: ${project.serviceName} cmdlets` : '';
-  const copyright = project.azure ? 'Microsoft Corporation. All rights reserved.' : '';
-  const tags = project.azure ? 'Azure ResourceManager ARM AppConfiguration PSModule' : '';
+  const authors = project.azure ? 'Microsoft Corporation' : project.metadata.authors;
+  const owners = project.azure ? 'Microsoft Corporation' : project.metadata.owners;
+  const licenseUrl = project.azure ? `https://aka.ms/azps-license` : project.metadata.licenseUrl;
+  const projectUrl = project.azure ? `https://github.com/Azure/azure-powershell` : project.metadata.projectUrl;
+  const description = project.azure ? `Microsoft Azure PowerShell: ${project.serviceName} cmdlets` : project.metadata.description;
+  const copyright = project.azure ? 'Microsoft Corporation. All rights reserved.' : project.metadata.copyright;
+  const tags = project.azure ? 'Azure ResourceManager ARM AppConfiguration PSModule' : project.metadata.tags;
+  const requireLicenseAcceptance = project.azure ? true : project.metadata.requireLicenseAcceptance;
   const dependencies = project.azure ? `
     <dependencies>
       <dependency id="Az.Accounts" version="${project.accountsVersionMinimum}" />
@@ -23,9 +25,9 @@ export async function generateNuspec(project: Project) {
   <metadata>
     <id>${project.moduleName}</id>
     <version>${project.moduleVersion}</version>
-    <authors>${authorsOwners}</authors>
-    <owners>${authorsOwners}</owners>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <authors>${authors}</authors>
+    <owners>${owners}</owners>
+    <requireLicenseAcceptance>${requireLicenseAcceptance}</requireLicenseAcceptance>
     <licenseUrl>${licenseUrl}</licenseUrl>
     <projectUrl>${projectUrl}</projectUrl>
     <description>${description}</description>

--- a/extensions/powershell/generators/psd1.ts
+++ b/extensions/powershell/generators/psd1.ts
@@ -16,13 +16,13 @@ export async function generatePsd1(project: Project) {
     yield indent(`RootModule = '${project.psm1}'`);
     yield indent(`ModuleVersion = '${project.moduleVersion}'`);
     yield indent(`CompatiblePSEditions = 'Core', 'Desktop'`);
-    const author = project.azure ? 'Microsoft Corporation' : '';
+    const author = project.azure ? 'Microsoft Corporation' : project.metadata.authors;
     yield indent(`Author = '${author}'`);
-    const companyName = project.azure ? 'Microsoft Corporation' : '';
+    const companyName = project.azure ? 'Microsoft Corporation' : project.metadata.companyName;
     yield indent(`CompanyName = '${companyName}'`);
-    const copyright = project.azure ? 'Microsoft Corporation. All rights reserved.' : '';
+    const copyright = project.azure ? 'Microsoft Corporation. All rights reserved.' : project.metadata.copyright;
     yield indent(`Copyright = '${copyright}'`);
-    const description = project.azure ? `Microsoft Azure PowerShell: ${project.serviceName} cmdlets` : '';
+    const description = project.azure ? `Microsoft Azure PowerShell: ${project.serviceName} cmdlets` : project.metadata.description;
     yield indent(`Description = '${description}'`);
     yield indent(`PowerShellVersion = '5.1'`);
     yield indent(`DotNetFrameworkVersion = '4.7.2'`);

--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -12,8 +12,20 @@ import { ModelExtensionsNamespace } from './namespaces/model-extensions'
 import { ModelCmdletNamespace } from './namespaces/model-cmdlet'
 import { ServiceNamespace } from './namespaces/service'
 import { CmdletNamespace } from './namespaces/cmdlet'
-import { Host } from '@microsoft.azure/autorest-extension-base';
+import { Host, Channel } from '@microsoft.azure/autorest-extension-base';
 import { codemodel } from '@microsoft.azure/autorest.codemodel-v3';
+
+export interface Metadata {
+  authors: string,
+  owners: string,
+  requireLicenseAcceptance: boolean,
+  description: string,
+  copyright: string,
+  tags: string,
+  companyName: string,
+  licenseUrl: string,
+  projectUrl: string
+}
 
 export class Project extends codeDomProject {
   public azure!: boolean;
@@ -62,6 +74,7 @@ export class Project extends codeDomProject {
   public accountsVersionMinimum!: string;
   public platyPsVersionMinimum!: string;
   public dependencyModuleFolder!: string;
+  public metadata!: Metadata;
   public state!: State;
   get model() { return <codemodel.Model>this.state.model };
 
@@ -145,6 +158,21 @@ export class Project extends codeDomProject {
     this.gitIgnore = `${this.baseFolder}/.gitignore`;
     this.gitAttributes = `${this.baseFolder}/.gitattributes`;
     this.readme = `${this.baseFolder}/readme.md`;
+
+    //Metadata
+    let defaultMetadata: Metadata = {
+      authors: '',
+      owners: '',
+      requireLicenseAcceptance: false,
+      description: '',
+      copyright: '',
+      tags: '',
+      companyName: '',
+      licenseUrl: '',
+      projectUrl: ''
+    };
+    let metadataFromConfig = await this.state.getValue<Metadata>('metadata', defaultMetadata);
+    this.metadata = Object.assign(defaultMetadata, metadataFromConfig);
 
     // add project namespace
     this.addNamespace(this.serviceNamespace = new ServiceNamespace(this.state));


### PR DESCRIPTION
The metadata will populate the nuspec and psd1 file so they validate during packaging (building with -pack flag)

Previously only modules marked with the azure flag would pass the packaging process.

Metadata can be provided through the configuration file. The azure flag will override any provided metdata values.

If no metadata values are provided, sensible default will be used (empty string).

These changes makes it possible for organizations outside of Microsoft to use autorest.powershell generation in a CI pipeline and automatically publish the result to a nuget store (PSGallery for example).

The expected format is the following:

``` yaml
metadata: 
  authors: string
  requireLicenseAcceptance: true|false
  description: string
  copyright: string
  tags: string
  companyName: string
  projectUrl: string
  licenseUrl: stirng
```

Not every value is needed. If, for example, tags is not provided a default value (empty string) will be assigned to the property instead.
