### PR TITLE
Addressed Issue:335

### DIFF
--- a/extensions/powershell/resources/assets/generate-help.ps1
+++ b/extensions/powershell/resources/assets/generate-help.ps1
@@ -16,7 +16,7 @@ if(-not (Test-Path $exportsFolder)) {
 $directories = Get-ChildItem -Directory -Path $exportsFolder
 $hasProfiles = ($directories | Measure-Object).Count -gt 0
 if(-not $hasProfiles) {
-  $directories = $exportsFolder
+  $directories = Get-Item -Path $exportsFolder
 }
 
 $docsFolder = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFolder, $project.docsFolder)}'


### PR DESCRIPTION
Addressed https://github.com/Azure/autorest.powershell/issues/335 where the generate-help was incorrectly obtaining the exports directory object. This caused an error when attempting to obtain the cmdlets because the path string did not have a FullName property.