### PR TITLE
Allow multi-version binary cmdlets

### DIFF
--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -300,6 +300,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         {
             var metadata = new CommandMetadata(info);
             var privateCmdletName = metadata.Name;
+            var canonicalParts = privateCmdletName.Split('!');
+            privateCmdletName = canonicalParts.Length > 1 ? canonicalParts[0] : privateCmdletName;
             var parts = privateCmdletName.Split('_');
             return parts.Length > 1
                 ? new[] { new Variant(parts[0], parts[1], info, metadata) }

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -299,9 +299,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public static Variant[] ToVariants(this CommandInfo info)
         {
             var metadata = new CommandMetadata(info);
-            var privateCmdletName = metadata.Name;
-            var canonicalParts = privateCmdletName.Split('!');
-            privateCmdletName = canonicalParts.Length > 1 ? canonicalParts[0] : privateCmdletName;
+            var privateCmdletName = metadata.Name.Split('!').First();
             var parts = privateCmdletName.Split('_');
             return parts.Length > 1
                 ? new[] { new Variant(parts[0], parts[1], info, metadata) }


### PR DESCRIPTION
Allow binary cmdlets with multiple versions - use '!' as a separator, with the proxy cmdlet name in the first part.

Note that '!' looks like the best choice to be the separator, as most other characters (including '@') are on a reserved list, and will produce a warning on import.  The other possibility  in the typewriter characters was '%'