### PR TITLE
Multiple small fixes

### DIFF
--- a/extensions/powershell/generators/csproj.ts
+++ b/extensions/powershell/generators/csproj.ts
@@ -47,5 +47,13 @@ ${release}
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);${removeCd(project.resourcesFolder)}/**</DefaultItemExcludes>
+  </PropertyGroup>
+
 </Project>`, undefined, 'source-file-csharp');
+}
+
+function removeCd(path: string): string {
+  return path.startsWith('./') ? path.replace('./', '') : path;
 }

--- a/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 var sb = new StringBuilder();
                 sb.Append(markdownInfo.ToHelpMetadataOutput());
                 sb.Append($"# {markdownInfo.CmdletName}{Environment.NewLine}{Environment.NewLine}");
-                sb.Append($"## SYNOPSIS{Environment.NewLine}{markdownInfo.Synopsis.ReplaceSentenceEndWithNewline()}{Environment.NewLine}{Environment.NewLine}");
+                sb.Append($"## SYNOPSIS{Environment.NewLine}{markdownInfo.Synopsis.ToDescriptionFormat()}{Environment.NewLine}{Environment.NewLine}");
 
                 sb.Append($"## SYNTAX{Environment.NewLine}{Environment.NewLine}");
                 var hasMultipleParameterSets = markdownInfo.SyntaxInfos.Length > 1;
@@ -56,7 +56,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                     sb.Append(syntaxInfo.ToHelpSyntaxOutput(hasMultipleParameterSets));
                 }
 
-                sb.Append($"## DESCRIPTION{Environment.NewLine}{markdownInfo.Description.ReplaceSentenceEndWithNewline()}{Environment.NewLine}{Environment.NewLine}");
+                sb.Append($"## DESCRIPTION{Environment.NewLine}{markdownInfo.Description.ToDescriptionFormat()}{Environment.NewLine}{Environment.NewLine}");
 
                 sb.Append($"## EXAMPLES{Environment.NewLine}{Environment.NewLine}");
                 foreach(var exampleInfo in markdownInfo.Examples)
@@ -131,7 +131,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var sb = new StringBuilder();
             sb.Append(ModuleInfo.ToModulePageMetadataOutput());
             sb.Append($"# {ModuleInfo.Name} Module{Environment.NewLine}");
-            sb.Append($"## Description{Environment.NewLine}{ModuleInfo.Description.ReplaceSentenceEndWithNewline()}{Environment.NewLine}{Environment.NewLine}");
+            sb.Append($"## Description{Environment.NewLine}{ModuleInfo.Description.ToDescriptionFormat()}{Environment.NewLine}{Environment.NewLine}");
 
             sb.Append($"## {ModuleInfo.Name} Cmdlets{Environment.NewLine}");
             foreach (var markdownInfo in markdownInfos)

--- a/extensions/powershell/resources/runtime/BuildTime/Models/PsHelpMarkdownOutputs.cs
+++ b/extensions/powershell/resources/runtime/BuildTime/Models/PsHelpMarkdownOutputs.cs
@@ -60,7 +60,7 @@ schema: {HelpInfo.Schema.ToString(3)}
 {ExampleInfo.Code}
 {ExampleCodeFooter}
 
-{ExampleInfo.Description.ReplaceSentenceEndWithNewline()}
+{ExampleInfo.Description.ToDescriptionFormat()}
 
 ";
     }
@@ -87,7 +87,7 @@ schema: {HelpInfo.Schema.ToString(3)}
                 : false.ToString();
 
             return $@"### -{ParameterInfo.Name}
-{ParameterInfo.Description.ReplaceSentenceEndWithNewline()}
+{ParameterInfo.Description.ToDescriptionFormat()}
 
 ```yaml
 Type: {ParameterInfo.Type.FullName}
@@ -138,14 +138,16 @@ Locale: en-US
         }
 
         public override string ToString() => $@"### [{HelpInfo.CmdletName}]({HelpInfo.CmdletName}.md)
-{HelpInfo.Description.ReplaceSentenceEndWithNewline()}
+{HelpInfo.Description.ToDescriptionFormat()}
 
 ";
     }
 
     internal static class PsHelpOutputExtensions
     {
+        public static string EscapeAngleBrackets(this string text) => text?.Replace("<", @"\<")?.Replace(">", @"\>");
         public static string ReplaceSentenceEndWithNewline(this string text) => text?.Replace(".  ", $".{Environment.NewLine}")?.Replace(". ", $".{Environment.NewLine}");
+        public static string ToDescriptionFormat(this string text) => text?.EscapeAngleBrackets()?.ReplaceSentenceEndWithNewline();
 
         public const string ExampleNameHeader = "### ";
         public const string ExampleCodeHeader = "```powershell";


### PR DESCRIPTION
Properly excluded files from the resources folder in the csproj generator. Fixed displaying descriptions in markdown when they contain <> characters. Cleaned up the ExportModelSurface. Allowed ExportModelSurface to show both enum values (if property is an enum) and associative array type (if either type or properties are IAssociativeArray).