### PR TITLE
Help link prefix

### DIFF
--- a/extensions/powershell/README.md
+++ b/extensions/powershell/README.md
@@ -34,6 +34,7 @@ load-priority: 1001
 module-version: 0.1.0
 skip-model-cmdlets: false
 azure: false
+help-link-prefix: https://docs.microsoft.com/en-us/powershell/module/
 ```
 
 > Names

--- a/extensions/powershell/project.ts
+++ b/extensions/powershell/project.ts
@@ -94,6 +94,7 @@ export class Project extends codeDomProject {
   public dependencyModuleFolder!: string;
   public metadata!: Metadata;
   public state!: State;
+  public helpLinkPrefix!: string;
   get model() { return <codemodel.Model>this.state.model };
 
   constructor(protected service: Host, objectInitializer?: Partial<Project>) {
@@ -131,9 +132,9 @@ export class Project extends codeDomProject {
     this.moduleVersion = await this.state.getValue('module-version');
     this.profiles = this.model.info.extensions['x-ms-metadata'].profiles || [];
     this.accountsVersionMinimum = '1.6.0';
+    this.helpLinkPrefix = await this.state.getValue('help-link-prefix');
 
     // Flags
-    // this.skipModelCmdlets = await this.state.getValue('skip-model-cmdlets');
     this.skipModelCmdlets = true;
     this.azure = this.model.details.default.isAzure;
 

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsHelpMarkdownOutputs.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsHelpMarkdownOutputs.cs
@@ -110,6 +110,8 @@ Dynamic: {ParameterInfo.IsDynamic}
     {
         public PSModuleInfo ModuleInfo { get; }
 
+        private static string HelpLinkPrefix { get; } = @"${$project.helpLinkPrefix}";
+
         public ModulePageMetadataOutput(PSModuleInfo moduleInfo)
         {
             ModuleInfo = moduleInfo;
@@ -118,7 +120,7 @@ Dynamic: {ParameterInfo.IsDynamic}
         public override string ToString() => $@"---
 Module Name: {ModuleInfo.Name}
 Module Guid: {ModuleInfo.Guid}
-Download Help Link: https://docs.microsoft.com/en-us/powershell/module/{ModuleInfo.Name.ToLowerInvariant()}
+Download Help Link: {HelpLinkPrefix}{ModuleInfo.Name.ToLowerInvariant()}
 Help Version: 1.0.0.0
 Locale: en-US
 ---

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsProxyTypes.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public string FileName { get; }
         public string FilePath { get; }
 
+        private static string HelpLinkPrefix { get; } = @"${$project.helpLinkPrefix}";
+
         public VariantGroup(string cmdletName, Variant[] variants, string outputFolder, string profileName = NoProfiles, bool isTest = false)
         {
             CmdletName = cmdletName;
@@ -63,7 +65,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             HasMultipleVariants = Variants.Length > 1;
             Description = Variants.SelectMany(v => v.Attributes).OfType<DescriptionAttribute>().FirstOrDefault()?.Description;
             IsGenerated = Variants.All(v => v.Attributes.OfType<GeneratedAttribute>().Any());
-            Link = $@"https://docs.microsoft.com/en-us/powershell/module/{@"${$project.moduleName}".ToLowerInvariant()}/{CmdletName.ToLowerInvariant()}";
+            Link = $@"{HelpLinkPrefix}{@"${$project.moduleName}".ToLowerInvariant()}/{CmdletName.ToLowerInvariant()}";
 
             OutputFolder = outputFolder;
             FileName = $"{CmdletName}{(isTest ? ".Tests" : String.Empty)}.ps1";


### PR DESCRIPTION
Fixes: https://github.com/Azure/autorest.powershell/issues/378

Added helpLinkPrefix to allow setting the base URL for help documentation links.