### PR TITLE
Adding target attribute to nuspec file elements

### DIFF
--- a/powershell/generators/nuspec.ts
+++ b/powershell/generators/nuspec.ts
@@ -36,11 +36,11 @@ export async function generateNuspec(project: Project) {
     <file src="${removeCd(project.psm1)}" />
     <!-- https://github.com/NuGet/Home/issues/3584 -->
     <file src="${removeCd(project.dll)}" target="${removeCd(project.binFolder)}" />
-    <file src="${removeCd(project.binFolder)}/${project.dllName}.deps.json" target="${removeCd(project.binFolder)}" />
-    <file src="${removeCd(project.internalFolder)}/**/*.*" exclude="${removeCd(project.internalFolder)}/readme.md" target="${removeCd(project.internalFolder)}" />
-    <file src="${removeCd(project.customFolder)}/**/*.*" exclude="${removeCd(project.customFolder)}/readme.md;${removeCd(project.customFolder)}/**/*.cs" target="${removeCd(project.customFolder)}" />
-    <file src="${removeCd(project.docsFolder)}/**/*.md" exclude="${removeCd(project.docsFolder)}/readme.md" target="${removeCd(project.docsFolder)}" />
-    <file src="${removeCd(project.exportsFolder)}/**/ProxyCmdletDefinitions.ps1" target="${removeCd(project.exportsFolder)}" />
+    <file src="${removeCd(project.binFolder)}\\${project.dllName}.deps.json" target="${removeCd(project.binFolder)}" />
+    <file src="${removeCd(project.internalFolder)}\\**\\*.*" exclude="${removeCd(project.internalFolder)}\\readme.md" target="${removeCd(project.internalFolder)}" />
+    <file src="${removeCd(project.customFolder)}\\**\\*.*" exclude="${removeCd(project.customFolder)}\\readme.md;${removeCd(project.customFolder)}\\**\\*.cs" target="${removeCd(project.customFolder)}" />
+    <file src="${removeCd(project.docsFolder)}\\**\\*.md" exclude="${removeCd(project.docsFolder)}\\readme.md" target="${removeCd(project.docsFolder)}" />
+    <file src="${removeCd(project.exportsFolder)}\\**\\ProxyCmdletDefinitions.ps1" target="${removeCd(project.exportsFolder)}" />
   </files>
 </package>`, undefined, 'source-file-other');
 }

--- a/powershell/generators/nuspec.ts
+++ b/powershell/generators/nuspec.ts
@@ -37,10 +37,10 @@ export async function generateNuspec(project: Project) {
     <!-- https://github.com/NuGet/Home/issues/3584 -->
     <file src="${removeCd(project.dll)}" target="${removeCd(project.binFolder)}" />
     <file src="${removeCd(project.binFolder)}/${project.dllName}.deps.json" target="${removeCd(project.binFolder)}" />
-    <file src="${removeCd(project.internalFolder)}/**/*.*" exclude="${removeCd(project.internalFolder)}/readme.md" />
-    <file src="${removeCd(project.customFolder)}/**/*.*" exclude="${removeCd(project.customFolder)}/readme.md;${removeCd(project.customFolder)}/**/*.cs" />
-    <file src="${removeCd(project.docsFolder)}/**/*.md" exclude="${removeCd(project.docsFolder)}/readme.md" />
-    <file src="${removeCd(project.exportsFolder)}/**/ProxyCmdletDefinitions.ps1" />
+    <file src="${removeCd(project.internalFolder)}/**/*.*" exclude="${removeCd(project.internalFolder)}/readme.md" target="${removeCd(project.internalFolder)}" />
+    <file src="${removeCd(project.customFolder)}/**/*.*" exclude="${removeCd(project.customFolder)}/readme.md;${removeCd(project.customFolder)}/**/*.cs" target="${removeCd(project.customFolder)}" />
+    <file src="${removeCd(project.docsFolder)}/**/*.md" exclude="${removeCd(project.docsFolder)}/readme.md" target="${removeCd(project.docsFolder)}" />
+    <file src="${removeCd(project.exportsFolder)}/**/ProxyCmdletDefinitions.ps1" target="${removeCd(project.exportsFolder)}" />
   </files>
 </package>`, undefined, 'source-file-other');
 }


### PR DESCRIPTION
On OS X `pack-module.ps1` is including the content of _custom/docs/exports/internal_ in the top level of the generated .nupkg rather than maintaining the directory structure.

Based on https://docs.microsoft.com/en-us/nuget/reference/nuspec#including-assembly-files a target attribute is required to ensure the correct structure is achieved