### PR TITLE
Debug update -adding cmdlet details to c# comment header 

### DIFF
--- a/extensions/powershell/cmdlet-class.ts
+++ b/extensions/powershell/cmdlet-class.ts
@@ -124,14 +124,11 @@ export class CmdletClass extends Class {
           ops = `${ops}\n [METADATA]\n${serialize(m)}`
         }
 
-        const details = {
-          verb: this.operation.details.csharp.verb,
-          subject: this.operation.details.csharp.subject,
-          subjectPrefix: this.operation.details.csharp.subjectPrefix,
-          variant: this.operation.details.csharp.name
-        }
-
-        ops = `${ops}\n [DETAILS]\n${serialize(details)}`;
+        ops = `${ops}\n [DETAILS]`;
+        ops = `${ops}\n verb: ${this.operation.details.csharp.verb}`;
+        ops = `${ops}\n subjectPrefix: ${this.operation.details.csharp.subjectPrefix}`;
+        ops = `${ops}\n subject: ${this.operation.details.csharp.subject}`;
+        ops = `${ops}\n variant: ${this.operation.details.csharp.name}`;
       }
     }
 

--- a/extensions/powershell/cmdlet-class.ts
+++ b/extensions/powershell/cmdlet-class.ts
@@ -123,8 +123,18 @@ export class CmdletClass extends Class {
         if (m) {
           ops = `${ops}\n [METADATA]\n${serialize(m)}`
         }
+
+        const details = {
+          verb: this.operation.details.csharp.verb,
+          subject: this.operation.details.csharp.subject,
+          subjectPrefix: this.operation.details.csharp.subjectPrefix,
+          variant: this.operation.details.csharp.name
+        }
+
+        ops = `${ops}\n [DETAILS]\n${serialize(details)}`;
       }
     }
+
     return ops ? `${header}\n${docComment(xmlize('remarks', ops))}` : header;
   }
 


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.powershell/issues/322

Instead of a file this gives info into the c# file when in debug mode. 