### PR TITLE
Surface output types + minor fix

### DIFF
--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -340,7 +340,7 @@ export class CallMethod extends Method {
           yield While(new LiteralExpression(`${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `), function* () {
             yield EOL;
             yield `// get the delay before polling. (default to 30 seconds if not present)`;
-            yield `int delay = ${response.value}.Headers.RetryAfter.Delta?.Seconds ?? 30;`
+            yield `int delay = ${response.value}.Headers.RetryAfter?.Delta?.Seconds ?? 30;`
             // yield If(`!int.TryParse( ${response.invokeMethod('GetFirstHeader', new StringExpression(`Retry-After`)).value}, out int delay)`, `delay = 30;`);
 
             yield eventListener.signal(ClientRuntime.Events.DelayBeforePolling, `$"Delaying {delay} seconds before polling."`, response.value);

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportCmdletSurface.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportCmdletSurface.cs
@@ -78,11 +78,12 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 .Select(vgg => (
                     CmdletNoun: vgg.Key,
                     CmdletVerbs: vgg.Select(vg => vg.CmdletVerb).OrderBy(cv => cv).ToArray(),
-                    ParameterGroups: vgg.SelectMany(vg => vg.ParameterGroups).DistinctBy(p => p.ParameterName).ToArray()))
+                    ParameterGroups: vgg.SelectMany(vg => vg.ParameterGroups).DistinctBy(p => p.ParameterName).ToArray(),
+                    OutputTypes: vgg.SelectMany(vg => vg.OutputTypes).Select(ot => ot.Type).DistinctBy(t => t.Name).Select(t => t.ToSyntaxTypeName()).ToArray()))
                 .OrderBy(vg => vg.CmdletNoun);
             foreach (var condensedGroup in condensedGroups)
             {
-                sb.Append($"### {condensedGroup.CmdletNoun} [{String.Join(", ", condensedGroup.CmdletVerbs)}]{Environment.NewLine}");
+                sb.Append($"### {condensedGroup.CmdletNoun} [{String.Join(", ", condensedGroup.CmdletVerbs)}] `{String.Join(", ", condensedGroup.OutputTypes)}`{Environment.NewLine}");
                 var parameterGroups = condensedGroup.ParameterGroups
                     .Where(pg => !pg.DontShow && (IncludeGeneralParameters || (pg.OrderCategory != ParameterCategory.Azure && pg.OrderCategory != ParameterCategory.Runtime)))
                     .OrderBy(pg => pg.OrderCategory)


### PR DESCRIPTION
This updates the cmdlet surface to include output types from the cmdlets. Also, minor fix for when Delta is missing from the RetryAfter header.