### PR TITLE
Allows the implemented interfaces of the types to get recognized by the complex type documentation generator.

### DIFF
--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -270,7 +270,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var hasBeenSeen = seenTypes?.Contains(unwrappedType) ?? false;
             (seenTypes ?? (seenTypes = new List<Type>())).Add(unwrappedType);
             NestedInfos = hasBeenSeen ? new ComplexInterfaceInfo[]{} :
-                InfoAttribute.PossibleTypes
+                unwrappedType.GetInterfaces()
+                .Concat(InfoAttribute.PossibleTypes)
                 .SelectMany(pt => pt.GetProperties()
                     .SelectMany(pi => pi.GetCustomAttributes(true).OfType<InfoAttribute>()
                         .Select(ia => ia.ToComplexInterfaceInfo(pi.Name, pi.PropertyType, seenTypes: seenTypes))))


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.powershell/issues/405