### PR TITLE
added typeconverter for enum structs

### DIFF
--- a/powershell/enums/namespace.ts
+++ b/powershell/enums/namespace.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { EnumDetails } from '@azure-tools/codemodel-v3';
-import { If, Parameter, Method, Namespace, System, Struct } from '@azure-tools/codegen-csharp';
+import { If, Parameter, Method, Namespace, System, Struct, Attribute, Class, dotnet, LambdaMethod, LiteralExpression, Modifier } from '@azure-tools/codegen-csharp';
 import { State } from '../internal/state';
-import { IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType } from '../internal/powershell-declarations';
+import { IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType, TypeConverterAttribute, PSTypeConverter } from '../internal/powershell-declarations';
 import { join } from 'path';
 
 export class EnumNamespace extends Namespace {
@@ -37,6 +37,7 @@ export class EnumNamespace extends Namespace {
         continue;
       }
 
+      // generate a typeconverter for the enum class too.
 
       const enumValues = values(enumInfo.details.values).select(v => <string>v.value).toArray();
       const enumClass = new Struct(this, enumInfo.details.name, undefined, {
@@ -58,6 +59,62 @@ export class EnumNamespace extends Namespace {
             `yield return new ${CompletionResult.declaration}("${enumValue}", "${enumValue}", ${CompletionResultType.declaration}.ParameterValue, "${enumValue}");`);
         }
       });
+
+
+      // generate a typeconverter for the enum class too.
+
+      const converterClass = new Class(this, `${enumInfo.details.name}TypeConverter`, undefined, {
+        interfaces: [PSTypeConverter],
+        partial: true,
+        description: enumInfo.description || `TypeConverter implementation for ${enumInfo.details.name}.`,
+        fileName: `${enumInfo.details.name}.TypeConverter`
+      });
+
+      converterClass.add(new LambdaMethod('CanConvertFrom', dotnet.Bool, dotnet.True, {
+        override: Modifier.Override,
+        parameters: [
+          new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+          new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+        ],
+        description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+        returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
+      }));
+
+      converterClass.add(new LambdaMethod('CanConvertTo', dotnet.Bool, dotnet.False, {
+        override: Modifier.Override,
+        parameters: [
+          new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+          new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+        ],
+        description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+        returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
+      }));
+
+      converterClass.add(new LambdaMethod('ConvertFrom', dotnet.Object, new LiteralExpression(`${enumInfo.details.name}.CreateFrom(sourceValue)`), {
+        override: Modifier.Override,
+        parameters: [
+          new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+          new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+          new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+          new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+        ],
+        description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" /> ',
+        returnsDescription: `an instance of <see cref="${enumInfo.details.name}" />, or <c>null</c> if there is no suitable conversion.`
+      }));
+
+      converterClass.add(new LambdaMethod('ConvertTo', dotnet.Object, dotnet.Null, {
+        override: Modifier.Override,
+        parameters: [
+          new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+          new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+          new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+          new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+        ], description: 'NotImplemented -- this will return <c>null</c>',
+        returnsDescription: 'will always return <c>null</c>.'
+      }));
+
+      enumClass.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+
     }
   }
 }


### PR DESCRIPTION
Creates a typeconverter class for enum structs:

``` csharp
namespace Microsoft.Azure.PowerShell.Cmdlets.Dns.Support
{

    /// <summary>TypeConverter implementation for HttpStatusCode.</summary>
    public partial class HttpStatusCodeTypeConverter :
        System.Management.Automation.PSTypeConverter
    {

        /// <summary>
        /// Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" />
        /// parameter.
        /// </summary>
        /// <param name="sourceValue">the <see cref="System.Object"/> to convert from</param>
        /// <param name="destinationType">the <see cref="System.Type" /> to convert to</param>
        /// <returns>
        /// <c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" />
        /// parameter, otherwise <c>false</c>.
        /// </returns>
        public override bool CanConvertFrom(object sourceValue, global::System.Type destinationType) => true;

        /// <summary>
        /// Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" />
        /// parameter.
        /// </summary>
        /// <param name="sourceValue">the <see cref="System.Object"/> to convert from</param>
        /// <param name="destinationType">the <see cref="System.Type" /> to convert to</param>
        /// <returns>
        /// <c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" />
        /// parameter, otherwise <c>false</c>.
        /// </returns>
        public override bool CanConvertTo(object sourceValue, global::System.Type destinationType) => false;

        /// <summary>
        /// Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider"
        /// /> and <see cref="ignoreCase" />
        /// </summary>
        /// <param name="sourceValue">the <see cref="System.Object"/> to convert from</param>
        /// <param name="destinationType">the <see cref="System.Type" /> to convert to</param>
        /// <param name="formatProvider">not used by this TypeConverter.</param>
        /// <param name="ignoreCase">when set to <c>true</c>, will ignore the case when converting.</param>
        /// <returns>
        /// an instance of <see cref="HttpStatusCode" />, or <c>null</c> if there is no suitable conversion.
        /// </returns>
        public override object ConvertFrom(object sourceValue, global::System.Type destinationType, global::System.IFormatProvider formatProvider, bool ignoreCase) => HttpStatusCode.CreateFrom(sourceValue);

        /// <summary>NotImplemented -- this will return <c>null</c></summary>
        /// <param name="sourceValue">the <see cref="System.Object"/> to convert from</param>
        /// <param name="destinationType">the <see cref="System.Type" /> to convert to</param>
        /// <param name="formatProvider">not used by this TypeConverter.</param>
        /// <param name="ignoreCase">when set to <c>true</c>, will ignore the case when converting.</param>
        /// <returns>will always return <c>null</c>.</returns>
        public override object ConvertTo(object sourceValue, global::System.Type destinationType, global::System.IFormatProvider formatProvider, bool ignoreCase) => null;
    }
}
```

// cc @niander 