### PR TITLE
Update Dockerfile

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
     && npm config set unsafe-perm true \
     && npm install -g @autorest/autorest \
     && npm install -g dotnet-sdk-2.1 \
-    && apt-get install -y \
+    && apt-get -o Acquire::Check-Valid-Until=false install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen $LANG && update-locale


### PR DESCRIPTION
Implemented workaround issue "E: Release file for http://security.ubuntu.com/ubuntu/dists/bionic-security/InRelease is not valid yet (invalid for another 6h 56min 59s). Updates for this repository will not be applied." when building the container.