### PR TITLE
Changed internal variable name from identity to _identity 

### DIFF
--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -53,9 +53,9 @@ export class OperationMethod extends Method {
     // add parameters
     this.methodParameters = [];
 
-    const identity = new Parameter('identity', System.String);
+    const _identity = new Parameter('_identity', System.String);
     if (this.viaIdentity) {
-      this.addParameter(identity);
+      this.addParameter(_identity);
     }
 
     for (var index = 0; index < this.operation.parameters.length; index++) {
@@ -157,7 +157,7 @@ export class OperationMethod extends Method {
         yield `// verify that Identity format is an exact match for uri`;
         yield EOL;
 
-        const match = Local("_match", `${System.Text.RegularExpressions.Regex.new(rx).value}.Match(${identity.value})`);
+        const match = Local("_match", `${System.Text.RegularExpressions.Regex.new(rx).value}.Match(${_identity.value})`);
         yield match.declarationStatement;
         yield If(`!${match}.Success`, `throw new global::System.Exception("Invalid identity for URI '${$this.operation.path}'");`);
         yield EOL;

--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -53,9 +53,9 @@ export class OperationMethod extends Method {
     // add parameters
     this.methodParameters = [];
 
-    const _identity = new Parameter('_identity', System.String);
+    const identity = new Parameter('identity', System.String);
     if (this.viaIdentity) {
-      this.addParameter(_identity);
+      this.addParameter(identity);
     }
 
     for (var index = 0; index < this.operation.parameters.length; index++) {
@@ -132,7 +132,7 @@ export class OperationMethod extends Method {
 
       if (this.viaIdentity) {
         url = url.replace(`{${pp.param.name}}`, `"
-        + ${pp.name}
+        + rest_${pp.name}
         + "`);
       } else {
         url = url.replace(`{${pp.param.name}}`, `"
@@ -157,13 +157,13 @@ export class OperationMethod extends Method {
         yield `// verify that Identity format is an exact match for uri`;
         yield EOL;
 
-        const match = Local("_match", `${System.Text.RegularExpressions.Regex.new(rx).value}.Match(${_identity.value})`);
+        const match = Local("_match", `${System.Text.RegularExpressions.Regex.new(rx).value}.Match(${identity.value})`);
         yield match.declarationStatement;
         yield If(`!${match}.Success`, `throw new global::System.Exception("Invalid identity for URI '${$this.operation.path}'");`);
         yield EOL;
         yield `// replace URI parameters with values from identity`
         for (const pp of pathParams) {
-          yield `var ${pp.name} = ${match.value}.Groups["${pp.param.name}"].Value;`
+          yield `var rest_${pp.name} = ${match.value}.Groups["${pp.param.name}"].Value;`
         }
       }
 
@@ -172,7 +172,7 @@ export class OperationMethod extends Method {
         initializer: System.Uri.new(`(
         "${url}"
         ${queryParams.length > 0 ? '+ "?"' : ''}${queryParams.joinWith(pp => `
-        + ${pp.serializeToNode(KnownMediaType.QueryParameter, pp.param.name, ClientRuntime.SerializationMode.None).value}`, `
+        + ${pp.serializeToNode(KnownMediaType.QueryParameter, `${pp.param.name}`, ClientRuntime.SerializationMode.None).value}`, `
         + "&"`
         )}
         ).TrimEnd('?','&')`.replace(/\s*\+ ""/gm, ''))

--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -172,7 +172,7 @@ export class OperationMethod extends Method {
         initializer: System.Uri.new(`(
         "${url}"
         ${queryParams.length > 0 ? '+ "?"' : ''}${queryParams.joinWith(pp => `
-        + ${pp.serializeToNode(KnownMediaType.QueryParameter, `${pp.param.name}`, ClientRuntime.SerializationMode.None).value}`, `
+        + ${pp.serializeToNode(KnownMediaType.QueryParameter, pp.param.name, ClientRuntime.SerializationMode.None).value}`, `
         + "&"`
         )}
         ).TrimEnd('?','&')`.replace(/\s*\+ ""/gm, ''))

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ See [Using AutoRest PowerShell ](docs/using-autorest-powershell.md) for examples
 
 # Contributing
 
-For instructions on cloning/building/etc, see [Development](docs/development)
+For instructions on cloning/building/etc, see [Development](docs/development.md)
 
 
 ## Contributor License Agreement Requirements


### PR DESCRIPTION
Previously, using an input swagger with a URL parameter named "identity" would cause compilation to fail:


```
PS C:\Users\t-jospic\test\teamsCallParkPolicyTest\generated> pwsh .\build-module.ps1 -test
Creating isolated process...
Cleaning build folders...
Compiling module...
generated\api\ODataService.cs(63,138): error CS0841: Cannot use local variable 'identity' before it is declared [C:\Users\t-jospic\test\teamsCallParkPolicyTest\generated\ODataService.csproj]
generated\api\ODataService.cs(70,21): error CS0136: A local or parameter named 'identity' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter [C:\Users\t-jospic\test\teamsCallParkPolicyTest\generated\ODataService.csproj]
generated\api\ODataService.cs(260,138): error CS0841: Cannot use local variable 'identity' before it is declared [C:\Users\t-jospic\test\teamsCallParkPolicyTest\generated\ODataService.csproj]
generated\api\ODataService.cs(267,21): error CS0136: A local or parameter named 'identity' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter [C:\Users\t-jospic\test\teamsCallParkPolicyTest\generated\ODataService.csproj]
….
….
+   Write-Error 'Compilation failed.'
+   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException,build-module.ps1
```

This following method is taken from the generated cmdlet output at `./generated/api/ODataService.cs`.  The input swagger contains a path parameter that is named "identity".


**Old**
```c#
public async global::System.Threading.Tasks.Task TeamsCallParkPolicyDeleteByIdViaIdentity(
global::System.String identity, // <=== ALWAYS named identity
global::System.Func<global::System.Net.Http.HttpResponseMessage, 
global::System.Threading.Tasks.Task> onNoContent, 
global::System.Func<global::System.Net.Http.HttpResponseMessage, 
global::System.Threading.Tasks.Task<Sample.API.Models.IError>,
global::System.Threading.Tasks.Task> onDefault, 
Sample.API.Runtime.IEventListener eventListener, 
Sample.API.Runtime.ISendAsync sender)
{

               {...truncated...}

                // replace URI parameters with values from identity
                var identity = _match.Groups["identity"].Value;   // <=== this variable is named based on input
              
                 {...truncated...}
}
```


**New**
Changes argument from `identity` to `_identity`, and updates all references of the parameter to match. Allows for user to use the name "identity" whenever he or she wants.

```c#
public async global::System.Threading.Tasks.Task TeamsCallParkPolicyDeleteByIdViaIdentity(
global::System.String _identity, // <=== changed
global::System.Func<global::System.Net.Http.HttpResponseMessage, 
global::System.Threading.Tasks.Task> onNoContent, 
global::System.Func<global::System.Net.Http.HttpResponseMessage, 
global::System.Threading.Tasks.Task<Sample.API.Models.IError>,
global::System.Threading.Tasks.Task> onDefault, 
Sample.API.Runtime.IEventListener eventListener, 
Sample.API.Runtime.ISendAsync sender)
{

               {...truncated...}

                // replace URI parameters with values from identity
                var identity = _match.Groups["identity"].Value;  
              
                 {...truncated...}
}
```


Also fix minor typo in readme.