### PR TITLE
Complex type documentation

### DIFF
--- a/extensions/powershell/resources/assets/build-module.ps1
+++ b/extensions/powershell/resources/assets/build-module.ps1
@@ -98,19 +98,24 @@ if(Test-Path $internalFolder) {
 }
 $null = New-Item -ItemType Directory -Force -Path $internalFolder
 
+Write-Host -ForegroundColor Green 'Creating exports...'
 Export-ProxyCmdlet -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder
 
+Write-Host -ForegroundColor Green 'Creating format.ps1xml...'
 $formatPs1xml = Join-Path $PSScriptRoot '${$project.formatPs1xml}'
 Export-FormatPs1xml -FilePath $formatPs1xml
 
+Write-Host -ForegroundColor Green 'Creating psd1...'
 $psd1 = Join-Path $PSScriptRoot '${$project.psd1}'
 $customFolder = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFolder, $project.customFolder)}'
 Export-Psd1 -ExportsFolder $exportsFolder -CustomFolder $customFolder -Psd1Path $psd1
 
+Write-Host -ForegroundColor Green 'Creating test stubs...'
 $testFolder = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFolder, $project.testFolder)}'
 $null = New-Item -ItemType Directory -Force -Path $testFolder
 Export-TestStub -ModulePath $modulePaths -OutputFolder $testFolder
 
+Write-Host -ForegroundColor Green 'Creating example stubs...'
 $examplesFolder = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFolder, $project.examplesFolder)}'
 $null = New-Item -ItemType Directory -Force -Path $examplesFolder
 Export-ExampleStub -ExportsFolder $exportsFolder -OutputFolder $examplesFolder

--- a/extensions/powershell/resources/built-time-cmdlets.csproj
+++ b/extensions/powershell/resources/built-time-cmdlets.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\csharp-v2\resources\runtime\csharp\client\InfoAttribute.cs" Link="InfoAttribute.cs" />
     <Compile Include="runtime\BuildTime\Cmdlets\ExportHelpMarkdown.cs" />
     <Compile Include="runtime\BuildTime\Cmdlets\ExportFormatPs1xml.cs" />
     <Compile Include="runtime\BuildTime\Cmdlets\ExportExampleStub.cs" />

--- a/extensions/powershell/resources/built-time-cmdlets.csproj
+++ b/extensions/powershell/resources/built-time-cmdlets.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\csharp-v2\resources\runtime\csharp\client\IAssociativeArray.cs" Link="IAssociativeArray.cs" />
     <Compile Include="..\..\csharp-v2\resources\runtime\csharp\client\InfoAttribute.cs" Link="InfoAttribute.cs" />
     <Compile Include="runtime\BuildTime\Cmdlets\ExportHelpMarkdown.cs" />
     <Compile Include="runtime\BuildTime\Cmdlets\ExportFormatPs1xml.cs" />

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                     sb.Append($"### {alias}{Environment.NewLine}{Environment.NewLine}");
                 }
 
+                sb.Append($"## NOTES{Environment.NewLine}{Environment.NewLine}");
+
                 sb.Append($"## RELATED LINKS{Environment.NewLine}{Environment.NewLine}");
                 foreach (var relatedLink in markdownInfo.RelatedLinks)
                 {

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Management.Automation;
 using System.Text;
 using static Microsoft.Rest.ClientRuntime.PowerShell.MarkdownTypesExtensions;
+using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyOutputExtensions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
@@ -104,6 +105,14 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 }
 
                 sb.Append($"## NOTES{Environment.NewLine}{Environment.NewLine}");
+                if (markdownInfo.ComplexInterfaceInfos.Any())
+                {
+                    sb.Append($"### {ComplexParameterHeader}");
+                }
+                foreach (var complexInterfaceInfo in markdownInfo.ComplexInterfaceInfos)
+                {
+                    sb.Append($"#### {complexInterfaceInfo.ToNoteOutput(includeDashes: true, includeBackticks: true)}{Environment.NewLine}{Environment.NewLine}");
+                }
 
                 sb.Append($"## RELATED LINKS{Environment.NewLine}{Environment.NewLine}");
                 foreach (var relatedLink in markdownInfo.RelatedLinks)

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
             foreach (var variantGroup in variantGroups)
             {
-                var parameterGroups = variantGroup.Variants.ToParameterGroups()
+                var parameterGroups = variantGroup.ParameterGroups
                     .OrderBy(pg => pg.OrderCategory)
                     .ThenByDescending(pg => pg.IsMandatory)
                     .ToList();
@@ -51,7 +51,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 var outputs = variantGroup.OutputTypes.Select(ot => ot.Type).ToArray();
 
                 var sb = new StringBuilder();
-                sb.Append(variantGroup.ToHelpCommentOutput(inputs, outputs));
+                sb.Append(variantGroup.ToHelpCommentOutput(inputs, outputs, parameterGroups.ToArray()));
                 sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
                 sb.Append(variantGroup.Aliases.ToAliasOutput());
                 sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                     sb.Append(parameterGroup.HasValidateNotNull.ToValidateNotNullOutput());
                     sb.Append(parameterGroup.ToArgumentCompleterOutput());
                     sb.Append(parameterGroup.OrderCategory.ToParameterCategoryOutput());
+                    sb.Append(parameterGroup.InfoAttribute?.ToInfoOutput().ToString() ?? String.Empty);
                     sb.Append(parameterGroup.ParameterType.ToParameterTypeOutput());
                     sb.Append(parameterGroup.Description.ToParameterHelpOutput());
                     sb.Append(parameterGroup.ParameterName.ToParameterNameOutput(parameterGroups.IndexOf(parameterGroup) == parameterGroups.Count - 1));

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportPsd1.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportPsd1.cs
@@ -74,9 +74,9 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             sb.AppendLine($@"{Indent}FormatsToProcess = {formatList}");
 
             var functionInfos = GetScriptCmdlets(ExportsFolder).ToArray();
-            var cmdletsList = functionInfos.Select(sc => sc.Name).Distinct().Append("*").ToPsList();
+            var cmdletsList = functionInfos.Select(fi => fi.Name).Distinct().Append("*").ToPsList();
             sb.AppendLine($@"{Indent}CmdletsToExport = {cmdletsList}");
-            var aliasesList = functionInfos.SelectMany(i => i.ScriptBlock.Attributes).ToAliasNames().Append("*").ToPsList();
+            var aliasesList = functionInfos.SelectMany(fi => fi.ScriptBlock.Attributes).ToAliasNames().Append("*").ToPsList();
             sb.AppendLine($@"{Indent}AliasesToExport = {aliasesList}");
 
             sb.AppendLine($@"{Indent}PrivateData = @{{");

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsMarkdownTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsMarkdownTypes.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Management.Automation;
 using static Microsoft.Rest.ClientRuntime.PowerShell.MarkdownTypesExtensions;
 using static Microsoft.Rest.ClientRuntime.PowerShell.PsHelpOutputExtensions;
-using static Microsoft.Rest.ClientRuntime.PowerShell.PsProxyOutputExtensions;
 
 namespace Microsoft.Rest.ClientRuntime.PowerShell
 {

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsMarkdownTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsMarkdownTypes.cs
@@ -189,11 +189,10 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public MarkdownParameterHelpInfo(PsParameterHelpInfo parameterHelpInfo, ParameterGroup parameterGroup)
         {
             Name = parameterGroup.ParameterName;
-            var firstParameter = parameterGroup.Parameters.First();
-            Description = parameterHelpInfo.Description.NullIfEmpty() ?? firstParameter.ParameterAttribute.HelpMessage;
+            Description = parameterHelpInfo.Description.NullIfEmpty() ?? parameterGroup.Description;
             Type = parameterGroup.ParameterType;
-            Position = parameterHelpInfo.PositionText.ToUpperFirstCharacter().NullIfEmpty() ?? firstParameter.Position?.ToString() ?? "Named";
-            DefaultValue = parameterHelpInfo.DefaultValueAsString.NullIfEmpty() ?? firstParameter.DefaultValue?.Value?.ToString() ?? "None";
+            Position = parameterHelpInfo.PositionText.ToUpperFirstCharacter().NullIfEmpty() ?? parameterGroup.FirstPosition?.ToString() ?? "Named";
+            DefaultValue = parameterHelpInfo.DefaultValueAsString.NullIfEmpty() ?? parameterGroup.DefaultValue?.Value?.ToString() ?? "None";
 
             HasAllParameterSets = parameterGroup.HasAllVariants;
             ParameterSetNames = parameterHelpInfo.ParameterSetNames.NullIfEmpty() ?? parameterGroup.Parameters.Select(p => p.VariantName).ToArray();
@@ -201,8 +200,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
             IsRequired = parameterHelpInfo.IsRequired ?? parameterGroup.IsMandatory;
             IsDynamic = parameterHelpInfo.IsDynamic ?? false;
-            AcceptsPipelineByValue = parameterHelpInfo.SupportsPipelineInput?.Contains("ByValue") ?? firstParameter.ValueFromPipeline;
-            AcceptsPipelineByPropertyName = parameterHelpInfo.SupportsPipelineInput?.Contains("ByPropertyName") ?? firstParameter.ValueFromPipelineByPropertyName;
+            AcceptsPipelineByValue = parameterHelpInfo.SupportsPipelineInput?.Contains("ByValue") ?? parameterGroup.ValueFromPipeline;
+            AcceptsPipelineByPropertyName = parameterHelpInfo.SupportsPipelineInput?.Contains("ByPropertyName") ?? parameterGroup.ValueFromPipelineByPropertyName;
             AcceptsWildcardCharacters = parameterGroup.SupportsWildcards;
         }
     }

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsMarkdownTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsMarkdownTypes.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         public string[] Inputs { get; }
         public string[] Outputs { get; }
+        public ComplexInterfaceInfo[] ComplexInterfaceInfos { get; }
         public string[] RelatedLinks { get; }
 
         public bool SupportsShouldProcess { get; }
@@ -59,6 +60,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                      parameterGroups.Where(pg => pg.IsInputType).Select(pg => pg.ParameterType.FullName).ToArray();
             Outputs = helpInfo.OutputTypes.Where(it => it.Name.NullIfWhiteSpace() != null).Select(ot => ot.Name).ToArray().NullIfEmpty() ??
                       variantGroup.OutputTypes.Select(ot => ot.Type.FullName).ToArray();
+
+            ComplexInterfaceInfos = parameterGroups.Where(pg => pg.IsComplexInterface).OrderBy(pg => pg.ParameterName).Select(pg => pg.ComplexInterfaceInfo).ToArray();
             RelatedLinks = helpInfo.RelatedLinks.Select(rl => rl.Text).ToArray();
 
             SupportsShouldProcess = variantGroup.SupportsShouldProcess;

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -266,6 +266,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var outputsText = !String.IsNullOrEmpty(outputs) ? $"{Environment.NewLine}{outputs}" : String.Empty;
             var notes = String.Join($"{Environment.NewLine}{Environment.NewLine}", ParameterGroups
                 .Where(pg => pg.IsComplexInterface)
+                .OrderBy(pg => pg.ParameterName)
                 .Select(pg => ToComplexInterfaceNote(pg.ComplexInterfaceInfo, String.Empty)));
             var complexParameterHeader = $"COMPLEX PARAMETER PROPERTIES{Environment.NewLine}To create the parameters described below, construct a hash table containing the appropriate properties. For information on hash tables, run Get-Help about_Hash_Tables.{Environment.NewLine}{Environment.NewLine}";
             var notesText = !String.IsNullOrEmpty(notes) ? $"{Environment.NewLine}.Notes{Environment.NewLine}{complexParameterHeader}{notes}" : String.Empty;

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -205,12 +205,57 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public VariantGroup VariantGroup { get; }
         public Type[] Inputs { get; }
         public Type[] Outputs { get; }
+        public ParameterGroup[] ParameterGroups { get; }
 
-        public HelpCommentOutput(VariantGroup variantGroup, Type[] inputs, Type[] outputs)
+        public HelpCommentOutput(VariantGroup variantGroup, Type[] inputs, Type[] outputs, ParameterGroup[] parameterGroups)
         {
             VariantGroup = variantGroup;
             Inputs = inputs;
             Outputs = outputs;
+            ParameterGroups = parameterGroups;
+        }
+
+        private static string ToComplexInterfaceNote(ComplexInterfaceInfo complexInterfaceInfo, string currentIndent)
+        {
+            string RenderProperty(ComplexInterfaceInfo info, string indent) => $"{indent}{info.ToPropertySyntaxOutput()}: {info.Description}";
+
+            //var sb = new StringBuilder();
+            //sb.AppendLine(RenderProperty(complexInterfaceInfo, currentIndent));
+            //foreach (var nestedInfo in complexInterfaceInfo.NestedInfos)
+            //{
+            //    var nestedIndent = $"{currentIndent}{HalfIndent}";
+            //    var infoText = nestedInfo.IsComplexInterface
+            //        ? ToComplexInterfaceNote(nestedInfo, nestedIndent)
+            //        : RenderProperty(nestedInfo, nestedIndent);
+            //    sb.AppendLine(infoText);
+            //}
+
+            ////var nested = complexInterfaceInfo.NestedInfos.Select(ni =>
+            ////{
+            ////    var nestedIndent = $"{currentIndent}{HalfIndent}";
+            ////    return ni.IsComplexInterface
+            ////        ? ToComplexInterfaceNote(ni, nestedIndent)
+            ////        : RenderProperty(ni, nestedIndent);
+            ////});
+            ////var nestedText = String.Join(Environment.NewLine, nested);
+            ////sb.Append(nestedText);
+            //return sb.ToString();
+
+
+            //var lines = new[] {RenderProperty(complexInterfaceInfo, currentIndent)};
+
+
+            var nested = complexInterfaceInfo.NestedInfos.Select(ni =>
+            {
+                var nestedIndent = $"{currentIndent}{HalfIndent}";
+                return ni.IsComplexInterface
+                    ? ToComplexInterfaceNote(ni, nestedIndent)
+                    : RenderProperty(ni, nestedIndent);
+            })
+            .Prepend(RenderProperty(complexInterfaceInfo, currentIndent));
+            //var nestedText = String.Join(Environment.NewLine, nested);
+            //sb.Append(nestedText);
+            return String.Join(Environment.NewLine, nested);
         }
 
         public override string ToString()
@@ -219,13 +264,17 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var inputsText = !String.IsNullOrEmpty(inputs) ? $"{Environment.NewLine}{inputs}" : String.Empty;
             var outputs = String.Join(Environment.NewLine, Outputs.Select(t => $".Outputs{Environment.NewLine}{t.FullName}"));
             var outputsText = !String.IsNullOrEmpty(outputs) ? $"{Environment.NewLine}{outputs}" : String.Empty;
+            var notes = String.Join($"{Environment.NewLine}{Environment.NewLine}", ParameterGroups
+                .Where(pg => pg.IsComplexInterface)
+                .Select(pg => ToComplexInterfaceNote(pg.ComplexInterfaceInfo, String.Empty)));
+            var notesText = !String.IsNullOrEmpty(notes) ? $"{Environment.NewLine}.Notes{Environment.NewLine}{notes}" : String.Empty;
             return $@"<#
 .Synopsis
 {VariantGroup.Description}
 .Description
 {VariantGroup.Description}
 .Example
-To view examples, please use the -Online parameter with Get-Help or navigate to: {VariantGroup.Link}{inputsText}{outputsText}
+To view examples, please use the -Online parameter with Get-Help or navigate to: {VariantGroup.Link}{inputsText}{outputsText}{notesText}
 .Link
 {VariantGroup.Link}
 #>
@@ -283,13 +332,58 @@ To view examples, please use the -Online parameter with Get-Help or navigate to:
         public override string ToString() => $"{Indent}[{typeof(CategoryAttribute).ToPsAttributeType()}('{Category}')]{Environment.NewLine}";
     }
 
+    internal class PropertySyntaxOutput
+    {
+        public string ParameterName { get; }
+        public Type ParameterType { get; }
+        public bool IsMandatory { get; }
+        public int? Position { get; }
+        
+        public bool IncludeSpace { get; }
+        public bool IncludeDash { get; }
+
+        public PropertySyntaxOutput(Parameter parameter)
+        {
+            ParameterName = parameter.ParameterName;
+            ParameterType = parameter.ParameterType;
+            IsMandatory = parameter.IsMandatory;
+            Position = parameter.Position;
+            IncludeSpace = true;
+            IncludeDash = true;
+        }
+
+        public PropertySyntaxOutput(ComplexInterfaceInfo complexInterfaceInfo)
+        {
+            ParameterName = complexInterfaceInfo.Name;
+            ParameterType = complexInterfaceInfo.Type;
+            IsMandatory = complexInterfaceInfo.Required;
+            Position = null;
+            IncludeSpace = false;
+            IncludeDash = false;
+        }
+
+        public override string ToString()
+        {
+            var leftOptional = !IsMandatory ? "[" : String.Empty;
+            var leftPositional = Position != null ? "[" : String.Empty;
+            var rightPositional = Position != null ? "]" : String.Empty;
+            var type = ParameterType != typeof(SwitchParameter) ? $" <{ParameterType.Name}>" : String.Empty;
+            var rightOptional = !IsMandatory ? "]" : String.Empty;
+            var space = IncludeSpace ? " " : String.Empty;
+            var dash = IncludeDash ? "-" : String.Empty;
+            return $"{space}{leftOptional}{leftPositional}{dash}{ParameterName}{rightPositional}{type}{rightOptional}";
+        }
+    }
+
     internal static class PsProxyOutputExtensions
     {
         public const string NoParameters = "__NoParameters";
 
         public const string AllParameterSets = "__AllParameterSets";
 
-        public const string Indent = "    ";
+        public const string HalfIndent = "  ";
+
+        public const string Indent = HalfIndent + HalfIndent;
 
         public const string ItemSeparator = ", ";
 
@@ -307,7 +401,9 @@ To view examples, please use the -Online parameter with Get-Help or navigate to:
         // https://stackoverflow.com/a/5284606/294804
         private static string RemoveEnd(this string text, string suffix) => text.EndsWith(suffix) ? text.Substring(0, text.Length - suffix.Length) : text;
 
-        public static string ToPsStringLiteral(this string value) => value?.Replace("'", "''")?.Replace("‘", "''")?.Replace("’", "''")?.Replace("<br>", " ")?.Replace("\r\n", " ")?.Replace("\n", " ") ?? String.Empty;
+        public static string ToPsSingleLine(this string value) => value?.Replace("<br>", " ")?.Replace("\r\n", " ")?.Replace("\n", " ") ?? String.Empty;
+
+        public static string ToPsStringLiteral(this string value) => value?.Replace("'", "''")?.Replace("‘", "''")?.Replace("’", "''")?.ToPsSingleLine() ?? String.Empty;
 
         public static string JoinIgnoreEmpty(this IEnumerable<string> values, string separator) => String.Join(separator, values?.Where(v => !String.IsNullOrEmpty(v)));
 
@@ -333,7 +429,7 @@ To view examples, please use the -Online parameter with Get-Help or navigate to:
 
         public static EndOutput ToEndOutput(this VariantGroup variantGroup) => new EndOutput();
 
-        public static HelpCommentOutput ToHelpCommentOutput(this VariantGroup variantGroup, Type[] inputs, Type[] outputs) => new HelpCommentOutput(variantGroup, inputs, outputs);
+        public static HelpCommentOutput ToHelpCommentOutput(this VariantGroup variantGroup, Type[] inputs, Type[] outputs, ParameterGroup[] parameterGroups) => new HelpCommentOutput(variantGroup, inputs, outputs, parameterGroups);
 
         public static ParameterHelpOutput ToParameterHelpOutput(this string helpMessage) => new ParameterHelpOutput(helpMessage);
 
@@ -342,5 +438,9 @@ To view examples, please use the -Online parameter with Get-Help or navigate to:
         public static DescriptionOutput ToDescriptionOutput(this string description) => new DescriptionOutput(description);
 
         public static ParameterCategoryOutput ToParameterCategoryOutput(this ParameterCategory category) => new ParameterCategoryOutput(category);
+
+        public static PropertySyntaxOutput ToPropertySyntaxOutput(this Parameter parameter) => new PropertySyntaxOutput(parameter);
+
+        public static PropertySyntaxOutput ToPropertySyntaxOutput(this ComplexInterfaceInfo complexInterfaceInfo) => new PropertySyntaxOutput(complexInterfaceInfo);
     }
 }

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -263,7 +263,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             NestedInfos = InfoAttribute.PossibleTypes
                 .SelectMany(pt => pt.GetProperties()
                     .SelectMany(pi => pi.GetCustomAttributes(true).OfType<InfoAttribute>()
-                        .Select(ia => ia.ToComplexInterfaceInfo(pi.Name, pi.PropertyType))))
+                        .Select(ia => ia.ToComplexInterfaceInfo(pi.Name, pi.PropertyType))
+                        .OrderByDescending(cii => cii.Required)))
                 .Where(cii => !cii.ReadOnly).ToArray();
             IsComplexInterface = NestedInfos.Any();
         }

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -230,11 +230,10 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             DontShow = ParameterAttribute.DontShow;
             IsMandatory = ParameterAttribute.Mandatory;
 
-            ComplexInterfaceInfo = InfoAttribute?.ToComplexInterfaceInfo(ParameterName, ParameterType);
-            //IsComplexInterface = InfoAttribute?.PossibleTypes.Any(pt => pt.IsInterface && pt.GetProperties(BindingFlags.SetProperty).Any(pi => pi.GetCustomAttributes(true).OfType<InfoAttribute>().Any())) ?? false;
-            //IsComplexInterface = InfoAttribute?.PossibleTypes.Where(pt => pt.IsInterface).SelectMany(pt => pt.GetProperties(BindingFlags.SetProperty).SelectMany(pi => pi.GetCustomAttributes(true).OfType<InfoAttribute>())).Any() ?? false;
+            var complexParameterName = ParameterName.ToUpperInvariant();
+            ComplexInterfaceInfo = InfoAttribute?.ToComplexInterfaceInfo(complexParameterName, ParameterType, true);
             IsComplexInterface = ComplexInterfaceInfo?.IsComplexInterface ?? false;
-            HelpMessage = $"{ParameterAttribute.HelpMessage}{(IsComplexInterface ? $"{Environment.NewLine}See NOTES section for {ParameterName} parameter for property information." : String.Empty)}";
+            HelpMessage = $"{ParameterAttribute.HelpMessage}{(IsComplexInterface ? $"{Environment.NewLine}To construct, see NOTES section for {complexParameterName} properties and create a hash table." : String.Empty)}";
         }
     }
 
@@ -251,13 +250,13 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public ComplexInterfaceInfo[] NestedInfos { get; }
         public bool IsComplexInterface { get; }
 
-        public ComplexInterfaceInfo(string name, Type type, InfoAttribute infoAttribute)
+        public ComplexInterfaceInfo(string name, Type type, InfoAttribute infoAttribute, bool? required)
         {
             Name = name;
             Type = type;
             InfoAttribute = infoAttribute;
 
-            Required = InfoAttribute.Required;
+            Required = required ?? InfoAttribute.Required;
             ReadOnly = InfoAttribute.ReadOnly;
             Description = InfoAttribute.Description.ToPsSingleLine();
 
@@ -311,6 +310,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 .Select(pg => new ParameterGroup(pg.Key, pg.Select(p => p).ToArray(), allVariantNames));
         }
 
-        public static ComplexInterfaceInfo ToComplexInterfaceInfo(this InfoAttribute infoAttribute, string name, Type type) => new ComplexInterfaceInfo(name, type, infoAttribute);
+        public static ComplexInterfaceInfo ToComplexInterfaceInfo(this InfoAttribute infoAttribute, string name, Type type, bool? required = null) => new ComplexInterfaceInfo(name, type, infoAttribute, required);
     }
 }

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public bool SupportsWildcards { get; }
         public bool IsComplexInterface { get; }
         public ComplexInterfaceInfo ComplexInterfaceInfo { get; }
+        public InfoAttribute InfoAttribute { get; }
 
         public int? FirstPosition { get; }
         public PSDefaultValueAttribute DefaultValue { get; }
@@ -177,6 +178,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             SupportsWildcards = Parameters.Any(p => p.SupportsWildcards);
             IsComplexInterface = Parameters.Any(p => p.IsComplexInterface);
             ComplexInterfaceInfo = Parameters.Where(p => p.IsComplexInterface).Select(p => p.ComplexInterfaceInfo).FirstOrDefault();
+            InfoAttribute = Parameters.Select(p => p.InfoAttribute).FirstOrDefault();
 
             FirstPosition = firstParameter.Position;
             DefaultValue = Parameters.Select(p => p.DefaultValue).FirstOrDefault(dv => dv != null);


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.powershell/issues/321

This uses the InfoAttribute and outputs complex parameter information into the Notes section of both the exports and the markdown documents.

Based on these changes, I've created another issue to revise this implementation. I consider this PR the 'first iteration' of this feature.
https://github.com/Azure/autorest.powershell/issues/388