### PR TITLE
Updating for upcoming linq and remodeler changes

### DIFF
--- a/powershell/cmdlets/namespace.ts
+++ b/powershell/cmdlets/namespace.ts
@@ -7,6 +7,7 @@ import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
 import { Schema, ClientRuntime } from '../llcsharp/exports';
 import { State } from '../internal/state';
 import { CmdletClass } from './class';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class CmdletNamespace extends Namespace {
   inputModels = new Array<Schema>();
@@ -14,7 +15,7 @@ export class CmdletNamespace extends Namespace {
     return this.state.project.cmdletFolder;
   }
 
-  constructor(parent: Namespace, private state: State, objectInitializer?: Partial<CmdletNamespace>) {
+  constructor(parent: Namespace, private state: State, objectInitializer?: DeepPartial<CmdletNamespace>) {
     super('Cmdlets', parent);
     this.apply(objectInitializer);
   }

--- a/powershell/cmdlets/parameter.ts
+++ b/powershell/cmdlets/parameter.ts
@@ -5,10 +5,11 @@
 
 import { components } from '@azure-tools/codemodel-v3';
 import { BackedProperty, TypeDeclaration } from '@azure-tools/codegen-csharp';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class CmdletParameter extends BackedProperty {
   public parameterDefinition: components.IParameter;
-  constructor(name: string, type: TypeDeclaration, parameterDefinition: components.IParameter, objectInitializer?: Partial<CmdletParameter>) {
+  constructor(name: string, type: TypeDeclaration, parameterDefinition: components.IParameter, objectInitializer?: DeepPartial<CmdletParameter>) {
     super(name, type);
     this.parameterDefinition = parameterDefinition;
     this.apply(objectInitializer);

--- a/powershell/enums/namespace.ts
+++ b/powershell/enums/namespace.ts
@@ -8,13 +8,14 @@ import { If, Parameter, Method, Namespace, System, Struct } from '@azure-tools/c
 import { State } from '../internal/state';
 import { IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType } from '../internal/powershell-declarations';
 import { join } from 'path';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class EnumNamespace extends Namespace {
   public get outputFolder(): string {
     return join(this.state.project.apiFolder, 'Support');
   }
 
-  constructor(parent: Namespace, public state: State, objectInitializer?: Partial<EnumNamespace>) {
+  constructor(parent: Namespace, public state: State, objectInitializer?: DeepPartial<EnumNamespace>) {
     super('Support', parent);
     this.apply(objectInitializer);
 

--- a/powershell/internal/name-inferrer.ts
+++ b/powershell/internal/name-inferrer.ts
@@ -5,6 +5,7 @@
 
 import { pascalCase, EnglishPluralizationService } from '@azure-tools/codegen';
 import { Channel, Message } from '@azure-tools/autorest-extension-base';
+import { length } from '@azure-tools/linq';
 
 function getPluralizationService(): EnglishPluralizationService {
   const result = new EnglishPluralizationService();
@@ -232,7 +233,7 @@ const cmdVerbMap = { ...cmdVerbMapGetVerb, ...cmdVerbMapCustom };
 function mapVerb(verb: string): Array<string> {
   verb = verb.toLowerCase();
   const keyHits = Object.keys(cmdVerbMap).filter(key => key.toLowerCase() === verb);
-  if (keyHits.length === 0) { return []; }
+  if (length(keyHits) === 0) { return []; }
   let value = cmdVerbMap[keyHits[0]];
   if (!Array.isArray(value)) { value = [value]; }
   return value;
@@ -246,8 +247,8 @@ export function getCommandName(operationId: string, onMessage: (message: Message
   const opIdValues = operationId.split('_', 2);
 
   // OperationId can be specified without '_' (Underscore), Verb will retrieved by the below logic for non-approved verbs.
-  let cmdNoun = opIdValues.length === 2 ? getSingularizedValue(opIdValues[0]) : '';
-  let cmdVerb = opIdValues.length === 2 ? opIdValues[1] : getSingularizedValue(operationId);
+  let cmdNoun = length(opIdValues) === 2 ? getSingularizedValue(opIdValues[0]) : '';
+  let cmdVerb = length(opIdValues) === 2 ? opIdValues[1] : getSingularizedValue(operationId);
   let cmdVerbs: Array<string> = [cmdVerb];
   const variant = operationId;
 
@@ -277,7 +278,7 @@ export function getCommandName(operationId: string, onMessage: (message: Message
       let buildFirstWord = false;
       let firstWordEnd = -1;
       let verbMatchEnd = -1;
-      for (let i = 0; i < unapprovedVerb.length; ++i) {
+      for (let i = 0; i < length(unapprovedVerb); ++i) {
         // Add the start condition of the first word so that the end condition is easier
         if (!firstWordStarted) {
           firstWordStarted = true;

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -14,6 +14,7 @@ import { ModuleNamespace } from '../module/module-namespace';
 import { CmdletNamespace } from '../cmdlets/namespace';
 import { Host } from '@azure-tools/autorest-extension-base';
 import { codemodel, PropertyDetails, exportedModels as T, ModelState, JsonType, } from '@azure-tools/codemodel-v3';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export type Schema = T.SchemaT<LanguageDetails<SchemaDetails>, LanguageDetails<PropertyDetails>>;
 
@@ -97,7 +98,7 @@ export class Project extends codeDomProject {
   public helpLinkPrefix!: string;
   get model() { return <codemodel.Model>this.state.model; }
 
-  constructor(protected service: Host, objectInitializer?: Partial<Project>) {
+  constructor(protected service: Host, objectInitializer?: DeepPartial<Project>) {
     super();
     this.apply(objectInitializer);
   }

--- a/powershell/internal/state.ts
+++ b/powershell/internal/state.ts
@@ -7,6 +7,7 @@ import { codemodel, ModelState } from '@azure-tools/codemodel-v3';
 
 import { Host, JsonPath } from '@azure-tools/autorest-extension-base';
 import { Project } from './project';
+import { DeepPartial } from '@azure-tools/codegen';
 
 
 export interface GeneratorSettings {
@@ -24,7 +25,7 @@ export interface GeneratorSettings {
 export class State extends ModelState<codemodel.Model> {
   project!: Project;
 
-  public constructor(service: Host, objectInitializer?: Partial<State>) {
+  public constructor(service: Host, objectInitializer?: DeepPartial<State>) {
     super(service);
     this.apply(objectInitializer);
   }
@@ -37,9 +38,10 @@ export class State extends ModelState<codemodel.Model> {
   }
 
   path(...childPath: JsonPath) {
-    const result = new State(this.service, this);
-    result.currentPath = [...this.currentPath, ...childPath];
-    return result;
+    // const result = new State(this.service, this);
+    // result.currentPath = [...this.currentPath, ...childPath];
+    // return result;
+    return this;
   }
 }
 

--- a/powershell/llcsharp/enums/enum.ts
+++ b/powershell/llcsharp/enums/enum.ts
@@ -23,6 +23,7 @@ import { Variable } from '@azure-tools/codegen-csharp';
 import { EnumImplementation } from '../schema/enum';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
 import { State } from '../generator';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class EnumClass extends Struct implements EnhancedTypeDeclaration {
   implementation: EnumImplementation;
@@ -75,7 +76,7 @@ export class EnumClass extends Struct implements EnhancedTypeDeclaration {
     return this.implementation.isRequired;
   }
 
-  constructor(schemaWithFeatures: EnumImplementation, state: State, objectInitializer?: Partial<EnumClass>) {
+  constructor(schemaWithFeatures: EnumImplementation, state: State, objectInitializer?: DeepPartial<EnumClass>) {
     if (!schemaWithFeatures.schema.details.csharp.enum) {
       throw new Error(`ENUM AINT XMSENUM: ${schemaWithFeatures.schema.details.csharp.name}`);
     }

--- a/powershell/llcsharp/enums/json-serializer.ts
+++ b/powershell/llcsharp/enums/json-serializer.ts
@@ -13,10 +13,11 @@ import { Namespace } from '@azure-tools/codegen-csharp';
 import { Parameter } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { State } from '../generator';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class JsonSerializerClass extends Class {
 
-  constructor(namespace: Namespace, protected state: State, objectInitializer?: Partial<JsonSerializerClass>) {
+  constructor(namespace: Namespace, protected state: State, objectInitializer?: DeepPartial<JsonSerializerClass>) {
     super(namespace, 'JsonSerialization');
     this.apply(objectInitializer);
 

--- a/powershell/llcsharp/enums/namespace.ts
+++ b/powershell/llcsharp/enums/namespace.ts
@@ -5,9 +5,10 @@
 
 import { Namespace } from '@azure-tools/codegen-csharp';
 import { State } from '../generator';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class SupportNamespace extends Namespace {
-  constructor(parent: Namespace, private state: State, objectInitializer?: Partial<SupportNamespace>) {
+  constructor(parent: Namespace, private state: State, objectInitializer?: DeepPartial<SupportNamespace>) {
     super('Support', parent);
     this.apply(objectInitializer);
   }

--- a/powershell/llcsharp/generator.ts
+++ b/powershell/llcsharp/generator.ts
@@ -9,11 +9,12 @@ import { Host, JsonPath } from '@azure-tools/autorest-extension-base';
 
 import { Project } from './project';
 import { Dictionary } from '@azure-tools/linq';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class State extends ModelState<Model> {
   project!: Project;
 
-  public constructor(service: Host, objectInitializer?: Partial<State>) {
+  public constructor(service: Host, objectInitializer?: DeepPartial<State>) {
     super(service);
     this.apply(objectInitializer);
   }
@@ -26,8 +27,9 @@ export class State extends ModelState<Model> {
   }
 
   path(...childPath: JsonPath) {
-    const result = new State(this.service, this);
-    result.currentPath = [...this.currentPath, ...childPath];
-    return result;
+    // const result = new State(this.service, this);
+    // result.currentPath = [...this.currentPath, ...childPath];
+    //return result;
+    return this;
   }
 }

--- a/powershell/llcsharp/model/interface.ts
+++ b/powershell/llcsharp/model/interface.ts
@@ -11,7 +11,9 @@ import { Schema } from '../code-model';
 import { State } from '../generator';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
 import { ModelClass } from './model-class';
-import { TypeContainer } from '@azure-tools/codegen-csharp/dist/type-container';
+import { TypeContainer } from '@azure-tools/codegen-csharp';
+import { DeepPartial } from '@azure-tools/codegen';
+import { values } from '@azure-tools/linq';
 
 
 export function addInfoAttribute(targetProperty: Property, pType: TypeDeclaration, isRequired: boolean, isReadOnly: boolean, description: string, serializedName: string) {
@@ -130,7 +132,7 @@ export class ModelInterface extends Interface implements EnhancedTypeDeclaration
     // return this.classImplementation.hasHeaderProperties; 
     return false;
   }
-  constructor(parent: TypeContainer, interfaceName: string, public classImplementation: ModelClass, public state: State, objectInitializer?: Partial<ModelInterface>) {
+  constructor(parent: TypeContainer, interfaceName: string, public classImplementation: ModelClass, public state: State, objectInitializer?: DeepPartial<ModelInterface>) {
     super(parent, interfaceName);
     this.partial = true;
     this.apply(objectInitializer);
@@ -154,7 +156,7 @@ export class ModelInterface extends Interface implements EnhancedTypeDeclaration
     };
     if (this.schema.details.csharp.virtualProperties) {
 
-      for (const virtualProperty of [...virtualProperties.owned]) {
+      for (const virtualProperty of values(virtualProperties.owned)) {
         if (virtualProperty.private && !this.isInternal) {
           continue;
         }
@@ -177,7 +179,7 @@ export class ModelInterface extends Interface implements EnhancedTypeDeclaration
         }
       }
 
-      for (const virtualProperty of [...virtualProperties.inlined]) {
+      for (const virtualProperty of values(virtualProperties.inlined)) {
 
         // don't publicly expose the 'private' properties.
         if (virtualProperty.private && !this.isInternal) {

--- a/powershell/llcsharp/model/model-class-dictionary.ts
+++ b/powershell/llcsharp/model/model-class-dictionary.ts
@@ -3,6 +3,7 @@ import { ModelClass } from './model-class';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
 import { ClientRuntime } from '../clientruntime';
 import { getAllVirtualProperties } from '@azure-tools/codemodel-v3';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class DictionaryImplementation extends Class {
   private get state() { return this.modelClass.state; }
@@ -10,7 +11,7 @@ export class DictionaryImplementation extends Class {
   public valueType!: TypeDeclaration | EnhancedTypeDeclaration;
   public ownsDictionary = false;
 
-  constructor(protected modelClass: ModelClass, objectInitializer?: Partial<DictionaryImplementation>) {
+  constructor(protected modelClass: ModelClass, objectInitializer?: DeepPartial<DictionaryImplementation>) {
     super(modelClass.namespace, modelClass.name);
     this.apply(objectInitializer);
   }

--- a/powershell/llcsharp/model/model-class-json.ts
+++ b/powershell/llcsharp/model/model-class-json.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { KnownMediaType, HeaderProperty, HeaderPropertyType, getAllProperties } from '@azure-tools/codemodel-v3';
-import { EOL, } from '@azure-tools/codegen';
+import { EOL, DeepPartial, } from '@azure-tools/codegen';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { Access, Modifier, StringExpression, Expression, System } from '@azure-tools/codegen-csharp';
 import { Class } from '@azure-tools/codegen-csharp';
@@ -36,7 +36,7 @@ export class JsonSerializableClass extends Class {
   private afj!: Method;
   private excludes: string;
 
-  constructor(protected modelClass: ModelClass, objectInitializer?: Partial<JsonSerializableClass>) {
+  constructor(protected modelClass: ModelClass, objectInitializer?: DeepPartial<JsonSerializableClass>) {
     super(modelClass.namespace, modelClass.name);
     this.apply(objectInitializer);
     this.partial = true;

--- a/powershell/llcsharp/model/model-class-xml.ts
+++ b/powershell/llcsharp/model/model-class-xml.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KnownMediaType, HeaderProperty, HeaderPropertyType } from '@azure-tools/codemodel-v3';
-import { EOL } from '@azure-tools/codegen';
+import { EOL, DeepPartial } from '@azure-tools/codegen';
 import { items, values } from '@azure-tools/linq';
 
 import { Access, Class, Constructor, dotnet, If, IsDeclaration, Method, Modifier, Not, Parameter, ParameterModifier, PartialMethod, Return, Statements, Switch, System, TerminalCase, Ternery } from '@azure-tools/codegen-csharp';
@@ -21,7 +21,7 @@ export class XmlSerializableClass extends Class {
   private bfj!: Method;
   private afj!: Method;
 
-  constructor(protected modelClass: ModelClass, objectInitializer?: Partial<XmlSerializableClass>) {
+  constructor(protected modelClass: ModelClass, objectInitializer?: DeepPartial<XmlSerializableClass>) {
     super(modelClass.namespace, modelClass.name);
     this.apply(objectInitializer);
     this.partial = true;

--- a/powershell/llcsharp/model/model-class.ts
+++ b/powershell/llcsharp/model/model-class.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { HeaderProperty, HeaderPropertyType, KnownMediaType, VirtualProperty, getAllVirtualProperties } from '@azure-tools/codemodel-v3';
 
-import { camelCase, deconstruct } from '@azure-tools/codegen';
+import { camelCase, deconstruct, DeepPartial } from '@azure-tools/codegen';
 import { items, values } from '@azure-tools/linq';
 import { Access, Class, Constructor, Expression, ExpressionOrLiteral, Field, If, Method, Modifier, Namespace, OneOrMoreStatements, Parameter, Statements, System, TypeDeclaration, valueOf, Variable, BackedProperty, Property, Virtual, toExpression, StringExpression, LiteralExpression, Attribute } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
@@ -95,7 +95,7 @@ export class ModelClass extends Class implements EnhancedTypeDeclaration {
 
   // public hasHeaderProperties: boolean;
 
-  constructor(namespace: Namespace, schemaWithFeatures: ObjectImplementation, state: State, objectInitializer?: Partial<ModelClass>) {
+  constructor(namespace: Namespace, schemaWithFeatures: ObjectImplementation, state: State, objectInitializer?: DeepPartial<ModelClass>) {
     super(namespace, schemaWithFeatures.schema.details.csharp.name);
     this.featureImplementation = schemaWithFeatures;
     this.schema.details.csharp.classImplementation = this; // mark the code-model with the class we're creating.
@@ -359,7 +359,7 @@ export class ModelClass extends Class implements EnhancedTypeDeclaration {
         return this.state.project.modelsNamespace.resolveTypeDeclaration(aSchema.additionalProperties, true, this.state);
       }
     } else
-      for (const each of aSchema.allOf) {
+      for (const each of values(aSchema.allOf)) {
         const r = this.additionalPropertiesType(each);
         if (r) {
           return r;

--- a/powershell/llcsharp/model/namespace.ts
+++ b/powershell/llcsharp/model/namespace.ts
@@ -16,10 +16,11 @@ import { EnumClass } from '../enums/enum';
 import * as validation from '../validations';
 import { ModelInterface } from './interface';
 import { ModelClass } from './model-class';
+import { DeepPartial } from '@azure-tools/codegen';
 
 
 class ApiVersionNamespace extends Namespace {
-  constructor(namespace: string, objectInitializer?: Partial<ApiVersionNamespace>) {
+  constructor(namespace: string, objectInitializer?: DeepPartial<ApiVersionNamespace>) {
     super(namespace);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
@@ -35,7 +36,7 @@ export class ModelsNamespace extends Namespace {
 
   resolver = new SchemaDefinitionResolver();
 
-  constructor(parent: Namespace, private schemas: Dictionary<Schema>, private state: State, objectInitializer?: Partial<ModelsNamespace>) {
+  constructor(parent: Namespace, private schemas: Dictionary<Schema>, private state: State, objectInitializer?: DeepPartial<ModelsNamespace>) {
     super('Models', parent);
     this.subNamespaces[this.fullName] = this;
 
@@ -90,7 +91,7 @@ export class ModelsNamespace extends Namespace {
       if (td instanceof EnumImplementation) {
         if (schema.details.csharp.enum) {
           const ec = state.project.supportNamespace.findClassByName(schema.details.csharp.enum.name);
-          if (ec.length === 0) {
+          if (length(ec) === 0) {
             new EnumClass(td, state);
             // return schema.details.csharp.typeDeclaration = <EnumClass>ec[0];
           }

--- a/powershell/llcsharp/model/property.ts
+++ b/powershell/llcsharp/model/property.ts
@@ -16,6 +16,7 @@ import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
 
 import { State } from '../generator';
 import { ModelClass } from './model-class';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class ModelProperty extends BackedProperty implements EnhancedVariable {
   /** emits an expression to deserialize a property from a member inside a container */
@@ -60,7 +61,7 @@ export class ModelProperty extends BackedProperty implements EnhancedVariable {
   private typeDeclaration: EnhancedTypeDeclaration;
   public details: any;
 
-  constructor(name: string, schema: Schema, isRequired: boolean, serializedName: string, description: string, state: State, objectInitializer?: Partial<ModelProperty>) {
+  constructor(name: string, schema: Schema, isRequired: boolean, serializedName: string, description: string, state: State, objectInitializer?: DeepPartial<ModelProperty>) {
     const decl = state.project.modelsNamespace.resolveTypeDeclaration(schema, isRequired, state.path('schema'));
     super(name, decl);
     this.typeDeclaration = decl;

--- a/powershell/llcsharp/operation/api-class.ts
+++ b/powershell/llcsharp/operation/api-class.ts
@@ -9,11 +9,12 @@ import { Class, Namespace } from '@azure-tools/codegen-csharp';
 import { State } from '../generator';
 import { CallMethod, OperationMethod, ValidationMethod } from '../operation/method';
 import { ParameterLocation } from '@azure-tools/codemodel-v3';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class ApiClass extends Class {
 
   // protected sender: Property;
-  constructor(namespace: Namespace, protected state: State, objectInitializer?: Partial<ApiClass>) {
+  constructor(namespace: Namespace, protected state: State, objectInitializer?: DeepPartial<ApiClass>) {
     super(namespace, state.model.details.csharp.name);
     this.apply(objectInitializer);
 

--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -5,7 +5,7 @@
 
 import { NewResponse, ParameterLocation } from '@azure-tools/codemodel-v3';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
-import { EOL } from '@azure-tools/codegen';
+import { EOL, DeepPartial } from '@azure-tools/codegen';
 import { Access, Modifier } from '@azure-tools/codegen-csharp';
 import { Class } from '@azure-tools/codegen-csharp';
 
@@ -43,19 +43,19 @@ export class EventListener {
 
   *signalNoCheck(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
     if (this.emitSignals) {
-      const params = additionalParameters.length > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
       yield `await ${this.expression.value}.Signal(${eventName}${params});`;
     }
   }
   *syncSignalNoCheck(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
     if (this.emitSignals) {
-      const params = additionalParameters.length > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
       yield `${this.expression.value}.Signal(${eventName}${params}).Wait();`;
     }
   }
   *signal(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
     if (this.emitSignals) {
-      const params = additionalParameters.length > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
       yield `await ${this.expression.value}.Signal(${eventName}${params}); if( ${this.expression.value}.Token.IsCancellationRequested ) { return; }`;
     } else {
       yield `if( ${this.expression.value}.CancellationToken.IsCancellationRequested ) { throw ${System.OperationCanceledException.new()}; }`;
@@ -63,7 +63,7 @@ export class EventListener {
   }
   *syncSignal(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
     if (this.emitSignals) {
-      const params = additionalParameters.length > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
       yield `${this.expression.value}.Signal(${eventName}${params}).Wait(); if( ${this.expression.value}.Token.IsCancellationRequested ) { return; }`;
     } else {
       yield `if( ${this.expression.value}.CancellationToken.IsCancellationRequested ) { throw ${System.OperationCanceledException.new()} }`;
@@ -83,7 +83,7 @@ export class OperationMethod extends Method {
 
   protected callName: string;
 
-  constructor(protected parent: Class, public operation: HttpOperation, public viaIdentity: boolean, protected state: State, objectInitializer?: Partial<OperationMethod>) {
+  constructor(protected parent: Class, public operation: HttpOperation, public viaIdentity: boolean, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
     super(viaIdentity ? `${operation.details.csharp.name}ViaIdentity` : operation.details.csharp.name, System.Threading.Tasks.Task());
     this.apply(objectInitializer);
     this.async = Modifier.Async;
@@ -101,7 +101,7 @@ export class OperationMethod extends Method {
       this.addParameter(identity);
     }
 
-    for (let index = 0; index < this.operation.parameters.length; index++) {
+    for (let index = 0; index < length(this.operation.parameters); index++) {
       const value = this.operation.parameters[index];
 
       const p = new OperationParameter(this, value, this.state.path('parameters', index));
@@ -230,7 +230,7 @@ export class OperationMethod extends Method {
       yield eventListener.signal(ClientRuntime.Events.RequestCreated, urlV.value);
       yield EOL;
 
-      if (headerParams.length > 0) {
+      if (length(headerParams) > 0) {
         yield '// add headers parameters';
         for (const hp of headerParams) {
           if (hp.param.name === 'Content-Length') {
@@ -265,7 +265,7 @@ export class OperationMethod extends Method {
 
     // remove constant parameters and make them locals instead.
     this.insert('// Constant Parameters');
-    for (let i = this.parameters.length; i--; i < 0) {
+    for (let i = length(this.parameters); i--; i < 0) {
       const p = this.parameters[i];
       if (p && p.defaultInitializer) {
         this.parameters.splice(i, 1);
@@ -277,7 +277,7 @@ export class OperationMethod extends Method {
 
 export class CallMethod extends Method {
   public returnNull = false;
-  constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: Partial<OperationMethod>) {
+  constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
     super(`${opMethod.operation.details.csharp.name}_Call`, System.Threading.Tasks.Task());
     this.description = `Actual wire call for <see cref="${opMethod.operation.details.csharp.name}" /> method.`;
     this.returnsDescription = opMethod.returnsDescription;
@@ -551,7 +551,7 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
     if (length(responses) > 1) {
       yield Switch('_contentType', function* () {
         for (const eachResponse of values(responses)) {
-          const mimetype = eachResponse.mimeTypes.length > 0 ? eachResponse.mimeTypes[0] : '';
+          const mimetype = length(eachResponse.mimeTypes) > 0 ? eachResponse.mimeTypes[0] : '';
           const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === eachResponse.details.csharp.name);
 
           let count = length(eachResponse.mimeTypes);
@@ -573,7 +573,7 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
       const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === response.details.csharp.name);
       // all mimeTypes per for this response code.
       yield eventListener.signal(ClientRuntime.Events.BeforeResponseDispatch, '_response');
-      yield $this.responseHandler(response.mimeTypes[0], response, callbackParameter);
+      yield $this.responseHandler(values(response.mimeTypes).first() || '', response, callbackParameter);
     }
   }
 
@@ -613,7 +613,7 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
 
 export class ValidationMethod extends Method {
 
-  constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: Partial<OperationMethod>) {
+  constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
     super(`${opMethod.operation.details.csharp.name}_Validate`, System.Threading.Tasks.Task());
     this.apply(objectInitializer);
     this.description = `Validation method for <see cref="${opMethod.operation.details.csharp.name}" /> method. Call this like the actual call, but you will get validation events back.`;

--- a/powershell/llcsharp/operation/namespace.ts
+++ b/powershell/llcsharp/operation/namespace.ts
@@ -7,9 +7,10 @@ import { ImportDirective } from '@azure-tools/codegen-csharp';
 import { Namespace } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { State } from '../generator';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class ServiceNamespace extends Namespace {
-  constructor(public state: State, objectInitializer?: Partial<ServiceNamespace>) {
+  constructor(public state: State, objectInitializer?: DeepPartial<ServiceNamespace>) {
     super(state.model.details.csharp.namespace || 'INVALID.NAMESPACE', state.project);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));

--- a/powershell/llcsharp/operation/parameter.ts
+++ b/powershell/llcsharp/operation/parameter.ts
@@ -17,6 +17,7 @@ import { HttpOperationParameter, Schema } from '../code-model';
 import { EnhancedVariable } from '../extended-variable';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
 import { State } from '../generator';
+import { DeepPartial } from '@azure-tools/codegen';
 
 /** represents a method parameter for an http operation (header/cookie/query/path) */
 export class OperationParameter extends Parameter implements EnhancedVariable {
@@ -24,7 +25,7 @@ export class OperationParameter extends Parameter implements EnhancedVariable {
 
   public param: HttpOperationParameter;
 
-  constructor(parent: Method, param: HttpOperationParameter, state: State, objectInitializer?: Partial<OperationParameter>) {
+  constructor(parent: Method, param: HttpOperationParameter, state: State, objectInitializer?: DeepPartial<OperationParameter>) {
     const typeDeclaration = state.project.modelsNamespace.resolveTypeDeclaration(param.schema, param.required, state.path('schema'));
     super(param.details.csharp.name, typeDeclaration);
     this.param = param;
@@ -106,7 +107,7 @@ export class OperationBodyParameter extends Parameter implements EnhancedVariabl
 
   public typeDeclaration: EnhancedTypeDeclaration;
 
-  constructor(parent: Method, name: string, description: string, schema: Schema, required: boolean, state: State, objectInitializer?: Partial<OperationBodyParameter>) {
+  constructor(parent: Method, name: string, description: string, schema: Schema, required: boolean, state: State, objectInitializer?: DeepPartial<OperationBodyParameter>) {
     const typeDeclaration = state.project.modelsNamespace.resolveTypeDeclaration(schema, required, state.path('schema'));
     super(name, typeDeclaration);
     this.typeDeclaration = typeDeclaration;
@@ -131,7 +132,7 @@ export class CallbackParameter extends Parameter {
   responseType: (EnhancedTypeDeclaration) | null;
   headerType: (EnhancedTypeDeclaration) | null;
 
-  constructor(name: string, responseType: (EnhancedTypeDeclaration) | null, headerType: (EnhancedTypeDeclaration) | null, state: State, objectInitializer?: Partial<CallbackParameter>) {
+  constructor(name: string, responseType: (EnhancedTypeDeclaration) | null, headerType: (EnhancedTypeDeclaration) | null, state: State, objectInitializer?: DeepPartial<CallbackParameter>) {
     // regular pipeline style. (callback happens after the pipline is called)
     if (responseType) {
       if (headerType) {

--- a/powershell/llcsharp/project.ts
+++ b/powershell/llcsharp/project.ts
@@ -12,6 +12,7 @@ import { ModelsNamespace } from './model/namespace';
 import { ApiClass } from './operation/api-class';
 import { ServiceNamespace } from './operation/namespace';
 import { SupportNamespace } from './enums/namespace';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class Project extends codeDomProject {
 
@@ -27,7 +28,7 @@ export class Project extends codeDomProject {
   runtimefolder!: string;
   azure!: boolean;
 
-  constructor(protected service: Host, objectInitializer?: Partial<Project>) {
+  constructor(protected service: Host, objectInitializer?: DeepPartial<Project>) {
     super();
     this.apply(objectInitializer);
   }

--- a/powershell/llcsharp/schema/char.ts
+++ b/powershell/llcsharp/schema/char.ts
@@ -7,6 +7,7 @@ import { Variable } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
 import { Primitive } from './primitive';
+import { length } from '@azure-tools/linq';
 
 export class Char extends Primitive {
   public isXmlAttribute = false;
@@ -15,7 +16,7 @@ export class Char extends Primitive {
 
   constructor(schema: Schema, public isRequired: boolean) {
     super(schema);
-    this.choices = schema.enum.length > 0 ? schema.enum : undefined;
+    this.choices = length(schema.enum) > 0 ? schema.enum : undefined;
   }
 
   get declaration(): string {

--- a/powershell/llcsharp/schema/schema-resolver.ts
+++ b/powershell/llcsharp/schema/schema-resolver.ts
@@ -42,7 +42,7 @@ export class SchemaDefinitionResolver {
       }
 
       case JsonType.Object: {
-        const result = this.cache.get(schema.details.csharp.fullname || '');
+        const result = schema.details.csharp && this.cache.get(schema.details.csharp.fullname || '');
         if (result) {
           return result;
         }
@@ -85,11 +85,11 @@ export class SchemaDefinitionResolver {
           case StringFormat.None:
           case undefined:
           case null:
-            if (schema.extensions['x-ms-enum']) {
+            if (schema.extensions && schema.extensions['x-ms-enum']) {
               return new EnumImplementation(schema, required);
             }
             /*
-            if (schema.extensions['x-ms-header-collection-prefix']) {
+            if(schema.extensions && schema.extensions['x-ms-header-collection-prefix']) {
               return new Wildcard(schema, new String(<any>{}, required));
             }
             */
@@ -131,7 +131,7 @@ export class SchemaDefinitionResolver {
         return new Numeric(schema, required, required ? 'float' : 'float?');
 
       case undefined:
-        if (schema.extensions['x-ms-enum']) {
+        if (schema.extensions && schema.extensions['x-ms-enum']) {
           return new EnumImplementation(schema, required);
         }
 

--- a/powershell/llcsharp/schema/string.ts
+++ b/powershell/llcsharp/schema/string.ts
@@ -14,6 +14,7 @@ import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
 import { popTempVar, pushTempVar } from './primitive';
 import { EnhancedTypeDeclaration } from './extended-type-declaration';
+import { length } from '@azure-tools/linq';
 
 /** A ETD for the c# string type. */
 export class String implements EnhancedTypeDeclaration {
@@ -200,7 +201,7 @@ ${this.validateEnum(eventListener, property)}
     return `await ${eventListener}.AssertRegEx(${nameof(property.value)},${property},@"${this.schema.pattern}");`;
   }
   private validateEnum(eventListener: Variable, property: Variable): string {
-    if (!this.schema.enum || this.schema.enum.length === 0) {
+    if (!this.schema.enum || length(this.schema.enum) === 0) {
       return '';
     }
     return `await ${eventListener}.AssertEnum(${nameof(property.value)},${property},${this.schema.enum.joinWith((v) => `@"${v}"`)});`;

--- a/powershell/llcsharp/validations.ts
+++ b/powershell/llcsharp/validations.ts
@@ -6,6 +6,7 @@
 import { JsonType, Schema } from '@azure-tools/codemodel-v3';
 import { State } from './generator';
 import * as message from './messages';
+import { length } from '@azure-tools/linq';
 
 export function objectWithFormat(schema: Schema, state: State): boolean {
   if (schema.type === JsonType.Object && schema.format) {
@@ -16,7 +17,7 @@ export function objectWithFormat(schema: Schema, state: State): boolean {
 }
 
 export function schemaHasEnum(schema: Schema, state: State): boolean {
-  if (schema.enum.length > 0) {
+  if (length(schema.enum) > 0) {
     state.error(`Schema with type:'${schema.type} and 'format:'${schema.format}' does not support 'enum' value restrictions.`, message.DoesNotSupportEnum);
     return true;
   }
@@ -24,8 +25,8 @@ export function schemaHasEnum(schema: Schema, state: State): boolean {
 }
 
 export function hasXmsEnum(schema: Schema, state: State): boolean {
-  if (schema.enum.length > 0) {
-    if (schema.extensions['x-ms-enum']) {
+  if (length(schema.enum) > 0) {
+    if (schema.extensions && schema.extensions['x-ms-enum']) {
       state.error(`Schema with type:'${schema.type} and 'format:'${schema.format}' does not support 'x-ms-enum' generation `, message.SchemaDoeNotSupportXMSEnum);
       return true;
     }

--- a/powershell/models/model-extensions.ts
+++ b/powershell/models/model-extensions.ts
@@ -8,13 +8,14 @@ import { Schema, ClientRuntime, SchemaDefinitionResolver, ObjectImplementation, 
 import { State } from '../internal/state';
 import { PSObject, PSTypeConverter, TypeConverterAttribute } from '../internal/powershell-declarations';
 import { join } from 'path';
+import { DeepPartial } from '@azure-tools/codegen';
 
 
 class ApiVersionModelExtensionsNamespace extends Namespace {
   public get outputFolder(): string {
     return `${this.baseFolder}/${this.apiVersion.replace(/.*\./g, '')}`;
   }
-  constructor(private baseFolder: string, private readonly apiVersion: string, objectInitializer?: Partial<ModelExtensionsNamespace>) {
+  constructor(private baseFolder: string, private readonly apiVersion: string, objectInitializer?: DeepPartial<ModelExtensionsNamespace>) {
     super(apiVersion);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`${ClientRuntime.name}.PowerShell`));
@@ -34,7 +35,7 @@ export class ModelExtensionsNamespace extends Namespace {
   }
   resolver = new SchemaDefinitionResolver();
 
-  constructor(parent: Namespace, private schemas: Dictionary<Schema>, private state: State, objectInitializer?: Partial<ModelExtensionsNamespace>) {
+  constructor(parent: Namespace, private schemas: Dictionary<Schema>, private state: State, objectInitializer?: DeepPartial<ModelExtensionsNamespace>) {
     super('Models', parent);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`${ClientRuntime.name}.PowerShell`));

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -8,6 +8,7 @@ import { Access, Alias, Class, ClassType, Constructor, dotnet, Field, LambdaMeth
 import { InvocationInfo, PSCredential, IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType, } from '../internal/powershell-declarations';
 import { State } from '../internal/state';
 import { ClientRuntime } from '../llcsharp/exports';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class ModuleClass extends Class {
 
@@ -69,7 +70,7 @@ export class ModuleClass extends Class {
   fHandler = this.add(new Field('_handler', System.Net.Http.HttpClientHandler, { initialValue: System.Net.Http.HttpClientHandler.new() }));
   fWebProxy = this.add(new Field('_webProxy', System.Net.WebProxy, { initialValue: System.Net.WebProxy.new() }));
 
-  constructor(namespace: Namespace, private readonly state: State, objectInitializer?: Partial<ModuleClass>) {
+  constructor(namespace: Namespace, private readonly state: State, objectInitializer?: DeepPartial<ModuleClass>) {
     super(namespace, 'Module');
     this.apply(objectInitializer);
     this.partial = true;

--- a/powershell/module/module-namespace.ts
+++ b/powershell/module/module-namespace.ts
@@ -6,6 +6,7 @@ import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../llcsharp/exports';
 import { State } from '../internal/state';
 import { ModuleClass } from './module-class';
+import { DeepPartial } from '@azure-tools/codegen';
 
 export class ModuleNamespace extends Namespace {
   public moduleClass: ModuleClass;
@@ -14,7 +15,7 @@ export class ModuleNamespace extends Namespace {
     return this.state.project.moduleFolder;
   }
 
-  constructor(public state: State, objectInitializer?: Partial<ModuleNamespace>) {
+  constructor(public state: State, objectInitializer?: DeepPartial<ModuleNamespace>) {
     super(state.model.details.csharp.namespace || 'INVALID.NAMESPACE', state.project);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -52,14 +52,14 @@
     "eslint": "~6.2.2"
   },
   "dependencies": {
-    "@azure-tools/codegen": "~2.0.0",
+    "@azure-tools/codegen": "~2.1.0",
     "@azure-tools/codegen-csharp": "~3.0.0",
-    "@azure-tools/codemodel-v3": "~3.0.0",
-    "@azure-tools/autorest-extension-base": "~3.0.0",
-    "@azure-tools/linq": "~3.0.0",
+    "@azure-tools/codemodel-v3": "~3.1.0",
+    "@azure-tools/autorest-extension-base": "~3.1.0",
+    "@azure-tools/linq": "~3.1.0",
     "@azure-tools/tasks": "~3.0.0",
     "@azure-tools/async-io": "~3.0.0",
-    "source-map-support": "0.5.9",
+    "source-map-support": "0.5.13",
     "xmlbuilder": "10.1.1"
   }
 }

--- a/powershell/plugins/cs-namer.ts
+++ b/powershell/plugins/cs-namer.ts
@@ -58,10 +58,10 @@ function setSchemaNames(schemas: Dictionary<Schema>, azure: boolean, serviceName
 
     // create the namespace if required
     if (azure) {
-      const metadata = schema.extensions['x-ms-metadata'];
+      const metadata = schema.extensions && schema.extensions['x-ms-metadata'];
       if (metadata) {
         const apiVersions = <Array<string> | undefined>metadata.apiVersions;
-        if (apiVersions && apiVersions.length > 0) {
+        if (apiVersions && length(apiVersions) > 0) {
           thisApiversion = minimum(apiVersions);
           thisNamespace = subNamespace.get(thisApiversion) || new Set<string>();
           subNamespace.set(thisApiversion, thisNamespace);

--- a/powershell/plugins/modifiers.ts
+++ b/powershell/plugins/modifiers.ts
@@ -64,7 +64,7 @@ function hasSpecialChars(str: string): boolean {
 
 function getFilterError(whereObject: any, prohibitedFilters: Array<string>, selectionType: string): string {
   let error = '';
-  for (const each of prohibitedFilters) {
+  for (const each of values(prohibitedFilters)) {
     if (whereObject[each] !== undefined) {
       error += `Can't filter by ${each} when selecting command. `;
     }
@@ -75,7 +75,7 @@ function getFilterError(whereObject: any, prohibitedFilters: Array<string>, sele
 
 function getSetError(setObject: any, prohibitedSetters: Array<string>, selectionType: string): string {
   let error = '';
-  for (const each of prohibitedSetters) {
+  for (const each of values(prohibitedSetters)) {
     if (setObject[each] !== undefined) {
       error += `Can't set ${each} when a ${selectionType} is selected. `;
     }
@@ -185,7 +185,7 @@ function isWhereModelDirective(it: any): it is WhereModelDirective {
       }
     }
 
-    if (modelSelectNameConflict.length > 0) {
+    if (length(modelSelectNameConflict) > 0) {
       error += `Can't select ${modelSelectNameType} and ${modelSelectNameConflict} at the same time`;
     }
 
@@ -305,7 +305,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
           .selectMany(operation => allVirtualParameters(operation.details.csharp.virtualParameters))
           .where(parameter => !!`${parameter.name}`.match(parameterRegex))
           .toArray();
-        for (const p of parameters) {
+        for (const p of values(parameters)) {
           const parameter = <any>p;
           const prevName = parameter.name;
           parameter.name = parameterReplacer ? parameterRegex ? parameter.name.replace(parameterRegex, parameterReplacer) : parameterReplacer : parameter.name;
@@ -322,11 +322,11 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
 
           if (alias) {
             const parsedAlias = new Array<string>();
-            for (const each of alias) {
+            for (const each of values(alias)) {
               parsedAlias.push(hasSpecialChars(each) ? prevName.replace(parameterRegex, each) : each);
             }
 
-            parameter.alias = [...new Set([...parameter.alias, ...parsedAlias])];
+            parameter.alias = [...new Set(values(parameter.alias, parsedAlias).toArray())];
             state.message({
               Channel: Channel.Debug, Text: `[DIRECTIVE] Added alias ${parsedAlias} to parameter ${parameter.name}.`
             });
@@ -346,7 +346,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
         }
 
       } else if (operations) {
-        for (const operation of operations) {
+        for (const operation of values(operations)) {
           const getCmdletName = (verb: string, subjectPrefix: string, subject: string, variantName: string): string => {
             return `${verb}-${subjectPrefix}${subject}${variantName ? `_${variantName}` : ''}`;
           };
@@ -394,11 +394,11 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
             };
 
             const parsedAlias = new Array<string>();
-            for (const each of alias) {
+            for (const each of values(alias)) {
               parsedAlias.push(getParsedAlias(each));
             }
 
-            operation.details.csharp.alias = [...new Set([...operation.details.csharp.alias, ...parsedAlias])];
+            operation.details.csharp.alias = [...new Set(values(operation.details.csharp.alias, parsedAlias).toArray())];
             state.message({
               Channel: Channel.Debug, Text: `[DIRECTIVE] Added alias ${parsedAlias} to command ${newCommandName}.`
             });
@@ -457,7 +457,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
           .selectMany(model => allVirtualProperties(model.details.csharp.virtualProperties))
           .where(property => !!`${property.name}`.match(propertyNameRegex))
           .toArray();
-        for (const property of properties) {
+        for (const property of values(properties)) {
           const prevName = property.name;
           property.name = propertyNameReplacer ? propertyNameRegex ? property.name.replace(propertyNameRegex, propertyNameReplacer) : propertyNameReplacer : property.name;
           property.description = propertyDescriptionReplacer ? propertyDescriptionReplacer : property.description;
@@ -473,7 +473,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
         }
 
       } else if (models) {
-        for (const model of models) {
+        for (const model of values(models)) {
 
           if (suppressFormat) {
             model.details.csharp.suppressFormat = true;
@@ -491,7 +491,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
                 parsedLabels[label.key.toLowerCase()] = label.value;
               }
 
-              for (const property of properties) {
+              for (const property of values(properties)) {
                 if (Object.keys(parsedLabels).includes(property.name.toLowerCase())) {
                   if (property.format === undefined) {
                     property.format = {};
@@ -508,7 +508,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
                 parsedWidths[w.key.toLowerCase()] = w.value;
               }
 
-              for (const property of properties) {
+              for (const property of values(properties)) {
                 if (Object.keys(parsedWidths).includes(property.name.toLowerCase())) {
                   if (property.format === undefined) {
                     property.format = {};
@@ -525,7 +525,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
                 indexes[item.value.toLowerCase()] = item.key;
               }
 
-              for (const property of properties) {
+              for (const property of values(properties)) {
                 if (propertiesToInclude.map(x => x.toLowerCase()).includes(property.name.toLowerCase())) {
                   if (property.format === undefined) {
                     property.format = {};
@@ -539,7 +539,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
             }
 
             if (propertiesToExclude) {
-              for (const property of properties) {
+              for (const property of values(properties)) {
                 if (propertiesToExclude.map(x => x.toLowerCase()).includes(property.name.toLowerCase())) {
                   property.format = { suppressFormat: true };
                 }
@@ -580,7 +580,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
           .selectMany(each => each.details.csharp.enum ? each.details.csharp.enum.values : [])
           .where(each => !!`${each.name}`.match(enumValueNameRegex))
           .toArray();
-        for (const enumValue of enumsValues) {
+        for (const enumValue of values(enumsValues)) {
           const prevName = enumValue.name;
           enumValue.name = enumValueNameReplacer ? enumNameRegex ? enumValue.name.replace(enumValueNameRegex, enumValueNameReplacer) : enumValueNameReplacer : prevName;
           if (enumValueNameRegex) {
@@ -593,7 +593,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
           }
         }
       } else {
-        for (const each of enums) {
+        for (const each of values(enums)) {
           const prevName = each.details.csharp.name;
           each.details.csharp.name = enumNameReplacer ? enumNameRegex ? each.details.csharp.name.replace(enumNameRegex, enumNameReplacer) : enumNameReplacer : prevName;
           state.message({
@@ -657,7 +657,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
             .toArray());
         }
 
-        for (const key of operationsToRemoveKeys) {
+        for (const key of values(operationsToRemoveKeys)) {
           const operationInfo = state.model.commands.operations[key].details.csharp;
           state.message({
             Channel: Channel.Debug, Text: `[DIRECTIVE] Removed command ${operationInfo.verb}-${operationInfo.subjectPrefix}${operationInfo.subject}${operationInfo.name ? `_${operationInfo.name}` : ''}`

--- a/powershell/plugins/ps-namer.ts
+++ b/powershell/plugins/ps-namer.ts
@@ -26,7 +26,7 @@ export function getDeduplicatedNoun(subjectPrefix: string, subject: string): { s
 
   // figure out what belongs to the subject
   const reversedFinalSubject = new Array<string>();
-  for (let mCount = dedupedMerge.length - 1, sCount = dedupedSubject.length - 1; sCount >= 0 && mCount >= 0; mCount-- , sCount--) {
+  for (let mCount = length(dedupedMerge) - 1, sCount = length(dedupedSubject) - 1; sCount >= 0 && mCount >= 0; mCount-- , sCount--) {
     if (dedupedMerge[mCount] !== dedupedSubject[sCount]) {
       break;
     }


### PR DESCRIPTION
Upcoming remodeler changes will drop empty collections and dictionaries
this changes the use of them to use the `null`/`undefined` tolerant `linq` methods.