### PR TITLE
my fix for ?&

### DIFF
--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -181,7 +181,7 @@ export class OperationMethod extends Method {
         + ${removeEncoding(pp, pp.param.name, KnownMediaType.QueryParameter)}`, `
         + "&"`
         )}
-        ,"\\\\?&*$|&*$|(\\\\?)&|(&)&+","$1$2").Replace("?&","?")`.replace(/\s*\+ ""/gm, ''))
+        ,"\\\\?&*$|&*$|(\\\\?)&+|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, ''))
       });
       yield urlV.declarationStatement;
 

--- a/extensions/csharp-v2/operation/method.ts
+++ b/extensions/csharp-v2/operation/method.ts
@@ -181,7 +181,7 @@ export class OperationMethod extends Method {
         + ${removeEncoding(pp, pp.param.name, KnownMediaType.QueryParameter)}`, `
         + "&"`
         )}
-        ,"\\\\?&*$|&*$|(\\\\?)&|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, ''))
+        ,"\\\\?&*$|&*$|(\\\\?)&|(&)&+","$1$2").Replace("?&","?")`.replace(/\s*\+ ""/gm, ''))
       });
       yield urlV.declarationStatement;
 


### PR DESCRIPTION
Despite the latest regex/query param change i'm still seeing issues with query parameters and stray `&`.  (referencing #442 and #445 )

Specifically, seeing GETs like this:

`GET /RESOURCE?&guid=039467b3-d779-493c-91ec-7137395a9582`  

Note the `?&`.  

Upon inspection I expected your regex to catch this case, but wasn't able to adapt what you have.  I'm simply adding a `.Replace("&?", "?")` in the interim, and that's doing the trick for me.

I'm sure there's a cleaner fix to this, but I wanted to surface the issue to you nonetheless.

@kenal-microsoft  @amareshbAtMicrosoft 