### PR TITLE
[Do not merge] Support for a simple API with modelerfour(defined in xkcd.ymal)

### DIFF
--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -4,11 +4,18 @@
 - Please don't edit this section unless you're re-configuring how the powershell extension plugs in to AutoRest
 AutoRest needs the below config to pick this up as a plug-in - see https://github.com/Azure/autorest/blob/master/docs/developer/architecture/AutoRest-extension.md
 
+> modelerfour configuration
+``` yaml
+modelerfour:
+  emit-yaml-tags: false
+```
+
 > if the modeler is loaded already, use that one, otherwise grab it.
 
-``` yaml !isLoaded('@autorest/remodeler') 
+``` yaml 
 use-extension:
   "@autorest/remodeler" : "~2.1.0" 
+  "@autorest/modelerfour": "4.13.351"
 
 # will use highest 2.0.x 
 ```
@@ -111,6 +118,27 @@ pipeline:
   tweakcodemodelazure:
     input: tweakcodemodel
 
+# --- extension powershell based on modelerfour
+  tweakcodemodel-v2:
+    input: modelerfour/identity
+
+  create-commands-v2:
+    input: tweakcodemodel-v2
+  
+  create-virtual-properties-v2:
+    input: create-commands-v2
+
+  csnamer-v2:
+    input: create-virtual-properties-v2
+
+  psnamer-v2:
+    input: csnamer-v2
+
+  llcsharp-v2:
+    input: psnamer-v2
+  
+  # powershell-v2:
+  #   input: psnamer-v2
 # --- extension powershell ---
 
   # creates high-level commands
@@ -144,7 +172,7 @@ pipeline:
     input: modifiers
 
   llcsharp/text-transform:
-    input: llcsharp
+    input: llcsharp-v2
     scope: scope-here
 
   powershell/text-transform:
@@ -174,10 +202,10 @@ scope-here:
 
 # Specific Settings for cm emitting - selects the file types and format that cmv2-emitter will spit out.
 code-model-emitter-settings:
-  input-artifact: code-model-v3
+  input-artifact: code-model-v4
   is-object: true
   output-uri-expr: |
-    "code-model-v3"
+    "code-model-v4"
 
 # testing:  ask for the files we need
 output-artifact:

--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -137,8 +137,8 @@ pipeline:
   llcsharp-v2:
     input: psnamer-v2
   
-  # powershell-v2:
-  #   input: psnamer-v2
+  powershell-v2:
+    input: psnamer-v2
 # --- extension powershell ---
 
   # creates high-level commands
@@ -164,7 +164,7 @@ pipeline:
 
   # creates powershell cmdlets for high-level commands. (leverages llc# code)
   powershell:
-    input: add-azure-completers # and the generated c# files
+   input: add-azure-completers # and the generated c# files
 
 # --- extension llcsharp  --- 
   # generates c# files for http-operations
@@ -176,7 +176,7 @@ pipeline:
     scope: scope-here
 
   powershell/text-transform:
-    input:  powershell
+    input:  powershell-v2
     scope: scope-here
 
   llcsharp/emitter:

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Schema as NewSchema } from '@azure-tools/codemodel';
 import { command, getAllProperties, JsonType, http, getAllPublicVirtualProperties, getVirtualPropertyFromPropertyName, ParameterLocation, getAllVirtualProperties, VirtualParameter, VirtualProperty } from '@azure-tools/codemodel-v3';
 import { escapeString, docComment, serialize, pascalCase, DeepPartial } from '@azure-tools/codegen';
 import { items, values, Dictionary, length } from '@azure-tools/linq';
@@ -12,7 +13,7 @@ import {
 } from '@azure-tools/codegen-csharp';
 import { ClientRuntime, EventListener, Schema, ArrayOf, EnumImplementation } from '../llcsharp/exports';
 import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute } from '../internal/powershell-declarations';
-import { State } from '../internal/state';
+import { State, NewState } from '../internal/state';
 import { Channel } from '@azure-tools/autorest-extension-base';
 import { IParameter } from '@azure-tools/codemodel-v3/dist/code-model/components';
 import { Variable, Local, ParameterModifier } from '@azure-tools/codegen-csharp';
@@ -1174,7 +1175,7 @@ export class CmdletClass extends Class {
             addDefaultInfo(cmdletParameter, vParam);
           }
 
-          const isEnum = propertyType.schema.details.csharp.enum !== undefined;
+          const isEnum = !(propertyType.schema instanceof NewSchema) && propertyType.schema.details.csharp.enum !== undefined;
           const hasEnum = propertyType instanceof ArrayOf && propertyType.elementType instanceof EnumImplementation;
           if (isEnum || hasEnum) {
             cmdletParameter.add(new Attribute(ArgumentCompleterAttribute, { parameters: [`typeof(${hasEnum ? (<ArrayOf>propertyType).elementType.declaration : propertyType.declaration})`] }));
@@ -1308,7 +1309,7 @@ export class CmdletClass extends Class {
         // regularCmdletParameter.add(new Attribute(ArgumentCompleterAttribute, { parameters: [`typeof(${this.declaration})`] }));
       }
 
-      const isEnum = propertyType.schema.details.csharp.enum !== undefined;
+      const isEnum = !(propertyType.schema instanceof NewSchema) && propertyType.schema.details.csharp.enum !== undefined;
       const hasEnum = propertyType instanceof ArrayOf && propertyType.elementType instanceof EnumImplementation;
       if (isEnum || hasEnum) {
         regularCmdletParameter.add(new Attribute(ArgumentCompleterAttribute, { parameters: [`typeof(${hasEnum ? (<ArrayOf>propertyType).elementType.declaration : propertyType.declaration})`] }));
@@ -1316,6 +1317,7 @@ export class CmdletClass extends Class {
     }
     const ifmatch = this.properties.find((v) => v.name.toLowerCase() === 'ifmatch');
     if (ifmatch) {
+      //no sure why there is an empty block
     }
 
   }
@@ -1372,7 +1374,7 @@ export class CmdletClass extends Class {
               let type = '';
               if (typeDeclaration instanceof ArrayOf) {
                 type = typeDeclaration.elementTypeDeclaration;
-              } else if (pageableInfo && pageableInfo.responseType === 'pageable') {
+              } else if (!(typeDeclaration.schema instanceof NewSchema) && pageableInfo && pageableInfo.responseType === 'pageable') {
                 if (typeDeclaration === undefined || typeDeclaration.schema.properties[pageableInfo.itemName] === undefined) {
                   throw new Error(`\n\nOn operation:\n  '${httpOperation.operationId}' at '${httpOperation.path}'\n  -- you have used 'x-ms-pageable' and there is no property name '${pageableInfo.itemName}' that is an array.\n\n`);
                 }

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -3,8 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Schema as NewSchema } from '@azure-tools/codemodel';
+import { Schema as NewSchema, SchemaType, ArraySchema, SchemaResponse, HttpParameter } from '@azure-tools/codemodel';
 import { command, getAllProperties, JsonType, http, getAllPublicVirtualProperties, getVirtualPropertyFromPropertyName, ParameterLocation, getAllVirtualProperties, VirtualParameter, VirtualProperty } from '@azure-tools/codemodel-v3';
+import { CommandOperation, VirtualParameter as NewVirtualParameter } from '../utils/command-operation';
+import { getAllProperties as NewGetAllProperties, getAllPublicVirtualProperties as NewGetAllPublicVirtualProperties, getVirtualPropertyFromPropertyName as NewGetVirtualPropertyFromPropertyName, VirtualProperty as NewVirtualProperty } from '../utils/schema';
 import { escapeString, docComment, serialize, pascalCase, DeepPartial } from '@azure-tools/codegen';
 import { items, values, Dictionary, length } from '@azure-tools/linq';
 import {
@@ -16,6 +18,7 @@ import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, Cmdle
 import { State, NewState } from '../internal/state';
 import { Channel } from '@azure-tools/autorest-extension-base';
 import { IParameter } from '@azure-tools/codemodel-v3/dist/code-model/components';
+import { IParameter as NewIParameter } from '../utils/components';
 import { Variable, Local, ParameterModifier } from '@azure-tools/codegen-csharp';
 import { getVirtualPropertyName } from '../llcsharp/model/model-class';
 const PropertiesRequiringNew = new Set(['Host', 'Events']);
@@ -153,6 +156,17 @@ export function addCompleterInfo(targetProperty: Property, parameter: VirtualPar
   }
 }
 
+export function NewAddCompleterInfo(targetProperty: Property, parameter: NewVirtualParameter) {
+  if (parameter.completerInfo && parameter.completerInfo.script) {
+    targetProperty.add(new Attribute(ClientRuntime.CompleterInfoAttribute, {
+      parameters: [
+        new LiteralExpression(`\nName = ${new StringExpression(parameter.completerInfo.name || '').value}`),
+        new LiteralExpression(`\nDescription =${new StringExpression(parameter.completerInfo.description || '').value}`),
+        new LiteralExpression(`\nScript = ${new StringExpression(parameter.completerInfo.script).value}`)
+      ]
+    }));
+  }
+}
 
 export function addDefaultInfo(targetProperty: Property, parameter: any) {
   if (parameter.defaultInfo && parameter.defaultInfo.script) {
@@ -172,15 +186,15 @@ export function addInfoAttribute(targetProperty: Property, pType: TypeDeclaratio
   while (pt.elementType) {
     switch (pt.elementType.schema.type) {
       case JsonType.Object:
-        if (pt.elementType.schema.details.csharp.interfaceImplementation) {
+        if (pt.elementType.schema.language.csharp.interfaceImplementation) {
           pt = {
-            declaration: pt.elementType.schema.details.csharp.interfaceImplementation.declaration,
+            declaration: pt.elementType.schema.language.csharp.interfaceImplementation.declaration,
             schema: pt.elementType.schema,
           };
         } else {
           // arg! it's not done yet. Hope it's not polymorphic itself. 
           pt = {
-            declaration: `${pt.elementType.schema.details.csharp.namespace}.${pt.elementType.schema.details.csharp.interfaceName}`,
+            declaration: `${pt.elementType.schema.language.csharp.namespace}.${pt.elementType.schema.language.csharp.interfaceName}`,
             schema: pt.elementType.schema,
           };
         }
@@ -196,13 +210,13 @@ export function addInfoAttribute(targetProperty: Property, pType: TypeDeclaratio
     }
   }
   const ptypes = new Array<string>();
-  if (pt.schema && pt.schema && pt.schema.details.csharp.byReference) {
-    ptypes.push(`typeof(${pt.schema.details.csharp.namespace}.${pt.schema.details.csharp.interfaceName}_Reference)`);
+  if (pt.schema && pt.schema && pt.schema.language.csharp.byReference) {
+    ptypes.push(`typeof(${pt.schema.language.csharp.namespace}.${pt.schema.language.csharp.interfaceName}_Reference)`);
     // do we need polymorphic types for by-resource ? Don't think so.
   } else {
     ptypes.push(`typeof(${pt.declaration})`);
-    if (pt.schema && pt.schema.details.csharp.classImplementation && pt.schema.details.csharp.classImplementation.discriminators) {
-      ptypes.push(...[...pt.schema.details.csharp.classImplementation.discriminators.values()].map(each => `typeof(${each.modelInterface.fullName})`));
+    if (pt.schema && pt.schema.language.csharp.classImplementation && pt.schema.language.csharp.classImplementation.discriminators) {
+      ptypes.push(...[...pt.schema.language.csharp.classImplementation.discriminators.values()].map(each => `typeof(${each.modelInterface.fullName})`));
     }
   }
 
@@ -1400,6 +1414,1237 @@ export class CmdletClass extends Class {
       .selectMany(httpOperation => items(httpOperation.responses))
       .selectMany(responsesItem => responsesItem.value)
       .any(value => value.schema === undefined);
+    if (outputTypes.size === 0) {
+      outputTypes.add(`typeof(${dotnet.Bool})`);
+    }
+
+    this.add(new Attribute(OutputTypeAttribute, { parameters: [...outputTypes] }));
+    if (shouldAddPassThru) {
+      const passThru = this.add(new Property('PassThru', SwitchParameter, { description: 'When specified, forces the cmdlet return a \'bool\' given that there isn\'t a return type by default.' }));
+      passThru.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Returns true when the command succeeds"'] }));
+      passThru.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+    }
+
+    this.add(new Attribute(DescriptionAttribute, { parameters: [new StringExpression(this.description)] }));
+    this.add(new Attribute(GeneratedAttribute));
+    if (operation.extensions && operation.extensions['x-ms-metadata'] && operation.extensions['x-ms-metadata'].profiles) {
+      const profileNames = Object.keys(operation.extensions && operation.extensions['x-ms-metadata'].profiles);
+      // wrap profile names
+      profileNames.forEach((element, index) => {
+        profileNames[index] = `"${element}"`;
+      });
+
+      this.add(new Attribute(ProfileAttribute, { parameters: [...profileNames] }));
+    }
+  }
+}
+
+export class NewCmdletClass extends Class {
+  private cancellationToken!: Expression;
+  public state: NewState;
+  private readonly eventListener: EventListener;
+  private readonly dropBodyParameter: boolean;
+  private invocationInfo!: Property;
+  correlationId!: Field;
+  processRecordId!: Field;
+  defaultProfile!: Property;
+  private readonly thingsToSerialize: Array<Variable>;
+  private bodyParameter?: Variable;
+  private bodyParameterInfo?: { type: TypeDeclaration; valueType: TypeDeclaration };
+  private apProp?: Property;
+  private operation: CommandOperation;
+  private debugMode?: boolean;
+  private variantName: string;
+  private isViaIdentity: boolean;
+  private hasStreamOutput: boolean;
+  private outFileParameter?: Property;
+
+  constructor(namespace: Namespace, operation: CommandOperation, state: NewState, objectInitializer?: DeepPartial<CmdletClass>) {
+    // generate the 'variant'  part of the name
+    const noun = `${state.project.prefix}${operation.details.csharp.subjectPrefix}${operation.details.csharp.subject}`;
+    const variantName = `${noun}${operation.details.csharp.name ? `_${operation.details.csharp.name}` : ''}`;
+
+    const name = `${operation.details.csharp.verb}${variantName}`;
+    super(namespace, name, PSCmdlet);
+    this.dropBodyParameter = operation.details.csharp.dropBodyParameter ? true : false;
+    this.apply(objectInitializer);
+    this.operation = operation;
+    this.state = state;
+    this.thingsToSerialize = [];
+    this.variantName = variantName;
+    this.hasStreamOutput = false;
+
+    this.interfaces.push(ClientRuntime.IEventListener);
+    this.eventListener = new EventListener(new LiteralExpression(`((${ClientRuntime.IEventListener})this)`), true);
+
+    this.isViaIdentity = variantName.indexOf('ViaIdentity') > 0;
+
+  }
+
+  async init() {
+
+    // basic stuff
+    this.addCommonStuff();
+
+    this.description = escapeString(this.operation.details.csharp.description);
+    const $this = this;
+
+    this.add(new Method('BeginProcessing', dotnet.Void, {
+      override: Modifier.Override,
+      access: Access.Protected,
+      description: `(overrides the default BeginProcessing method in ${PSCmdlet})`,
+      *body() {
+        yield 'Module.Instance.SetProxyConfiguration(Proxy, ProxyCredential, ProxyUseDefaultCredentials);';
+        yield If($this.$<Property>('Break'), `${ClientRuntime.AttachDebugger}.Break();`);
+
+        yield $this.eventListener.syncSignal(Events.CmdletBeginProcessing);
+      }
+    }));
+
+    // construct the class
+    this.NewAddClassAttributes(this.operation, this.variantName);
+    if (this.hasStreamOutput) {
+      this.outFileParameter = this.add(new Property('OutFile', System.String, { attributes: [], description: 'Path to write output file to.' }));
+      this.outFileParameter.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = true', 'HelpMessage = "Path to write output file to"'] }));
+      this.outFileParameter.add(new Attribute(ValidateNotNull));
+      this.outFileParameter.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Body`] }));
+    }
+
+    this.NewAddPowershellParameters(this.operation);
+
+    // implement IEventListener
+    this.implementIEventListener();
+
+    // add constructors
+    this.implementConstructors();
+
+    // processRecord
+    this.NewImplementProcessRecord(this.operation);
+
+    this.NewImplementProcessRecordAsync(this.operation);
+    this.debugMode = await this.state.getValue('debug', false);
+
+    // json serialization
+    this.NewImplementSerialization(this.operation);
+
+    for (const prop of this.properties) {
+      if (prop.name === 'Host') {
+        prop['new'] = Modifier.New;
+      }
+    }
+
+    return this;
+  }
+
+  public get headerComment(): string {
+    const header = super.headerComment;
+    const ops = '';
+
+    for (const httpOperation of values(this.operation.callGraph)) {
+      // ops = `${ops}\n[OpenAPI] ${httpOperation.operationId}=>${httpOperation.method.toUpperCase()}:"${httpOperation.path}"`;
+      // skip-for-time-being
+      //   if (this.debugMode) {
+      //     const m = (httpOperation.extensions && httpOperation.extensions['x-ms-metadata']) || (httpOperation.pathExtensions ? httpOperation.pathExtensions['x-ms-metadata'] : undefined);
+      //     if (m) {
+      //       ops = `${ops}\n [METADATA]\n${serialize(m)}`;
+      //     }
+
+      //     ops = `${ops}\n [DETAILS]`;
+      //     ops = `${ops}\n verb: ${this.operation.details.csharp.verb}`;
+      //     ops = `${ops}\n subjectPrefix: ${this.operation.details.csharp.subjectPrefix}`;
+      //     ops = `${ops}\n subject: ${this.operation.details.csharp.subject}`;
+      //     ops = `${ops}\n variant: ${this.operation.details.csharp.name}`;
+      //   }
+    }
+
+    return ops ? `${header}\n${docComment(xmlize('remarks', ops))}` : header;
+  }
+
+  private addCommonStuff() {
+
+    // add a private copy of invocation information for our own uses.
+    const privateInvocationInfo = this.add(new Field('__invocationInfo', InvocationInfo, { description: 'A copy of the Invocation Info (necessary to allow asJob to clone this cmdlet)', access: Access.Private }));
+    this.invocationInfo = new Property('InvocationInformation', InvocationInfo, { description: 'Accessor for our copy of the InvocationInfo.' });
+    this.invocationInfo.get = toExpression(`${privateInvocationInfo.value} = ${privateInvocationInfo.value} ?? this.MyInvocation `);
+    this.invocationInfo.set = new Statements(privateInvocationInfo.assign('value'));
+    this.add(this.invocationInfo);
+
+    if (this.state.project.azure) {
+      this.correlationId = this.add(new Field('__correlationId', dotnet.String, { initialValue: 'System.Guid.NewGuid().ToString()', description: 'A unique id generatd for the this cmdlet when it is instantiated.', access: Access.Private }));
+      this.processRecordId = this.add(new Field('__processRecordId', dotnet.String, { description: 'A unique id generatd for the this cmdlet when ProcessRecord() is called.', access: Access.Private }));
+    }
+
+    // pipeline property
+    this.add(new Property('Pipeline', ClientRuntime.HttpPipeline, { getAccess: Access.Private, setAccess: Access.Private, description: `The instance of the <see cref="${ClientRuntime.HttpPipeline}" /> that the remote call will use.` }));
+
+    // client API property (gs01: fill this in correctly)
+    const clientAPI = new ClassType(this.state.model.language.csharp?.namespace, this.state.model.language.csharp?.name || '');
+    this.add(new LambdaProperty('Client', clientAPI, new LiteralExpression(`${this.state.project.serviceNamespace.moduleClass.declaration}.Instance.ClientAPI`), { description: 'The reference to the client API class.' }));
+
+    this.add(new Method('StopProcessing', dotnet.Void, { access: Access.Protected, override: Modifier.Override, description: 'Interrupts currently running code within the command.' })).add(function* () {
+      yield `((${ClientRuntime.IEventListener})this).Cancel();`;
+      yield 'base.StopProcessing();';
+    });
+
+    const $this = this;
+    this.add(new Method('EndProcessing', dotnet.Void, { access: Access.Protected, override: Modifier.Override, description: 'Performs clean-up after the command execution' })).add(function* () {
+      // gs01: remember what you were doing here to make it so these can be parallelized...
+      yield '';
+      yield $this.eventListener.syncSignal(Events.CmdletEndProcessing);
+    });
+
+    // debugging
+    const brk = this.add(new Property('Break', SwitchParameter, { attributes: [], description: 'Wait for .NET debugger to attach' }));
+    brk.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'DontShow = true', 'HelpMessage = "Wait for .NET debugger to attach"'] }));
+    brk.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+    // Cmdlet Parameters for pipeline manipulations.
+    const prepend = this.add(new Property('HttpPipelinePrepend', ClientRuntime.SendAsyncSteps, { attributes: [], description: 'SendAsync Pipeline Steps to be prepended to the front of the pipeline' }));
+    prepend.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'DontShow = true', 'HelpMessage = "SendAsync Pipeline Steps to be prepended to the front of the pipeline"'] }));
+    prepend.add(new Attribute(ValidateNotNull));
+    prepend.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+    const append = this.add(new Property('HttpPipelineAppend', ClientRuntime.SendAsyncSteps, { attributes: [], description: 'SendAsync Pipeline Steps to be appended to the front of the pipeline' }));
+    append.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'DontShow = true', 'HelpMessage = "SendAsync Pipeline Steps to be appended to the front of the pipeline"'] }));
+    append.add(new Attribute(ValidateNotNull));
+    append.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+    const proxyCredential = this.add(new Property('ProxyCredential', PSCredential, { attributes: [], description: 'Credentials for a proxy server to use for the remote call' }));
+    proxyCredential.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'DontShow = true', 'HelpMessage = "Credentials for a proxy server to use for the remote call"'] }));
+    proxyCredential.add(new Attribute(ValidateNotNull));
+    proxyCredential.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+    const useDefaultCreds = this.add(new Property('ProxyUseDefaultCredentials ', SwitchParameter, { attributes: [], description: 'Use the default credentials for the proxy' }));
+    useDefaultCreds.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'DontShow = true', 'HelpMessage = "Use the default credentials for the proxy"'] }));
+    useDefaultCreds.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+    const proxyUri = this.add(new Property('Proxy', System.Uri, { attributes: [], description: 'The URI for the proxy server to use' }));
+    proxyUri.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'DontShow = true', 'HelpMessage = "The URI for the proxy server to use"'] }));
+    proxyUri.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+    if (this.state.project.azure) {
+      this.defaultProfile = this.add(new Property('DefaultProfile', PSObject, { description: 'The credentials, account, tenant, and subscription used for communication with Azure' }));
+      this.defaultProfile.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "The credentials, account, tenant, and subscription used for communication with Azure."'] }));
+      this.defaultProfile.add(new Attribute(ValidateNotNull));
+      this.defaultProfile.add(new Attribute(Alias, { parameters: ['"AzureRMContext"', '"AzureCredential"'] }));
+      this.defaultProfile.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
+    }
+  }
+
+
+  private NewIsWritableCmdlet(operation: CommandOperation): boolean {
+    if (operation.callGraph[0].requests) {
+      switch (operation.callGraph[0].requests[0]?.protocol.http?.method.toLowerCase()) {
+        case 'put':
+        case 'post':
+        case 'delete':
+        case 'patch':
+          return true;
+      }
+    }
+    return false;
+  }
+
+
+  private NewImplementProcessRecord(operation: CommandOperation) {
+    const $this = this;
+    const writable = this.NewIsWritableCmdlet(operation);
+
+    this.add(new Method('ProcessRecord', undefined, { access: Access.Protected, override: Modifier.Override, description: 'Performs execution of the command.' })).add(function* () {
+      yield $this.eventListener.syncSignal(Events.CmdletProcessRecordStart);
+      if ($this.state.project.azure) {
+        yield $this.processRecordId.assign('System.Guid.NewGuid().ToString()');
+      }
+      yield Try(function* () {
+        yield '// work';
+        const normal = new Statements(function* () {
+          const acr = new LocalVariable('asyncCommandRuntime', dotnet.Var, { initializer: AsyncCommandRuntime.new(dotnet.This, $this.cancellationToken) });
+          yield Using(acr.declarationExpression, function* () {
+            yield `${acr}.Wait( ProcessRecordAsync(),${$this.cancellationToken});`;
+          });
+        });
+
+        if (operation.asjob) {
+          const asjob = $this.add(new Property('AsJob', SwitchParameter, { description: 'when specified, runs this cmdlet as a PowerShell job' }));
+          asjob.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Run the command as a job"'] }));
+          asjob.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+          const nowait = $this.add(new Property('NoWait', SwitchParameter, { description: 'when specified, will make the remote call, and return an AsyncOperationResponse, letting the remote operation continue asynchronously.' }));
+          nowait.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Run the command asynchronously"'] }));
+          nowait.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Runtime`] }));
+
+        }
+
+        const work: OneOrMoreStatements = operation.asjob ? function* () {
+          yield If('true == MyInvocation?.BoundParameters?.ContainsKey("AsJob")', function* () {
+            // clone the cmdlet instance, since the instance can be reused and overwrite data.
+            const instance = new LocalVariable('instance', dotnet.Var, { initializer: 'this.Clone()' });
+            yield instance.declarationStatement;
+
+            // create the job (which will set the CommandRuntime of the clone to the AsyncJob itself)
+            const job = new LocalVariable('job', dotnet.Var, { initializer: AsyncJob.new(instance, 'this.MyInvocation.Line, this.MyInvocation.MyCommand.Name, this._cancellationTokenSource.Token', 'this._cancellationTokenSource.Cancel') });
+            yield job.declarationStatement;
+
+            // add the job to the repository
+            yield `JobRepository.Add(${job});`;
+
+            // invoke the cmdlet's PRA
+            const task = new LocalVariable('task', dotnet.Var, { initializer: `${instance}.ProcessRecordAsync()` });
+            yield task.declarationStatement;
+
+            // have the AsyncJob monitor the lifetime of the Task
+            yield `${job}.Monitor(${task});`;
+
+            // return the job to the user now.
+            yield `WriteObject(${job});`;
+
+          });
+          yield Else(normal);
+        } : normal;
+
+        if (writable) {
+          yield If(`ShouldProcess($"Call remote '${operation.callGraph[0].language.csharp?.name}' operation")`, work);
+        } else {
+          yield work;
+        }
+      });
+      const aggregateException = new Parameter('aggregateException', System.AggregateException);
+      yield Catch(aggregateException, function* () {
+        yield '// unroll the inner exceptions to get the root cause';
+        yield ForEach('innerException', new LiteralExpression(`${aggregateException.use}.Flatten().InnerExceptions`), function* () {
+          yield $this.eventListener.syncSignal(Events.CmdletException, new LiteralExpression('$"{innerException.GetType().Name} - {innerException.Message} : {innerException.StackTrace}"'));
+          yield '// Write exception out to error channel.';
+          yield `WriteError( new ${ErrorRecord}(innerException,string.Empty, ${ErrorCategory('NotSpecified')}, null) );`;
+        });
+      });
+      const exception = new Parameter('exception', System.Exception);
+      yield Catch(exception, function* () {
+        yield $this.eventListener.syncSignal(Events.CmdletException, new LiteralExpression(`$"{${exception.use}.GetType().Name} - {${exception.use}.Message} : {${exception.use}.StackTrace}"`));
+        yield '// Write exception out to error channel.';
+        yield `WriteError( new ${ErrorRecord}(${exception.use},string.Empty, ${ErrorCategory('NotSpecified')}, null) );`;
+      }, { when: new LiteralExpression('(exception as System.Management.Automation.PipelineStoppedException)== null || (exception as System.Management.Automation.PipelineStoppedException).InnerException != null') });
+
+      yield Finally(function* () {
+        yield $this.eventListener.syncSignalNoCheck(Events.CmdletProcessRecordEnd);
+      });
+    });
+
+  }
+
+
+  private NewImplementProcessRecordAsync(operation: CommandOperation) {
+    const $this = this;
+    const PAR = this.add(new Method('ProcessRecordAsync', System.Threading.Tasks.Task(), {
+      access: Access.Protected, async: Modifier.Async,
+      description: 'Performs execution of the command, working asynchronously if required.',
+      returnsDescription: `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the method is completed.`
+    }));
+
+    // we don't want to use SynchContext here.
+    PAR.push(Using('NoSynchronizationContext', ''));
+
+    PAR.add(function* () {
+      if ($this.apProp && $this.bodyParameter && $this.bodyParameterInfo) {
+        // yield `${ClientRuntime}.DictionaryExtensions.HashTableToDictionary<${$this.bodyParameterInfo.type.declaration},${$this.bodyParameterInfo.valueType.declaration}>(${$this.apProp.value},${$this.bodyParameter.Cast($this.bodyParameterInfo.type)});`;
+        let vt = $this.bodyParameterInfo.valueType.declaration;
+        if (vt.endsWith('SwitchParameter')) {
+          vt = 'bool';
+        }
+        yield `${ClientRuntime}.DictionaryExtensions.HashTableToDictionary<${vt}>(${$this.apProp.value},${$this.bodyParameter}.AdditionalProperties);`;
+      }
+
+      // construct the call to the operation
+      yield $this.eventListener.signal(Events.CmdletProcessRecordAsyncStart);
+
+      yield $this.eventListener.signal(Events.CmdletGetPipeline);
+
+      const pipeline = $this.$<Property>('Pipeline');
+
+      if ($this.state.project.azure) {
+        yield pipeline.assign(new LiteralExpression(`${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.CreatePipeline(${$this.invocationInfo}, ${$this.correlationId}, ${$this.processRecordId}, this.ParameterSetName)`));
+      } else {
+        yield pipeline.assign(new LiteralExpression(`${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.CreatePipeline(${$this.invocationInfo}, this.ParameterSetName)`));
+      }
+
+      yield If(IsNotNull($this.$<Property>('HttpPipelinePrepend')), pipeline.invokeMethod('Prepend', toExpression(`(this.CommandRuntime as Microsoft.Rest.ClientRuntime.PowerShell.IAsyncCommandRuntimeExtensions)?.Wrap(${$this.$<Property>('HttpPipelinePrepend')}) ?? ${$this.$<Property>('HttpPipelinePrepend')}`)));
+      yield If(IsNotNull($this.$<Property>('HttpPipelineAppend')), pipeline.invokeMethod('Append', toExpression(`(this.CommandRuntime as Microsoft.Rest.ClientRuntime.PowerShell.IAsyncCommandRuntimeExtensions)?.Wrap(${$this.$<Property>('HttpPipelineAppend')}) ?? ${$this.$<Property>('HttpPipelineAppend')}`)));
+
+      yield '// get the client instance';
+      const apiCall = operation.callGraph[0];
+
+      // find each parameter to the method, and find out where the value is going to come from.
+      const operationParameters =
+        values(apiCall.parameters).
+          // filter out constants and path parameters when using piping for identity
+          where(each => !(each.language.csharp?.constantValue) && each.language.default?.name !== '$host'/* && (!$this.isViaIdentity || each.in !== ParameterLocation.Path) */).
+
+          select(p => {
+            return {
+              name: p.language.csharp?.name,
+              param: values($this.properties).
+                where(each => each.metadata.parameterDefinition).
+                first(each => each.metadata.parameterDefinition.details.csharp.uid === p.language.csharp?.uid),
+              isPathParam: $this.isViaIdentity && p.protocol.http?.in === ParameterLocation.Path
+            };
+
+          }).
+          select(each => {
+            if (each.param) {
+
+              const httpParam = (<HttpParameter>(each.param.metadata.parameterDefinition));
+              if (httpParam.required) {
+                return {
+                  name: each.param,
+                  expression: each.param,
+                  isPathParam: each.isPathParam
+                };
+              }
+
+              const httpParamTD = $this.state.project.schemaDefinitionResolver.resolveTypeDeclaration((<NewSchema>httpParam.schema), httpParam.required, $this.state);
+              return {
+                name: each.param,
+                expression: toExpression(`this.InvocationInformation.BoundParameters.ContainsKey("${each.param.value}") ? ${each.param.value} : ${httpParamTD.defaultOfType}`),
+                isPathParam: each.isPathParam
+              };
+
+            }
+
+            return { name: each.name, expression: dotnet.Null, isPathParam: each.isPathParam };
+          }).toArray();
+
+      // is there a body parameter we should include?
+      if ($this.bodyParameter) {
+        operationParameters.push({ name: 'body', expression: $this.bodyParameter, isPathParam: false });
+      }
+
+      // create the response handlers
+      const responses = [...values(apiCall.responses)];
+
+      const callbackMethods = values(responses).toArray().map(each => new LiteralExpression(each.language.csharp?.name || ''));
+
+      // make callback methods
+      for (const each of values(responses)) {
+
+        const parameters = new Array<Parameter>();
+        parameters.push(new Parameter('responseMessage', System.Net.Http.HttpResponseMessage, { description: `the raw response message as an ${System.Net.Http.HttpResponseMessage}.` }));
+
+        if (each.language.csharp?.responseType) {
+          parameters.push(new Parameter('response', System.Threading.Tasks.Task({ declaration: each.language.csharp?.responseType }), { description: `the body result as a <see cref="${each.language.csharp.responseType}" /> from the remote call` }));
+        }
+        if (each.language.csharp?.headerType) {
+          parameters.push(new Parameter('headers', System.Threading.Tasks.Task({ declaration: each.language.csharp.headerType }), { description: `the header result as a <see cref="${each.language.csharp.headerType}" /> from the remote call` }));
+        }
+
+        const override = `override${pascalCase(each.language.csharp?.name || '')}`;
+        const returnNow = new Parameter('returnNow', System.Threading.Tasks.Task(dotnet.Bool), { modifier: ParameterModifier.Ref, description: `/// Determines if the rest of the ${each.language.csharp?.name} method should be processed, or if the method should return immediately (set to true to skip further processing )` });
+        const overrideResponseMethod = new PartialMethod(override, dotnet.Void, {
+          parameters: [...parameters, returnNow],
+          description: `<c>${override}</c> will be called before the regular ${each.language.csharp?.name} has been processed, allowing customization of what happens on that response. Implement this method in a partial class to enable this behavior`,
+          returnsDescription: `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the method is completed.`
+        });
+        $this.add(overrideResponseMethod);
+
+        const responseMethod = new Method(`${each.language.csharp?.name}`, System.Threading.Tasks.Task(), {
+          access: Access.Private,
+          parameters,
+          async: Modifier.Async,
+          description: each.language.csharp?.description,
+          returnsDescription: `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the method is completed.`
+        });
+        responseMethod.push(Using('NoSynchronizationContext', ''));
+
+
+        responseMethod.add(function* () {
+          const skip = Local('_returnNow', `${System.Threading.Tasks.Task(dotnet.Bool).declaration}.FromResult(${dotnet.False})`);
+          yield skip.declarationStatement;
+          yield `${overrideResponseMethod.invoke(...parameters, `ref ${skip.value}`)};`;
+          yield `// if ${override} has returned true, then return right away.`;
+          yield If(And(IsNotNull(skip), `await ${skip}`), Return());
+
+          if (each.language.csharp?.isErrorResponse) {
+            // this should write an error to the error channel.
+            yield `// Error Response : ${each.protocol.http?.statusCodes[0]}`;
+
+
+            const unexpected = function* () {
+              yield '// Unrecognized Response. Create an error record based on what we have.';
+              const ex = (each.language.csharp?.responseType) ?
+                Local('ex', `new ${ClientRuntime.name}.RestException<${each.language.csharp.responseType}>(responseMessage, await response)`) :
+                Local('ex', `new ${ClientRuntime.name}.RestException(responseMessage)`);
+
+              yield ex.declarationStatement;
+
+              yield `WriteError( new global::System.Management.Automation.ErrorRecord(${ex.value}, ${ex.value}.Code, global::System.Management.Automation.ErrorCategory.InvalidOperation, new { ${operationParameters.filter(e => valueOf(e.expression) !== 'null').map(each => `${each.name}=${each.expression}`).join(', ')} }) 
+{ 
+  ErrorDetails = new global::System.Management.Automation.ErrorDetails(${ex.value}.Message) { RecommendedAction = ${ex.value}.Action }
+});`;
+            };
+            if (each instanceof SchemaResponse) {
+              // the schema should be the error information.
+              // this supports both { error { message, code} } and { message, code} 
+
+              let props = getAllPublicVirtualProperties(each.schema.language.csharp?.virtualProperties);
+              const errorProperty = values(props).first(p => p.property.details.csharp.name === 'error');
+              let ep = '';
+              if (errorProperty) {
+                props = getAllPublicVirtualProperties(errorProperty.property.schema.details.csharp.virtualProperties);
+                ep = `${errorProperty.name}?.`;
+              }
+
+              const codeProp = props.find(p => p.name.toLowerCase().indexOf('code') > -1); // first property with 'code'
+              const messageProp = props.find(p => p.name.toLowerCase().indexOf('message') > -1); // first property with 'message'
+              const actionProp = props.find(p => p.name.toLowerCase().indexOf('action') > -1); // first property with 'action'
+
+              if (codeProp && messageProp) {
+                const lcode = new LocalVariable('code', dotnet.Var, { initializer: `(await response)?.${ep}${codeProp.name}` });
+                const lmessage = new LocalVariable('message', dotnet.Var, { initializer: `(await response)?.${ep}${messageProp.name}` });
+                const laction = actionProp ? new LocalVariable('action', dotnet.Var, { initializer: `(await response)?.${ep}${actionProp.name} ?? ${System.String.Empty}` }) : undefined;
+                yield lcode;
+                yield lmessage;
+                yield laction;
+
+                yield If(Or(IsNull(lcode), (IsNull(lmessage))), unexpected);
+                yield Else(`WriteError( new global::System.Management.Automation.ErrorRecord(new global::System.Exception($"[{${lcode}}] : {${lmessage}}"), ${lcode}?.ToString(), global::System.Management.Automation.ErrorCategory.InvalidOperation, new { ${operationParameters.filter(e => valueOf(e.expression) !== 'null').map(each => `${each.name}=${each.expression}`).join(', ')} })
+{
+  ErrorDetails = new global::System.Management.Automation.ErrorDetails(${lmessage}) { RecommendedAction = ${laction || System.String.Empty} }
+});`
+
+                );
+                return;
+              } else {
+                yield unexpected;
+                return;
+              }
+            } else {
+              yield unexpected;
+              return;
+            }
+          }
+
+          yield `// ${each.language.csharp?.name} - response for ${each.protocol.http?.statusCodes[0]} / ${values(each.protocol.http?.mediaTypes).join('/')}`;
+
+          if ('schema' in each) {
+            const schema = (<SchemaResponse>each).schema;
+
+            if (apiCall.language.csharp?.pageable) {
+              const pageable = apiCall.language.csharp.pageable;
+              yield '// response should be returning an array of some kind. +Pageable';
+              yield `// ${pageable.responseType} / ${pageable.itemName || '<none>'} / ${pageable.nextLinkName || '<none>'}`;
+              switch (pageable.responseType) {
+                // the result is (or works like a x-ms-pageable)
+                // skip-for-time-being
+                // case 'pageable':
+                // case 'nested-array': {
+                //   const valueProperty = schema.properties[pageable.itemName];
+                //   const nextLinkProperty = schema.properties[pageable.nextLinkName];
+                //   if (valueProperty && nextLinkProperty) {
+                //     // it's pageable!
+                //     const result = new LocalVariable('result', dotnet.Var, { initializer: new LiteralExpression('await response') });
+                //     yield result.declarationStatement;
+                //     // write out the current contents
+                //     const vp = getVirtualPropertyFromPropertyName(each.schema.details.csharp.virtualProperties, valueProperty.serializedName);
+                //     if (vp) {
+                //       yield `WriteObject(${result.value}.${vp.name},true);`;
+                //     }
+                //     const nl = getVirtualPropertyFromPropertyName(each.schema.details.csharp.virtualProperties, nextLinkProperty.serializedName);
+                //     if (nl) {
+                //       const nextLinkName = `${result.value}.${nl.name}`;
+                //       yield (If(`${nextLinkName} != null`,
+                //         If('responseMessage.RequestMessage is System.Net.Http.HttpRequestMessage requestMessage ', function* () {
+                //           yield `requestMessage = requestMessage.Clone(new global::System.Uri( ${nextLinkName} ),${ClientRuntime.Method.Get} );`;
+                //           yield $this.eventListener.signal(Events.FollowingNextLink);
+                //           yield `await this.${$this.$<Property>('Client').invokeMethod(`${apiCall.details.csharp.name}_Call`, ...[toExpression('requestMessage'), ...callbackMethods, dotnet.This, pipeline]).implementation}`;
+                //         })
+                //       ));
+                //     }
+                //     return;
+                //   } else if (valueProperty) {
+                //     // it's just a nested array
+                //     const p = getVirtualPropertyFromPropertyName(each.schema.details.csharp.virtualProperties, valueProperty.serializedName);
+                //     if (p) {
+                //       yield `WriteObject((await response).${p.name}, true);`;
+                //     }
+                //     return;
+                //   }
+                // }
+                //   break;
+
+                // it's just an array,
+                case 'array':
+                  // just write-object(enumerate) with the output
+                  yield 'WriteObject(await response, true);';
+                  return;
+              }
+              // ok, let's see if the response type
+            }
+            const props = getAllPublicVirtualProperties(schema.language.csharp?.virtualProperties);
+            const outValue = (length(props) === 1) ? `(await response).${props[0].name}` : '(await response)';
+
+
+            // we expect to get back some data from this call.
+
+            const rType = $this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(<NewSchema>schema, true, $this.state);
+            yield `// (await response) // should be ${rType.declaration}`;
+            if ($this.hasStreamOutput && $this.outFileParameter) {
+              const outfile = $this.outFileParameter;
+              const provider = Local('provider');
+              provider.initializer = undefined;
+              const paths = Local('paths', `this.SessionState.Path.GetResolvedProviderPathFromPSPath(${outfile.value}, out ${provider.declarationExpression})`);
+              yield paths.declarationStatement;
+              yield If(`${provider.value}.Name != "FileSystem" || ${paths.value}.Count == 0`, `ThrowTerminatingError( new System.Management.Automation.ErrorRecord(new global::System.Exception("Invalid output path."),string.Empty, global::System.Management.Automation.ErrorCategory.InvalidArgument, ${outfile.value}) );`);
+              yield If(`${paths.value}.Count > 1`, `ThrowTerminatingError( new System.Management.Automation.ErrorRecord(new global::System.Exception("Multiple output paths not allowed."),string.Empty, global::System.Management.Automation.ErrorCategory.InvalidArgument, ${outfile.value}) );`);
+
+              if (rType.declaration === System.IO.Stream.declaration) {
+                // this is a stream output. write to outfile
+                const stream = Local('stream', 'await response');
+                yield Using(stream.declarationExpression, function* () {
+                  const fileStream = Local('fileStream', `global::System.IO.File.OpenWrite(${paths.value}[0])`);
+                  yield Using(fileStream.declarationExpression, `await ${stream.value}.CopyToAsync(${fileStream.value});`);
+                });
+              } else {
+                // assuming byte array output (via outValue)
+                yield `global::System.IO.File.WriteAllBytes(${paths.value}[0],${outValue});`;
+              }
+
+              yield If('true == MyInvocation?.BoundParameters?.ContainsKey("PassThru")', function* () {
+                // no return type. Let's just return ... true?
+                yield 'WriteObject(true);';
+              });
+              return;
+            }
+
+            //  let's just return the result object (or unwrapped result object)
+            yield `WriteObject(${outValue});`;
+            return;
+          }
+
+          yield If('true == MyInvocation?.BoundParameters?.ContainsKey("PassThru")', function* () {
+            // no return type. Let's just return ... true?
+            yield 'WriteObject(true);';
+          });
+        });
+        $this.add(responseMethod);
+      }
+
+      yield Try(function* () {
+        // make the call.
+
+        const actualCall = function* () {
+          yield $this.eventListener.signal(Events.CmdletBeforeAPICall);
+          const idOpParams = operationParameters.filter(each => !each.isPathParam);
+          // skip-for-time-being, viaidentity
+          // const idschema = values($this.state.project.model.schemas).first(each => each.details.default.uid === 'universal-parameter-type');
+
+
+          // if ($this.isViaIdentity) {
+          //   const identityFromPathParams = function* () {
+          //     yield '// try to call with PATH parameters from Input Object';
+
+          //     if (idschema) {
+          //       const allVPs = getAllPublicVirtualProperties(idschema.details.csharp.virtualProperties);
+          //       const props = [...values(idschema.properties)];
+
+          //       const idOpParams = operationParameters.map(each => {
+          //         const pascalName = pascalCase(`${each.name}`);
+
+          //         if (!each.isPathParam) {
+          //           return {
+          //             name: undefined,
+          //             value: valueOf(each.expression)
+          //           };
+          //         }
+          //         const match = props.find(p => pascalCase(p.serializedName) === pascalName);
+          //         if (match) {
+
+          //           const defaultOfType = $this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(<Schema>match.schema, true, $this.state).defaultOfType;
+          //           // match up vp name
+          //           const vp = allVPs.find(pp => pascalCase(pp.property.serializedName) === pascalName);
+          //           if (vp) {
+          //             return {
+          //               name: `InputObject.${vp.name}`,
+          //               value: `InputObject.${vp.name} ?? ${defaultOfType}`
+          //             };
+          //           }
+          //           // fall back!
+
+          //           console.error(`Unable to match identity parameter '${each.name}' member to appropriate virtual parameter. (Guessing '${pascalCase(match.details.csharp.name)}').`);
+          //           return {
+          //             name: `InputObject.${pascalCase(match.details.csharp.name)}`,
+          //             value: `InputObject.${pascalCase(match.details.csharp.name)} ?? ${defaultOfType}`
+          //           };
+          //         }
+          //         console.error(`Unable to match idenity parameter '${each.name}' member to appropriate virtual parameter. (Guessing '${pascalName}')`);
+          //         return {
+          //           name: `InputObject.${pascalName}`,
+          //           value: `InputObject.${pascalName}`
+          //         };
+          //       });
+          //       for (const opParam of idOpParams) {
+          //         if (opParam.name) {
+          //           yield If(IsNull(opParam.name), `ThrowTerminatingError( new ${ErrorRecord}(new global::System.Exception("InputObject has null value for ${opParam.name}"),string.Empty, ${ErrorCategory('InvalidArgument')}, InputObject) );`);
+          //         }
+          //       }
+          //       yield `await this.${$this.$<Property>('Client').invokeMethod(`${apiCall.details.csharp.name}`, ...[...idOpParams.map(each => toExpression(each.value)), ...callbackMethods, dotnet.This, pipeline]).implementation}`;
+
+          //     }
+          //   };
+
+          //   if (idschema && values(idschema.properties).first(each => each.details.csharp.uid === 'universal-parameter:resource identity')) {
+          //     yield If('InputObject?.Id != null', `await this.${$this.$<Property>('Client').invokeMethod(`${apiCall.details.csharp.name}ViaIdentity`, ...[toExpression('InputObject.Id'), ...idOpParams.map(each => each.expression), ...callbackMethods, dotnet.This, pipeline]).implementation}`);
+          //     yield Else(identityFromPathParams);
+          //   } else {
+          //     yield identityFromPathParams;
+          //   }
+          // } else {
+          yield `await this.${$this.$<Property>('Client').invokeMethod(`${apiCall.language.csharp?.name}`, ...[...operationParameters.map(each => each.expression), ...callbackMethods, dotnet.This, pipeline]).implementation}`;
+          //}
+          yield $this.eventListener.signal(Events.CmdletAfterAPICall);
+        };
+
+        if ($this.state.project.azure && operationParameters.find(each => each.expression && each.expression.value === 'SubscriptionId') && $this.operation.details.csharp.verb.toLowerCase() === 'get') {
+          yield 'foreach( var SubscriptionId in this.SubscriptionId )';
+          yield BlockStatement(actualCall);
+        } else {
+          yield actualCall;
+        }
+      });
+      const ure = new Parameter('urexception', { declaration: `${ClientRuntime.fullName}.UndeclaredResponseException` });
+      yield Catch(ure, function* () {
+        yield `WriteError(new global::System.Management.Automation.ErrorRecord(${ure.value}, ${ure.value}.StatusCode.ToString(), global::System.Management.Automation.ErrorCategory.InvalidOperation, new {  ${operationParameters.filter(e => valueOf(e.expression) !== 'null').map(each => `${each.name}=${each.expression}`).join(',')}})
+{
+  ErrorDetails = new global::System.Management.Automation.ErrorDetails(${ure.value}.Message) { RecommendedAction = ${ure.value}.Action }
+});`;
+      });
+      yield Finally(function* () {
+        yield $this.eventListener.signalNoCheck(Events.CmdletProcessRecordAsyncEnd);
+      });
+    });
+  }
+
+
+  private NewImplementSerialization(operation: CommandOperation) {
+    const $this = this;
+    // clone
+    if (operation.asjob) {
+      const clone = this.add(new Method('Clone', this, {
+        description: 'Creates a duplicate instance of this cmdlet (via JSON serialization).',
+        returnsDescription: `a duplicate instance of ${this.name}`,
+      }));
+
+      clone.add(function* () {
+        const i = new LocalVariable('clone', dotnet.Var, {
+          initializer: $this.new()
+        });
+        yield i.declarationStatement;
+
+        if ($this.state.project.azure) {
+          for (const f of [$this.correlationId, $this.processRecordId, $this.defaultProfile]) {
+            yield `${i.value}.${f} = this.${f};`;
+          }
+        }
+        for (const f of [$this.invocationInfo, 'Proxy', 'Pipeline', 'AsJob', 'Break', 'ProxyCredential', 'ProxyUseDefaultCredentials', 'HttpPipelinePrepend', 'HttpPipelineAppend',]) {
+          yield `${i.value}.${f} = this.${f};`;
+        }
+
+        for (const f of $this.thingsToSerialize) {
+          yield `${i.value}.${f} = this.${f};`;
+        }
+
+        // _name = this._name,
+        //_parametersBody = this._parametersBody,
+        //_resourceGroupName = this._resourceGroupName,
+        //_subscriptionId = this._subscriptionId,
+
+        yield Return(i);
+      });
+    }
+  }
+  private implementConstructors() {
+    // default constructor
+    this.add(new Constructor(this, { description: `Intializes a new instance of the <see cref="${this.name}" /> cmdlet class.` }));
+  }
+
+  private implementIEventListener() {
+    const $this = this;
+    const cts = this.add(new Field('_cancellationTokenSource', System.Threading.CancellationTokenSource, {
+      access: Access.Private,
+      initialValue: new LiteralExpression(`new ${System.Threading.CancellationTokenSource.declaration}()`),
+      description: `The <see cref="${System.Threading.CancellationTokenSource}" /> for this operation.`
+    }));
+    this.add(new LambdaProperty(`${ClientRuntime.IEventListener}.Token`, System.Threading.CancellationToken, new LiteralExpression(`${cts.value}.Token`), { getAccess: Access.Default, setAccess: Access.Default, description: '<see cref="IEventListener" /> cancellation token.' }));
+    this.cancellationToken = toExpression(`((${ClientRuntime.IEventListener})this).Token`);
+    this.add(new LambdaProperty(`${ClientRuntime.IEventListener}.Cancel`, System.Action(), new LiteralExpression(`${cts.value}.Cancel`), { getAccess: Access.Default, setAccess: Access.Default, description: '<see cref="IEventListener" /> cancellation delegate. Stops the cmdlet when called.' }));
+
+    const id = new Parameter('id', dotnet.String, { description: 'The message id' });
+    const token = new Parameter('token', System.Threading.CancellationToken, { description: 'The message cancellation token. When this call is cancelled, this should be <c>true</c>' });
+    const messageData = new Parameter('messageData', System.Func(ClientRuntime.EventData), { description: 'Detailed message data for the message event.' });
+    const signalMethod = this.add(new Method(`${ClientRuntime.IEventListener}.Signal`, System.Threading.Tasks.Task(), {
+      async: Modifier.Async,
+      parameters: [id, token, messageData],
+      access: Access.Default,
+      description: 'Handles/Dispatches events during the call to the REST service.',
+      returnsDescription: `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the message is completed.`
+    }));
+    signalMethod.push(Using('NoSynchronizationContext', ''));
+
+    signalMethod.add(function* () {
+      yield If(`${token.value}.IsCancellationRequested`, Return());
+
+      // if the 
+
+      const sw = Switch(id, [
+        TerminalCase(Events.Verbose.value, function* () {
+          yield `WriteVerbose($"{(messageData().Message ?? ${System.String.Empty})}");`;
+          yield Return();
+        }),
+
+        TerminalCase(Events.Warning.value, function* () {
+          yield `WriteWarning($"{(messageData().Message ?? ${System.String.Empty})}");`;
+          yield Return();
+        }),
+        TerminalCase(Events.Information.value, function* () {
+          if ($this.operation.asjob) {
+            yield '// When an operation supports asjob, Information messages must go thru verbose.';
+            yield `WriteVerbose($"INFORMATION: {(messageData().Message ?? ${System.String.Empty})}");`;
+          }
+          else {
+            const data = new LocalVariable('data', dotnet.Var, { initializer: new LiteralExpression(`${messageData.use}()`) });
+            yield data.declarationStatement;
+            yield 'WriteInformation(data, new[] { data.Message });';
+          }
+          yield Return();
+
+        }),
+        TerminalCase(Events.Debug.value, function* () {
+          yield `WriteDebug($"{(messageData().Message ?? ${System.String.Empty})}");`;
+          yield Return();
+        }),
+        TerminalCase(Events.Error.value, function* () {
+          yield 'WriteError(new global::System.Management.Automation.ErrorRecord( new global::System.Exception(messageData().Message), string.Empty, global::System.Management.Automation.ErrorCategory.NotSpecified, null ) );';
+          yield Return();
+        }),
+      ]);
+
+      if ($this.operation.asjob) {
+        // if we support -AsJob, we support -NoWait
+        sw.add(Case(Events.DelayBeforePolling.value, function* () {
+          yield If('true == MyInvocation?.BoundParameters?.ContainsKey("NoWait")', function* () {
+            yield 'var data = messageData();';
+            yield 'if (data.ResponseMessage is System.Net.Http.HttpResponseMessage response)';
+            yield '{';
+            yield '    var asyncOperation = response.GetFirstHeader(@"Azure-AsyncOperation");';
+            yield '    var location = response.GetFirstHeader(@"Location");';
+            yield '    var uri = global::System.String.IsNullOrEmpty(asyncOperation) ? global::System.String.IsNullOrEmpty(location) ? response.RequestMessage.RequestUri.AbsoluteUri : location : asyncOperation;';
+            yield `    WriteObject(new ${ClientRuntime}.PowerShell.AsyncOperationResponse { Target = uri });`;
+
+            yield '    // do nothing more. ';
+            yield '    data.Cancel();';
+            yield '    return;';
+            yield '}';
+          });
+        }));
+      }
+
+      // the whole switch statement
+      yield sw;
+
+      if ($this.state.project.azure) {
+        // in azure mode, we signal the AzAccount module with every event that makes it here.
+        yield `await ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.Signal(${id.value}, ${token.value}, ${messageData.value}, (i,t,m) => ((${ClientRuntime.IEventListener})this).Signal(i,t,()=> ${ClientRuntime.EventDataConverter}.ConvertFrom( m() ) as ${ClientRuntime.EventData} ), ${$this.invocationInfo.value}, this.ParameterSetName, ${$this.correlationId.value}, ${$this.processRecordId.value}, null );`;
+        yield If(`${token.value}.IsCancellationRequested`, Return());
+      }
+      yield `WriteDebug($"{id}: {(messageData().Message ?? ${System.String.Empty})}");`;
+      // any handling of the signal on our side...
+    });
+  }
+
+
+  private NewAddPowershellParameters(operation: CommandOperation) {
+    const vps = operation.details.csharp.virtualParameters || {
+      body: [],
+      operation: [],
+    };
+
+    for (const parameter of values(operation.parameters)) {
+      // these are the parameters that this command expects
+      parameter.schema;
+      const td = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(<NewSchema>parameter.schema, true, this.state);
+
+      if (parameter.details.csharp.constantValue) {
+        // this parameter has a constant value -- SKIP IT
+        continue;
+      }
+
+      if (parameter.details.csharp.fromHost) {
+        // the parameter is expected to be gotten from the host.(ie, Az.Accounts)
+
+        const hostParameter = this.add(new BackedProperty(parameter.details.csharp.name, td, {
+          metadata: {
+            parameterDefinition: parameter.details.csharp.httpParameter
+          },
+          description: parameter.details.csharp.description,
+        }));
+        this.thingsToSerialize.push(hostParameter);
+        // in the BeginProcessing, we should tell it to go get the value for this property from the common module
+        this.$<Method>('BeginProcessing').add(hostParameter.assignPrivate(new LiteralExpression(`${this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetParameter(this.MyInvocation, ${this.correlationId.value}, "${parameter.name}") as string`)));
+        continue;
+      }
+      const $this = this;
+
+      if (parameter.details.csharp.apiversion) {
+        // Api-version parameters for azure are a custom implementation
+        this.add(new Property(parameter.details.csharp.name, td, {
+          getAccess: Access.Internal,
+          setAccess: Access.Private,
+          metadata: {
+            parameterDefinition: parameter.details.csharp.httpParameter
+          },
+          description: parameter.details.csharp.description,
+          *get() {
+            const metadata = operation.extensions['x-ms-metadata'];
+            const profiles = <Dictionary<string>>metadata.profiles || new Dictionary<string>();
+
+            yield Switch(`${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.Profile`, function* () {
+              for (const { key: profileName, value: apiVersion } of items(profiles)) {
+                yield TerminalCase(`"${profileName}"`, Return(`"${apiVersion}"`));
+              }
+              yield TerminalDefaultCase(Return(`"${metadata.apiVersions[0]}"`));
+            });
+          }
+        }));
+        continue;
+      }
+
+      if (this.dropBodyParameter && parameter.details.csharp.isBodyParameter) {
+        // we're supposed to use parameters for the body parameter instead of a big object
+        const expandedBodyParameter = this.add(new BackedProperty(parameter.details.csharp.name, td, {
+          description: parameter.details.csharp.description,
+
+          initializer: (parameter.schema.type === SchemaType.Array) ? 'null' : `new ${parameter.schema.language.csharp?.fullname}()`,
+          setAccess: Access.Private,
+          getAccess: Access.Private,
+        }));
+        this.thingsToSerialize.push(expandedBodyParameter);
+
+        for (const vParam of vps.body) {
+          const vSchema = vParam.schema;
+          vParam.origin;
+          const propertyType = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(vSchema, true, this.state);
+
+          // we need to know if the actual underlying property is actually nullable.
+          const nullable = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(vSchema, (<NewVirtualProperty>vParam.origin).property.language.csharp?.required, this.state).isNullable;
+
+          const cmdletParameter = new Property(vParam.name, propertyType, {
+            get: toExpression(`${expandedBodyParameter.value}.${getVirtualPropertyName((<any>vParam.origin)) || vParam.origin.name}${!nullable ? '' : ` ?? ${propertyType.defaultOfType}`}`), // /* ${inspect(vParam.origin)} */
+            // get: toExpression(`null == ${expandedBodyParameter.value}.${vParam.origin.name} ? ${propertyType.defaultOfType} : (${propertyType.declaration}) ${expandedBodyParameter.value}.${vParam.origin.name}`),
+            set: toExpression(`${expandedBodyParameter.value}.${getVirtualPropertyName((<any>vParam.origin)) || vParam.origin.name} = value`),
+            new: PropertiesRequiringNew.has(vParam.name) ? Modifier.New : Modifier.None
+          });
+
+          if (vParam.schema.language.csharp?.byReference) {
+            // this parameter's schema is marked as 'by-reference' which means we should 
+            // tag it with an ExportAs attribute for the I*Reference type.
+            cmdletParameter.add(new Attribute(ExportAsAttribute, { parameters: [`typeof(${vParam.schema.language.csharp.referenceInterface})`] }));
+          }
+
+          if (vParam.schema.type === SchemaType.Array) {
+            //skip-for-time-being
+            // if ((<ArraySchema>vParam.schema). && vParam.schema.items.details.csharp.byReference) {
+            //   cmdletParameter.add(new Attribute(ExportAsAttribute, { parameters: [`typeof(${vParam.schema.items.details.csharp.referenceInterface}[])`] }));
+            // }
+            cmdletParameter.add(new Attribute(AllowEmptyCollectionAttribute));
+          }
+          //skip-for-time-being
+          // if (vSchema.additionalProperties) {
+          //   // we have to figure out if this is a standalone dictionary or a hybrid object/dictionary.
+          //   // if it's a hybrid, we have to create another parameter like -<XXX>AdditionalProperties and have that dump the contents into the dictionary
+          //   // if it's a standalone dictionary, we can just use hashtable instead
+          //   if (length(vSchema.properties) === 0) {
+          //     // it's a pure dictionary
+          //     // add an attribute for changing the exported type.
+          //     cmdletParameter.add(new Attribute(ExportAsAttribute, { parameters: [`typeof(${System.Collections.Hashtable})`] }));
+          //   } else {
+          //     // it's a hybrid. We need to add an additional property that puts its items into the target container
+
+          //   }
+
+          // }
+
+          const desc = (vParam.description || '.').replace(/[\r?\n]/gm, '');
+          cmdletParameter.description = desc;
+
+          // check if this parameter is a byte array, which would indicate that it should really be a file input
+          if (cmdletParameter.type.declaration === dotnet.Binary.declaration) {
+            // set the generated parameter to internal
+            cmdletParameter.setAccess = Access.Internal;
+            cmdletParameter.getAccess = Access.Internal;
+
+            // create a InputFileXXX for the parameter
+            const ifname = vParam.name.toLowerCase() === 'value' ? 'InputFile' : pascalCase([vParam.name, 'Input', 'File']);
+
+            const inputFileParameter = new Property(ifname, dotnet.String, {
+              // get: toExpression(`${expandedBodyParameter.value}.${vParam.origin.name}${vParam.required ? '' : ` ?? ${propertyType.defaultOfType}`}`),
+              set: function* () {
+                const provider = Local('provider');
+                provider.initializer = undefined;
+                const paths = Local('paths', `this.SessionState.Path.GetResolvedProviderPathFromPSPath(value, out ${provider.declarationExpression})`);
+                yield paths.declarationStatement;
+                yield If(`${provider.value}.Name != "FileSystem" || ${paths.value}.Count == 0`, 'ThrowTerminatingError( new System.Management.Automation.ErrorRecord(new global::System.Exception("Invalid input path."),string.Empty, global::System.Management.Automation.ErrorCategory.InvalidArgument, value) );');
+                yield If(`${paths.value}.Count > 1`, 'ThrowTerminatingError( new System.Management.Automation.ErrorRecord(new global::System.Exception("Multiple input paths not allowed."),string.Empty, global::System.Management.Automation.ErrorCategory.InvalidArgument, value) );');
+                yield cmdletParameter.assign(`global::System.IO.File.ReadAllBytes(${paths.value}[0])`);
+              },
+              description: `Input File for ${cmdletParameter.name} (${escapeString(desc)})`
+            });
+
+            inputFileParameter.add(new Attribute(ParameterAttribute, { parameters: [new LiteralExpression(`Mandatory = ${vParam.required ? 'true' : 'false'}`), new LiteralExpression(`HelpMessage = "Input File for ${cmdletParameter.name} (${escapeString(desc || '.')})"`)] }));
+            inputFileParameter.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Body`] }));
+
+            $this.add(inputFileParameter);
+          } else {
+            cmdletParameter.add(new Attribute(ParameterAttribute, { parameters: [new LiteralExpression(`Mandatory = ${vParam.required ? 'true' : 'false'}`), new LiteralExpression(`HelpMessage = "${escapeString(desc || '.')}"`)] }));
+            cmdletParameter.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Body`] }));
+            addInfoAttribute(cmdletParameter, propertyType, !!vParam.required, false, desc, (<NewVirtualProperty>vParam.origin).property.serializedName);
+            NewAddCompleterInfo(cmdletParameter, vParam);
+            addDefaultInfo(cmdletParameter, vParam);
+          }
+
+          const isEnum = !(propertyType.schema instanceof NewSchema) && propertyType.schema.details.csharp.enum !== undefined;
+          const hasEnum = propertyType instanceof ArrayOf && propertyType.elementType instanceof EnumImplementation;
+          if (isEnum || hasEnum) {
+            cmdletParameter.add(new Attribute(ArgumentCompleterAttribute, { parameters: [`typeof(${hasEnum ? (<ArrayOf>propertyType).elementType.declaration : propertyType.declaration})`] }));
+          }
+          // add aliases if there is any
+          if (length(vParam.alias) > 0) {
+            cmdletParameter.add(new Attribute(Alias, { parameters: vParam.alias.map(x => '"' + x + '"') }));
+          }
+
+          this.add(cmdletParameter);
+        }
+        // skip-for-time-being
+        // if (parameter.schema.additionalProperties) {
+        //   // if there is an additional properties on this type
+        //   // add a hashtable parameter for additionalProperties
+        //   let apPropName = '';
+        //   const options = ['AdditionalProperties', 'MoreProperties', 'ExtendedProperties', 'Properties'];
+        //   for (const n of options) {
+        //     if (this.properties.find(each => each.name === n)) {
+        //       continue;
+        //     }
+        //     apPropName = n;
+        //     break;
+        //   }
+
+        //   this.apProp = this.add(new Property(apPropName, System.Collections.Hashtable));
+        //   this.apProp.add(new Attribute(ParameterAttribute, {
+        //     parameters: ['Mandatory = false', 'HelpMessage = "Additional Parameters"']
+        //   }));
+        //   this.bodyParameterInfo = {
+        //     type: {
+        //       declaration: parameter.schema.details.csharp.fullname
+        //     },
+        //     valueType: parameter.schema.additionalProperties === true ? System.Object : this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(<Schema>parameter.schema.additionalProperties, true, this.state)
+        //   };
+        // }
+
+        this.bodyParameter = expandedBodyParameter;
+        continue;
+      }
+    }
+
+    // skip-for-time-being
+    // if (this.isViaIdentity) {
+    //   // add in the pipeline parameter for the identity
+
+    //   const idschema = values(this.state.project.model.schemas).first(each => each.details.default.uid === 'universal-parameter-type');
+    //   const idtd = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(<Schema>idschema, true, this.state);
+    //   const idParam = this.add(new BackedProperty('InputObject', idtd, {
+    //     description: 'Identity Parameter'
+    //   }));
+    //   const parameters = [new LiteralExpression('Mandatory = true'), new LiteralExpression('HelpMessage = "Identity Parameter"'), new LiteralExpression('ValueFromPipeline = true')];
+    //   idParam.add(new Attribute(ParameterAttribute, { parameters }));
+    //   idParam.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Path`] }));
+    // }
+    for (const vParam of values(vps.operation)) {
+      if (vParam.name === 'Host') {
+        // skip 'Host'
+        continue;
+      }
+      const vSchema = vParam.schema;
+      const propertyType = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(vSchema, true, this.state);
+
+
+      const origin = <NewIParameter>vParam.origin;
+
+      const regularCmdletParameter = (this.state.project.azure && vParam.name === 'SubscriptionId' && operation.details.csharp.verb.toLowerCase() === 'get') ?
+
+        // special case for subscription id
+        this.add(new BackedProperty(vParam.name, dotnet.StringArray, {
+          metadata: {
+            parameterDefinition: origin.details.csharp.httpParameter
+          },
+          description: vParam.description
+        })) :
+
+        // everything else
+        this.add(new BackedProperty(vParam.name, propertyType, {
+          metadata: {
+            parameterDefinition: origin.details.csharp.httpParameter
+          },
+          description: vParam.description
+        }));
+
+      // skip-for-time-being
+      // if (vSchema.additionalProperties) {
+      //   // we have to figure out if this is a standalone dictionary or a hybrid object/dictionary.
+      //   // if it's a hybrid, we have to create another parameter like -<XXX>AdditionalProperties and have that dump the contents into the dictionary
+      //   // if it's a standalone dictionary, we can just use hashtable instead
+      //   if (length(vSchema.properties) === 0) {
+      //     // it's a pure dictionary
+      //     // change the property type to hashtable.
+      //     // add an attribute to change the exported type.
+      //     regularCmdletParameter.add(new Attribute(ExportAsAttribute, { parameters: [`typeof(${System.Collections.Hashtable})`] }));
+      //   } else {
+      //     // it's a hybrid. We need to add an additional property that puts its items into the target container
+
+      //   }
+
+      // }
+
+      this.thingsToSerialize.push(regularCmdletParameter);
+
+      const parameters = [new LiteralExpression(`Mandatory = ${vParam.required ? 'true' : 'false'}`), new LiteralExpression(`HelpMessage = "${escapeString(vParam.description) || '.'}"`)];
+      if (origin.details.csharp.isBodyParameter) {
+        parameters.push(new LiteralExpression('ValueFromPipeline = true'));
+        this.bodyParameter = regularCmdletParameter;
+      }
+      regularCmdletParameter.add(new Attribute(ParameterAttribute, { parameters }));
+      if (vParam.schema.type === SchemaType.Array) {
+        regularCmdletParameter.add(new Attribute(AllowEmptyCollectionAttribute));
+      }
+
+      addInfoAttribute(regularCmdletParameter, propertyType, vParam.required, false, vParam.description, vParam.origin.name);
+      NewAddCompleterInfo(regularCmdletParameter, vParam);
+      addDefaultInfo(regularCmdletParameter, vParam);
+
+      // add aliases if there is any
+      if (length(vParam.alias) > 0) {
+        regularCmdletParameter.add(new Attribute(Alias, { parameters: vParam.alias.map(x => '"' + x + '"') }));
+      }
+
+      const httpParam = origin.details.csharp.httpParameter;
+      const uid = httpParam ? httpParam.details.csharp.uid : 'no-parameter';
+
+      // skip-for-time-being
+      // const cat = values(operation.callGraph[0].parameters).
+      //   where(each => !(each.details.csharp.constantValue)).
+      //   first(each => each.details.csharp.uid === uid);
+
+      // if (cat) {
+      //   regularCmdletParameter.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.${pascalCase(cat.in)}`] }));
+      // }
+
+
+      if (origin.details.csharp.completer) {
+        // add the completer to this class and tag this parameter with the completer.
+        // regularCmdletParameter.add(new Attribute(ArgumentCompleterAttribute, { parameters: [`typeof(${this.declaration})`] }));
+      }
+
+      const isEnum = !(propertyType.schema instanceof NewSchema) && propertyType.schema.details.csharp.enum !== undefined;
+      const hasEnum = propertyType instanceof ArrayOf && propertyType.elementType instanceof EnumImplementation;
+      if (isEnum || hasEnum) {
+        regularCmdletParameter.add(new Attribute(ArgumentCompleterAttribute, { parameters: [`typeof(${hasEnum ? (<ArrayOf>propertyType).elementType.declaration : propertyType.declaration})`] }));
+      }
+    }
+    const ifmatch = this.properties.find((v) => v.name.toLowerCase() === 'ifmatch');
+    if (ifmatch) {
+      //no sure why there is an empty block
+    }
+
+  }
+
+
+  private NewAddClassAttributes(operation: CommandOperation, variantName: string) {
+    const cmdletAttribParams: Array<ExpressionOrLiteral> = [
+      category[operation.details.csharp.verb] ? verbEnum(category[operation.details.csharp.verb], operation.details.csharp.verb) : `"${operation.details.csharp.verb}"`,
+      new StringExpression(variantName)
+    ];
+
+    if (this.NewIsWritableCmdlet(operation)) {
+      cmdletAttribParams.push('SupportsShouldProcess = true');
+    }
+
+    if (operation.details.csharp.hidden) {
+      this.add(new Attribute(InternalExportAttribute));
+      const noun = `${operation.details.csharp.subjectPrefix}${operation.details.csharp.subject}`;
+      const cmdletName = `${operation.details.csharp.verb}-${noun}${operation.details.csharp.name ? `_${operation.details.csharp.name}` : ''}`;
+      this.state.message({ Channel: Channel.Debug, Text: `[DIRECTIVE] Applied 'hidden' directive to ${cmdletName}. Added attribute ${InternalExportAttribute.declaration} to cmdlet.` });
+    }
+
+    this.add(new Attribute(CmdletAttribute, { parameters: cmdletAttribParams }));
+
+    // add alias attribute if there is any aliases for this cmdlet
+    if (length(operation.details.csharp.alias) > 0) {
+      this.add(new Attribute(Alias, { parameters: operation.details.csharp.alias.map((x: string) => '"' + x + '"') }));
+    }
+
+    let shouldAddPassThru = false;
+    // set to hold the output types
+    const outputTypes = new Set<string>();
+    for (const httpOperation of values(operation.callGraph)) {
+      const pageableInfo = httpOperation.language.csharp?.pageable;
+      const v = httpOperation.responses && httpOperation.responses.length > 0 && httpOperation.responses[0] instanceof SchemaResponse;
+      for (const schema of values(httpOperation.responses).selectNonNullable(each => (<SchemaResponse>each).schema)) {
+
+        const props = NewGetAllProperties(schema);
+
+        // does the target type just wrap a single output?
+        const resultSchema = length(props) !== 1 ? <NewSchema>schema : <NewSchema>props[0].schema;
+
+        // make sure return type for boolean stays boolean!
+        if (resultSchema.type === SchemaType.Boolean) {
+          outputTypes.add(`typeof(${dotnet.Bool})`);
+        } else {
+          const typeDeclaration = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(resultSchema, true, this.state);
+
+          if (typeDeclaration.declaration === System.IO.Stream.declaration || typeDeclaration.declaration === dotnet.Binary.declaration) {
+            // if this is a stream, skip the output type.
+            this.hasStreamOutput = true;
+            shouldAddPassThru = true;
+            outputTypes.add(`typeof(${dotnet.Bool})`);
+          } else {
+
+            let type = '';
+            if (typeDeclaration instanceof ArrayOf) {
+              type = typeDeclaration.elementTypeDeclaration;
+            } else if (!(typeDeclaration.schema instanceof NewSchema) && pageableInfo && pageableInfo.responseType === 'pageable') {
+              if (typeDeclaration === undefined || typeDeclaration.schema.properties[pageableInfo.itemName] === undefined) {
+                //skip-for-time-being, since operationId does not support in m4 any more
+                //throw new Error(`\n\nOn operation:\n  '${httpOperation.operationId}' at '${httpOperation.path}'\n  -- you have used 'x-ms-pageable' and there is no property name '${pageableInfo.itemName}' that is an array.\n\n`);
+                throw new Error('An error needs to be more specific');
+              }
+              const nestedSchema = typeDeclaration.schema.properties[pageableInfo.itemName].schema;
+              // skip-for-time-being
+              //const nestedTypeDeclaration = this.state.project.schemaDefinitionResolver.resolveTypeDeclaration(nestedSchema, true, this.state);
+              //type = (<ArrayOf>nestedTypeDeclaration).elementTypeDeclaration;
+            } else {
+              type = typeDeclaration.declaration;
+            }
+            // check if this is a stream output
+            if (type) {
+              outputTypes.add(`typeof(${type})`);
+            }
+          }
+        }
+
+      }
+    }
+
+    // if any response does not return,
+    // the cmdlet should have a PassThru parameter
+    shouldAddPassThru = shouldAddPassThru || values(operation.callGraph)
+      .selectMany(httpOperation => values(httpOperation.responses))
+      //.selectMany(responsesItem => responsesItem.value)
+      .any(value => value instanceof SchemaResponse);
     if (outputTypes.size === 0) {
       outputTypes.add(`typeof(${dotnet.Bool})`);
     }

--- a/powershell/cmdlets/namespace.ts
+++ b/powershell/cmdlets/namespace.ts
@@ -5,7 +5,7 @@
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
 import { Schema, ClientRuntime } from '../llcsharp/exports';
-import { State } from '../internal/state';
+import { State, NewState } from '../internal/state';
 import { CmdletClass } from './class';
 import { DeepPartial } from '@azure-tools/codegen';
 
@@ -30,6 +30,33 @@ export class CmdletNamespace extends Namespace {
         continue;
       }
       this.addClass(await new CmdletClass(this, operation, this.state.path('commands', 'operations', index)).init());
+    }
+    return this;
+  }
+}
+
+export class NewCmdletNamespace extends Namespace {
+  inputModels = new Array<Schema>();
+  public get outputFolder(): string {
+    return this.state.project.cmdletFolder;
+  }
+
+  constructor(parent: Namespace, private state: NewState, objectInitializer?: DeepPartial<CmdletNamespace>) {
+    super('Cmdlets', parent);
+    this.apply(objectInitializer);
+  }
+
+  async init() {
+    this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
+
+    // generate cmdlet classes on top of the SDK
+    for (const { key: index, value: operation } of items(this.state.model.commands.operations)) {
+      // skip ViaIdentity for set-* cmdlets.
+      if (this.state.project.azure && operation.details.csharp.verb === 'Set' && operation.details.csharp.name.indexOf('ViaIdentity') > 0) {
+        continue;
+      }
+      // skip-for-time-being
+      //this.addClass(await new CmdletClass(this, operation, this.state.path('commands', 'operations', index)).init());
     }
     return this;
   }

--- a/powershell/cmdlets/namespace.ts
+++ b/powershell/cmdlets/namespace.ts
@@ -6,7 +6,7 @@ import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
 import { Schema, ClientRuntime } from '../llcsharp/exports';
 import { State, NewState } from '../internal/state';
-import { CmdletClass } from './class';
+import { CmdletClass, NewCmdletClass } from './class';
 import { DeepPartial } from '@azure-tools/codegen';
 
 export class CmdletNamespace extends Namespace {
@@ -56,7 +56,7 @@ export class NewCmdletNamespace extends Namespace {
         continue;
       }
       // skip-for-time-being
-      //this.addClass(await new CmdletClass(this, operation, this.state.path('commands', 'operations', index)).init());
+      this.addClass(await new NewCmdletClass(this, operation, this.state.path('commands', 'operations', index)).init());
     }
     return this;
   }

--- a/powershell/enums/namespace.ts
+++ b/powershell/enums/namespace.ts
@@ -5,7 +5,7 @@
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { EnumDetails } from '@azure-tools/codemodel-v3';
 import { If, Parameter, Method, Namespace, System, Struct, Attribute, Class, dotnet, LambdaMethod, LiteralExpression, Modifier } from '@azure-tools/codegen-csharp';
-import { State } from '../internal/state';
+import { State, NewState } from '../internal/state';
 import { IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType, TypeConverterAttribute, PSTypeConverter } from '../internal/powershell-declarations';
 import { join } from 'path';
 import { DeepPartial } from '@azure-tools/codegen';
@@ -117,5 +117,114 @@ export class EnumNamespace extends Namespace {
       enumClass.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
 
     }
+  }
+}
+export class NewEnumNamespace extends Namespace {
+  public get outputFolder(): string {
+    return join(this.state.project.apiFolder, 'Support');
+  }
+
+  constructor(parent: Namespace, public state: NewState, objectInitializer?: DeepPartial<EnumNamespace>) {
+    super('Support', parent);
+    this.apply(objectInitializer);
+    // skip-for-time-being
+    // const enumInfos = values(state.model.schemas)
+    //   .where(each => each.details.csharp.enum !== undefined && !each.details.csharp.skip)
+    //   .select(each => ({ details: <EnumDetails>each.details.csharp.enum, description: each.details.csharp.description }))
+    //   .toArray();
+
+    // const done = new Set<string>();
+
+
+    // for (const enumInfo of enumInfos) {
+    //   if (done.has(enumInfo.details.name)) {
+    //     continue;
+    //   }
+
+    //   done.add(enumInfo.details.name);
+
+    //   if (state.project.azure && /^api-?version$/i.exec(enumInfo.details.name)) {
+    //     continue;
+    //   }
+
+    //   // generate a typeconverter for the enum class too.
+
+    //   const enumValues = values(enumInfo.details.values).select(v => <string>v.value).toArray();
+    //   const enumClass = new Struct(this, enumInfo.details.name, undefined, {
+    //     interfaces: [IArgumentCompleter],
+    //     partial: true,
+    //     description: enumInfo.description || `Argument completer implementation for ${enumInfo.details.name}.`,
+    //     fileName: `${enumInfo.details.name}.Completer`
+    //   });
+    //   const commandName = new Parameter('commandName', System.String, { description: 'The name of the command that needs argument completion.' });
+    //   const parameterName = new Parameter('parameterName', System.String, { description: 'The name of the parameter that needs argument completion.' });
+    //   const wordToComplete = new Parameter('wordToComplete', System.String, { description: 'The (possibly empty) word being completed.' });
+    //   const commandAst = new Parameter('commandAst', CommandAst, { description: 'The command ast in case it is needed for completion.' });
+    //   const fakeBoundParameters = new Parameter('fakeBoundParameters', System.Collections.IDictionary, { description: 'This parameter is similar to $PSBoundParameters, except that sometimes PowerShell cannot or will not attempt to evaluate an argument, in which case you may need to use commandAst.' });
+    //   const completeArgumentParams = [commandName, parameterName, wordToComplete, commandAst, fakeBoundParameters];
+
+    //   enumClass.add(new Method('CompleteArgument', System.Collections.Generic.IEnumerable(CompletionResult), { parameters: completeArgumentParams, description: 'Implementations of this function are called by PowerShell to complete arguments.', returnsDescription: 'A collection of completion results, most like with ResultType set to ParameterValue.' })).add(function* () {
+    //     for (const enumValue of enumValues) {
+    //       yield If(`${System.String.declaration}.IsNullOrEmpty(${wordToComplete.name}) || "${enumValue}".StartsWith(${wordToComplete.name}, ${System.StringComparison.declaration}.InvariantCultureIgnoreCase)`,
+    //         `yield return new ${CompletionResult.declaration}("${enumValue}", "${enumValue}", ${CompletionResultType.declaration}.ParameterValue, "${enumValue}");`);
+    //     }
+    //   });
+
+
+    //   // generate a typeconverter for the enum class too.
+
+    //   const converterClass = new Class(this, `${enumInfo.details.name}TypeConverter`, undefined, {
+    //     interfaces: [PSTypeConverter],
+    //     partial: true,
+    //     description: enumInfo.description || `TypeConverter implementation for ${enumInfo.details.name}.`,
+    //     fileName: `${enumInfo.details.name}.TypeConverter`
+    //   });
+
+    //   converterClass.add(new LambdaMethod('CanConvertFrom', dotnet.Bool, dotnet.True, {
+    //     override: Modifier.Override,
+    //     parameters: [
+    //       new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+    //       new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+    //     ],
+    //     description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+    //     returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
+    //   }));
+
+    //   converterClass.add(new LambdaMethod('CanConvertTo', dotnet.Bool, dotnet.False, {
+    //     override: Modifier.Override,
+    //     parameters: [
+    //       new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+    //       new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+    //     ],
+    //     description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+    //     returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
+    //   }));
+
+    //   converterClass.add(new LambdaMethod('ConvertFrom', dotnet.Object, new LiteralExpression(`${enumInfo.details.name}.CreateFrom(sourceValue)`), {
+    //     override: Modifier.Override,
+    //     parameters: [
+    //       new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+    //       new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+    //       new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+    //       new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+    //     ],
+    //     description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" /> ',
+    //     returnsDescription: `an instance of <see cref="${enumInfo.details.name}" />, or <c>null</c> if there is no suitable conversion.`
+    //   }));
+
+    //   converterClass.add(new LambdaMethod('ConvertTo', dotnet.Object, dotnet.Null, {
+    //     override: Modifier.Override,
+    //     parameters: [
+    //       new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+    //       new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+    //       new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+    //       new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+    //     ], description: 'NotImplemented -- this will return <c>null</c>',
+    //     returnsDescription: 'will always return <c>null</c>.'
+    //   }));
+
+    //   enumClass.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+
+    // }
   }
 }

--- a/powershell/generators/csproj.ts
+++ b/powershell/generators/csproj.ts
@@ -4,11 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Project } from '../internal/project';
+import { NewProject } from '../internal/project';
 
 function removeCd(path: string): string {
   return path.startsWith('./') ? path.replace('./', '') : path;
 }
-export async function generateCsproj(project: Project) {
+export async function generateCsproj(project: Project | NewProject) {
   const release = project.azure ? `    <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>MSSharedLibKey.snk</AssemblyOriginatorKeyFile>

--- a/powershell/generators/gitattributes.ts
+++ b/powershell/generators/gitattributes.ts
@@ -3,8 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 
-export async function generateGitAttributes(project: Project) {
+export async function generateGitAttributes(project: Project | NewProject) {
   project.state.writeFile(project.gitAttributes, '* text=auto', undefined, 'source-file-other');
 }

--- a/powershell/generators/gitignore.ts
+++ b/powershell/generators/gitignore.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Host } from '@azure-tools/autorest-extension-base';
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 
-export async function generateGitIgnore(project: Project) {
+export async function generateGitIgnore(project: Project | NewProject) {
   project.state.writeFile(project.gitIgnore, `bin
 obj
 .vs

--- a/powershell/generators/nuspec.ts
+++ b/powershell/generators/nuspec.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Host } from '@azure-tools/autorest-extension-base';
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 
 function removeCd(path: string): string {
   return path.startsWith('./') ? path.replace('./', '') : path;
 }
-export async function generateNuspec(project: Project) {
+export async function generateNuspec(project: Project | NewProject) {
   const dependencies = project.azure ? `
     <dependencies>
       <dependency id="Az.Accounts" version="${project.accountsVersionMinimum}" />

--- a/powershell/generators/psm1.custom.ts
+++ b/powershell/generators/psm1.custom.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Host } from '@azure-tools/autorest-extension-base';
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 import { PSScriptFile } from '../file-formats/psscript-file';
 import { relative } from 'path';
 
-export async function generatePsm1Custom(project: Project) {
+export async function generatePsm1Custom(project: Project | NewProject) {
   const psm1 = new PSScriptFile(await project.state.readFile(project.psm1Custom) || '');
   const dllPath = relative(project.customFolder, project.dll);
   const internalPath = relative(project.customFolder, project.psm1Internal);

--- a/powershell/generators/psm1.internal.ts
+++ b/powershell/generators/psm1.internal.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Host } from '@azure-tools/autorest-extension-base';
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 import { PSScriptFile } from '../file-formats/psscript-file';
 import { relative } from 'path';
 import { getProfileExportScript } from './psm1';
 
-export async function generatePsm1Internal(project: Project) {
+export async function generatePsm1Internal(project: Project | NewProject) {
   const psm1 = new PSScriptFile(await project.state.readFile(project.psm1Internal) || '');
   const dllPath = relative(project.internalFolder, project.dll);
   psm1.prepend('Generated', `

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 import { PSScriptFile } from '../file-formats/psscript-file';
 import { relative } from 'path';
+
 
 export function getProfileExportScript(exportFolderScript: string, isAzure: boolean): string {
   return `
@@ -39,7 +40,7 @@ export function getProfileExportScript(exportFolderScript: string, isAzure: bool
 `;
 }
 
-export async function generatePsm1(project: Project) {
+export async function generatePsm1(project: Project | NewProject) {
   const psm1 = new PSScriptFile(await project.state.readFile(project.psm1) || '');
   let azureInitialize = '';
   if (project.azure) {

--- a/powershell/generators/readme.ts
+++ b/powershell/generators/readme.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 import { MdFile } from '../file-formats/md-file';
 
-export async function generateReadme(project: Project) {
+export async function generateReadme(project: Project | NewProject) {
   const md = new MdFile(await project.state.readFile(project.readme) || '');
   let azureInfo = '';
   if (project.azure) {

--- a/powershell/generators/script-cmdlet.ts
+++ b/powershell/generators/script-cmdlet.ts
@@ -4,7 +4,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 import { serialize, indent, setIndentation, applyOverrides, pascalCase } from '@azure-tools/codegen';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { State } from '../internal/state';
@@ -52,7 +52,7 @@ function getType(type: string) {
   return type;
 }
 
-export async function generateScriptCmdlets(project: Project) {
+export async function generateScriptCmdlets(project: Project | NewProject) {
   const commands = await project.state.getValue<Array<ScenarioCommand>>('command', []);
   for (const command of values(commands)) {
     if (!command.action) {

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -377,8 +377,8 @@ export class NewProject extends codeDomProject {
     this.serviceNamespace.header = this.license;
     this.addNamespace(this.serviceNamespace);
 
-    //this.supportNamespace = new NewEnumNamespace(this.serviceNamespace, this.state);
-    //this.supportNamespace.header = this.license;
+    this.supportNamespace = new NewEnumNamespace(this.serviceNamespace, this.state);
+    this.supportNamespace.header = this.license;
     //this.addNamespace(this.supportNamespace);
 
     this.modelsExtensions = new NewModelExtensionsNamespace(this.serviceNamespace, <any>this.state.model.schemas, this.state.path('components', 'schemas'));

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -4,17 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Dictionary } from '@azure-tools/linq';
-import { SchemaDefinitionResolver, SchemaDetails, LanguageDetails, EnhancedTypeDeclaration, Boolean } from '../llcsharp/exports';
-import { State } from './state';
+import { SchemaDefinitionResolver, SchemaDetails, LanguageDetails, EnhancedTypeDeclaration, Boolean, NewSchemaDefinitionResolver } from '../llcsharp/exports';
+import { State, NewState } from './state';
 import { Project as codeDomProject } from '@azure-tools/codegen-csharp';
-import { EnumNamespace } from '../enums/namespace';
-import { ModelExtensionsNamespace } from '../models/model-extensions';
+import { EnumNamespace, NewEnumNamespace } from '../enums/namespace';
+import { ModelExtensionsNamespace, NewModelExtensionsNamespace } from '../models/model-extensions';
 
-import { ModuleNamespace } from '../module/module-namespace';
-import { CmdletNamespace } from '../cmdlets/namespace';
+import { ModuleNamespace, NewModuleNamespace } from '../module/module-namespace';
+import { CmdletNamespace, NewCmdletNamespace } from '../cmdlets/namespace';
 import { Host } from '@azure-tools/autorest-extension-base';
 import { codemodel, PropertyDetails, exportedModels as T, ModelState, JsonType, } from '@azure-tools/codemodel-v3';
 import { DeepPartial } from '@azure-tools/codegen';
+import { PwshModel } from '../utils/PwshModel';
+import { NewModelState } from '../utils/model-state';
+import { Schema as NewSchema } from '@azure-tools/codemodel';
 
 export type Schema = T.SchemaT<LanguageDetails<SchemaDetails>, LanguageDetails<PropertyDetails>>;
 
@@ -48,6 +51,26 @@ export class PSSchemaResolver extends SchemaDefinitionResolver {
           return new PSSwitch(schema, required);
         }
       }
+
+      return super.resolveTypeDeclaration(schema, required, state);
+    } finally {
+      this.inResolve = before;
+    }
+  }
+}
+
+export class NewPSSchemaResolver extends NewSchemaDefinitionResolver {
+  inResolve = false;
+  resolveTypeDeclaration(schema: NewSchema | undefined, required: boolean, state: NewModelState<PwshModel>): EnhancedTypeDeclaration {
+    const before = this.inResolve;
+    try {
+      // skip-for-time-being
+      // if (!this.inResolve) {
+      //   this.inResolve = true;
+      //   if (schema && schema.type === JsonType.Boolean) {
+      //     return new PSSwitch(schema, required);
+      //   }
+      // }
 
       return super.resolveTypeDeclaration(schema, required, state);
     } finally {
@@ -204,6 +227,166 @@ export class Project extends codeDomProject {
 
     // add cmdlet namespace
     this.cmdlets = await new CmdletNamespace(this.serviceNamespace, this.state).init();
+    this.cmdlets.header = this.license;
+    this.addNamespace(this.cmdlets);
+
+
+    // abort now if we have any errors.
+    this.state.checkpoint();
+    return this;
+  }
+}
+
+export class NewProject extends codeDomProject {
+  public azure!: boolean;
+  public license!: string;
+  public cmdletFolder!: string;
+
+  public customFolder!: string;
+  public internalFolder!: string;
+  public testFolder!: string;
+  public runtimeFolder!: string;
+  public binFolder!: string;
+  public objFolder!: string;
+  public exportsFolder!: string;
+  public docsFolder!: string;
+  public examplesFolder!: string;
+  public resourcesFolder!: string;
+  public serviceName!: string;
+  public moduleName!: string;
+  public csproj!: string;
+  public nuspec!: string;
+  public gitIgnore!: string;
+  public gitAttributes!: string;
+  public readme!: string;
+  public dllName!: string;
+  public dll!: string;
+  public psd1!: string;
+  public psm1!: string;
+  public psm1Custom!: string;
+  public psm1Internal!: string;
+  public formatPs1xml!: string;
+  public apiFolder!: string;
+  public baseFolder!: string;
+  public moduleFolder!: string;
+  public schemaDefinitionResolver!: NewSchemaDefinitionResolver;
+  public moduleVersion!: string;
+  public profiles!: Array<string>;
+
+  public prefix!: string;
+  public subjectPrefix!: string;
+  public projectNamespace!: string;
+  public overrides!: Dictionary<string>;
+  public serviceNamespace!: NewModuleNamespace;
+  public supportNamespace!: NewEnumNamespace;
+  public cmdlets!: NewCmdletNamespace;
+
+  public modelsExtensions!: NewModelExtensionsNamespace;
+  public accountsVersionMinimum!: string;
+  public dependencyModuleFolder!: string;
+  public metadata!: Metadata;
+  public state!: NewState;
+  public helpLinkPrefix!: string;
+  get model() { return <PwshModel>this.state.model; }
+
+  constructor(protected service: Host, objectInitializer?: DeepPartial<Project>) {
+    super();
+    this.apply(objectInitializer);
+  }
+
+
+  public async init(): Promise<this> {
+    await super.init();
+    this.state = await new NewState(this.service).init(this);
+
+    this.schemaDefinitionResolver = new NewPSSchemaResolver();
+
+    this.projectNamespace = this.state.model.language.csharp?.namespace || '';
+
+
+    this.overrides = {
+      'Carbon.Json.Converters': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Internal.Extensions': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Internal': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Data': `${this.projectNamespace}.Runtime.Json`,
+      'using Data;': '',
+      'using Parser;': '',
+      'using Converters;': '',
+      'using Internal.Extensions;': '',
+
+      'Carbon.Json.Parser': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Json': `${this.projectNamespace}.Runtime.Json`,
+      'Microsoft.Rest.ClientRuntime': `${this.projectNamespace}.Runtime`,
+      'Microsoft.Rest': `${this.projectNamespace}`,
+    };
+
+    // Values
+    this.moduleVersion = await this.state.getValue('module-version');
+    // skip-for-time-being
+    //this.profiles = this.model.info.extensions['x-ms-metadata'].profiles || [];
+    this.profiles = [];
+    this.accountsVersionMinimum = '1.7.4';
+    this.helpLinkPrefix = await this.state.getValue('help-link-prefix');
+    this.metadata = await this.state.getValue<Metadata>('metadata');
+    this.license = await this.state.getValue('header-text', '');
+
+    // Flags
+    this.azure = this.model.language.default.isAzure;
+
+    // Names
+    this.prefix = this.model.language.default.prefix;
+    this.serviceName = this.model.language.default.serviceName;
+    this.subjectPrefix = this.model.language.default.subjectPrefix;
+    this.moduleName = await this.state.getValue('module-name');
+    this.dllName = await this.state.getValue('dll-name');
+
+    // Folders
+    this.baseFolder = await this.state.getValue('current-folder');
+    this.moduleFolder = await this.state.getValue('module-folder');
+    this.cmdletFolder = await this.state.getValue('cmdlet-folder');
+
+    this.customFolder = await this.state.getValue('custom-cmdlet-folder');
+    this.internalFolder = await this.state.getValue('internal-cmdlet-folder');
+    this.testFolder = await this.state.getValue('test-folder');
+    this.runtimeFolder = await this.state.getValue('runtime-folder');
+    this.apiFolder = await this.state.getValue('api-folder');
+
+    this.binFolder = await this.state.getValue('bin-folder');
+    this.objFolder = await this.state.getValue('obj-folder');
+    this.exportsFolder = await this.state.getValue('exports-folder');
+    this.docsFolder = await this.state.getValue('docs-folder');
+    this.dependencyModuleFolder = await this.state.getValue('dependency-module-folder');
+    this.examplesFolder = await this.state.getValue('examples-folder');
+    this.resourcesFolder = await this.state.getValue('resources-folder');
+
+    // File paths
+    this.csproj = await this.state.getValue('csproj');
+    this.dll = await this.state.getValue('dll');
+    this.psd1 = await this.state.getValue('psd1');
+    this.psm1 = await this.state.getValue('psm1');
+    this.psm1Custom = await this.state.getValue('psm1-custom');
+    this.psm1Internal = await this.state.getValue('psm1-internal');
+    this.formatPs1xml = await this.state.getValue('format-ps1xml');
+    this.nuspec = await this.state.getValue('nuspec');
+    this.gitIgnore = `${this.baseFolder}/.gitignore`;
+    this.gitAttributes = `${this.baseFolder}/.gitattributes`;
+    this.readme = `${this.baseFolder}/readme.md`;
+
+    // add project namespace
+    this.serviceNamespace = new NewModuleNamespace(this.state);
+    this.serviceNamespace.header = this.license;
+    this.addNamespace(this.serviceNamespace);
+
+    //this.supportNamespace = new NewEnumNamespace(this.serviceNamespace, this.state);
+    //this.supportNamespace.header = this.license;
+    //this.addNamespace(this.supportNamespace);
+
+    this.modelsExtensions = new NewModelExtensionsNamespace(this.serviceNamespace, <any>this.state.model.schemas, this.state.path('components', 'schemas'));
+    this.modelsExtensions.header = this.license;
+    this.addNamespace(this.modelsExtensions);
+
+    // add cmdlet namespace
+    this.cmdlets = await new NewCmdletNamespace(this.serviceNamespace, this.state).init();
     this.cmdlets.header = this.license;
     this.addNamespace(this.cmdlets);
 

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -379,7 +379,7 @@ export class NewProject extends codeDomProject {
 
     this.supportNamespace = new NewEnumNamespace(this.serviceNamespace, this.state);
     this.supportNamespace.header = this.license;
-    //this.addNamespace(this.supportNamespace);
+    this.addNamespace(this.supportNamespace);
 
     this.modelsExtensions = new NewModelExtensionsNamespace(this.serviceNamespace, <any>this.state.model.schemas, this.state.path('components', 'schemas'));
     this.modelsExtensions.header = this.license;

--- a/powershell/internal/state.ts
+++ b/powershell/internal/state.ts
@@ -5,9 +5,11 @@
 
 import { codemodel, ModelState } from '@azure-tools/codemodel-v3';
 
-import { Host, JsonPath } from '@azure-tools/autorest-extension-base';
-import { Project } from './project';
+import { Host, JsonPath, Session } from '@azure-tools/autorest-extension-base';
+import { Project, NewProject } from './project';
 import { DeepPartial } from '@azure-tools/codegen';
+import { PwshModel } from '../utils/PwshModel';
+import { NewModelState } from '../utils/model-state';
 
 
 export interface GeneratorSettings {
@@ -45,3 +47,25 @@ export class State extends ModelState<codemodel.Model> {
   }
 }
 
+export class NewState extends NewModelState<PwshModel> {
+  project!: NewProject;
+
+  public constructor(service: Host, objectInitializer?: DeepPartial<State>) {
+    super(service);
+    this.apply(objectInitializer);
+  }
+
+  async init(project?: NewProject) {
+    if (project) {
+      this.project = project;
+    }
+    return await super.init(project);
+  }
+
+  path(...childPath: JsonPath) {
+    // const result = new State(this.service, this);
+    // result.currentPath = [...this.currentPath, ...childPath];
+    //return result;
+    return this;
+  }
+}

--- a/powershell/llcsharp/enums/namespace.ts
+++ b/powershell/llcsharp/enums/namespace.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Namespace } from '@azure-tools/codegen-csharp';
-import { State } from '../generator';
+import { State, NewState } from '../generator';
 import { DeepPartial } from '@azure-tools/codegen';
 
 export class SupportNamespace extends Namespace {
-  constructor(parent: Namespace, private state: State, objectInitializer?: DeepPartial<SupportNamespace>) {
+  constructor(parent: Namespace, private state: State | NewState, objectInitializer?: DeepPartial<SupportNamespace>) {
     super('Support', parent);
     this.apply(objectInitializer);
   }

--- a/powershell/llcsharp/generator.ts
+++ b/powershell/llcsharp/generator.ts
@@ -4,12 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ModelState } from '@azure-tools/codemodel-v3';
+import { codeModelSchema } from '@azure-tools/codemodel';
 import { Model } from './code-model';
-import { Host, JsonPath } from '@azure-tools/autorest-extension-base';
+import { Host, JsonPath, Session, startSession } from '@azure-tools/autorest-extension-base';
 
-import { Project } from './project';
+import { Project, NewProject } from './project';
 import { Dictionary } from '@azure-tools/linq';
 import { DeepPartial } from '@azure-tools/codegen';
+import { PwshModel } from '../utils/PwshModel';
+import { NewModelState } from '../utils/model-state';
 
 export class State extends ModelState<Model> {
   project!: Project;
@@ -24,6 +27,31 @@ export class State extends ModelState<Model> {
       this.project = project;
     }
     return await super.init(project);
+  }
+
+  path(...childPath: JsonPath) {
+    // const result = new State(this.service, this);
+    // result.currentPath = [...this.currentPath, ...childPath];
+    //return result;
+    return this;
+  }
+}
+
+export class NewState extends NewModelState<PwshModel> {
+  project!: NewProject;
+
+  public constructor(service: Host, objectInitializer?: DeepPartial<State>) {
+    super(service);
+    this.apply(objectInitializer);
+  }
+
+  async init(project?: NewProject) {
+    if (project) {
+      this.project = project;
+    }
+    //const session = await startSession<PwshModel>(this.service, {}, codeModelSchema);
+    return await super.init(project);
+    //return await super.init(project);
   }
 
   path(...childPath: JsonPath) {

--- a/powershell/llcsharp/model/interface.ts
+++ b/powershell/llcsharp/model/interface.ts
@@ -8,9 +8,10 @@ import { KnownMediaType, JsonType, getPolymorphicBases } from '@azure-tools/code
 import { Expression, ExpressionOrLiteral, Interface, Namespace, OneOrMoreStatements, Variable, Access, InterfaceProperty, Attribute, StringExpression, LiteralExpression, Property, TypeDeclaration } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
-import { State } from '../generator';
+import { Schema as NewSchema, Language } from '@azure-tools/codemodel';
+import { State, NewState } from '../generator';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
-import { ModelClass } from './model-class';
+import { ModelClass, NewModelClass } from './model-class';
 import { TypeContainer } from '@azure-tools/codegen-csharp';
 import { DeepPartial } from '@azure-tools/codegen';
 import { values } from '@azure-tools/linq';
@@ -222,3 +223,155 @@ export class ModelInterface extends Interface implements EnhancedTypeDeclaration
   }
 }
 
+export class NewModelInterface extends Interface implements EnhancedTypeDeclaration {
+  get schema(): NewSchema {
+    return this.classImplementation.schema;
+  }
+
+  get defaultOfType() {
+    return this.classImplementation.defaultOfType;
+  }
+
+  get convertObjectMethod() {
+    return this.classImplementation.convertObjectMethod;
+  }
+  deserializeFromContainerMember(mediaType: KnownMediaType, container: ExpressionOrLiteral, serializedName: string, defaultValue: Expression): Expression {
+    return this.classImplementation.deserializeFromContainerMember(mediaType, container, serializedName, defaultValue);
+  }
+  deserializeFromNode(mediaType: KnownMediaType, node: ExpressionOrLiteral, defaultValue: Expression): Expression {
+    return this.classImplementation.deserializeFromNode(mediaType, node, defaultValue);
+  }
+  /** emits an expression to deserialize content from a string */
+  deserializeFromString(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    return this.classImplementation.deserializeFromString(mediaType, content, defaultValue);
+  }
+
+  /** emits an expression to deserialize content from a content/response */
+  deserializeFromResponse(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    return this.classImplementation.deserializeFromResponse(mediaType, content, defaultValue);
+  }
+
+  /** emits an expression serialize this to a HttpContent */
+  serializeToContent(mediaType: KnownMediaType, value: ExpressionOrLiteral, mode: Expression): Expression {
+    return this.classImplementation.serializeToContent(mediaType, value, mode);
+  }
+
+  serializeToNode(mediaType: KnownMediaType, value: ExpressionOrLiteral, serializedName: string, mode: Expression): Expression {
+    return this.classImplementation.serializeToNode(mediaType, value, serializedName, mode);
+  }
+  serializeToContainerMember(mediaType: KnownMediaType, value: ExpressionOrLiteral, container: Variable, serializedName: string, mode: Expression): OneOrMoreStatements {
+    return this.classImplementation.serializeToContainerMember(mediaType, value, container, serializedName, mode);
+  }
+
+  get isXmlAttribute(): boolean {
+    return this.classImplementation.isXmlAttribute;
+  }
+
+  public isNullable = true;
+
+  get isRequired(): boolean {
+    return this.classImplementation.isRequired;
+  }
+
+  public validatePresence(eventListener: Variable, property: Variable): OneOrMoreStatements {
+    return this.classImplementation.validatePresence(eventListener, property);
+  }
+  public validateValue(eventListener: Variable, property: Variable): OneOrMoreStatements {
+    return this.classImplementation.validateValue(eventListener, property);
+  }
+
+  get hasHeaderProperties(): boolean {
+    // disabled
+    // return this.classImplementation.hasHeaderProperties; 
+    return false;
+  }
+  constructor(parent: TypeContainer, interfaceName: string, public classImplementation: NewModelClass, public state: NewState, objectInitializer?: DeepPartial<ModelInterface>) {
+    super(parent, interfaceName);
+    this.partial = true;
+    this.apply(objectInitializer);
+  }
+
+  get isInternal(): boolean {
+    return this.accessModifier === Access.Internal;
+  }
+
+  init() {
+    (<any>this).init = () => { }; // only allow a single init!
+    this.schema.language.csharp = this.schema.language.csharp || new Language();
+    const implData = (this.schema.language.csharp = this.schema.language.csharp || {});
+    //implData.interfaceImplementation = this;
+    this.description = `${this.schema.language.csharp.description}`;
+
+    const virtualProperties = this.schema.language.csharp.virtualProperties || {
+      owned: [],
+      inherited: [],
+      inlined: []
+    };
+    // skip-for-time-being
+    // if (this.schema.language.csharp.virtualProperties) {
+
+    //   for (const virtualProperty of values(virtualProperties.owned)) {
+    //     if (virtualProperty.private && !this.isInternal) {
+    //       continue;
+    //     }
+
+    //     const modelProperty = virtualProperty.property;
+
+    //     const internalSet = !!(!this.isInternal && (modelProperty.details.csharp.readOnly || modelProperty.details.csharp.constantValue));
+
+    //     const isRequired = !!modelProperty.details.csharp.required;
+    //     const pType = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>modelProperty.schema, isRequired, this.state.path('schema'));
+    //     const p = this.add(new InterfaceProperty(virtualProperty.name, pType, {
+    //       description: modelProperty.details.csharp.description,
+    //       setAccess: internalSet ? Access.Internal : Access.Public
+    //     }));
+
+    //     this.addInfoAttribute(p, pType, isRequired, internalSet, modelProperty.details.csharp.description, modelProperty.serializedName);
+
+    //     if (!this.isInternal && modelProperty.details.csharp.constantValue !== undefined) {
+    //       p.setAccess = Access.Internal;
+    //     }
+    //   }
+
+    //   for (const virtualProperty of values(virtualProperties.inlined)) {
+
+    //     // don't publicly expose the 'private' properties.
+    //     if (virtualProperty.private && !this.isInternal) {
+    //       continue;
+    //     }
+
+    //     const modelProperty = virtualProperty.property;
+    //     const isRequired = !!modelProperty.details.csharp.required;
+    //     const pType = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>modelProperty.schema, isRequired, this.state.path('schema'));
+
+    //     const internalSet = !!(!this.isInternal && (modelProperty.details.csharp.readOnly || modelProperty.details.csharp.constantValue));
+
+    //     const p = this.add(new InterfaceProperty(virtualProperty.name, pType, {
+    //       description: modelProperty.details.csharp.description,
+    //       setAccess: internalSet ? Access.Internal : Access.Public
+    //     }));
+    //     this.addInfoAttribute(p, pType, isRequired, internalSet, modelProperty.details.csharp.description, modelProperty.serializedName);
+
+    //   }
+    // }
+
+    if (!this.isInternal) {
+      // mark it as json serializable
+      if (!this.schema.language.csharp.isHeaderModel) {
+        if (this.state.project.jsonSerialization) {
+          this.interfaces.push(ClientRuntime.IJsonSerializable);
+        }
+        if (this.state.project.xmlSerialization) {
+          this.interfaces.push(ClientRuntime.IXmlSerializable);
+        }
+      }
+    }
+    return this;
+  }
+
+  addInfoAttribute(p: Property, pType: TypeDeclaration, isRequired: boolean, internalSet: boolean, description: string, serializedName: string) {
+    if (!this.isInternal) {
+      return addInfoAttribute(p, pType, isRequired, internalSet, description, serializedName);
+    }
+  }
+}

--- a/powershell/llcsharp/model/model-class-json.ts
+++ b/powershell/llcsharp/model/model-class-json.ts
@@ -2,7 +2,9 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { Schema as NewSchema, ObjectSchema } from '@azure-tools/codemodel';
 import { KnownMediaType, HeaderProperty, HeaderPropertyType, getAllProperties } from '@azure-tools/codemodel-v3';
+import { getAllProperties as newGetAllProperties } from '@azure-tools/codemodel';
 import { EOL, DeepPartial, } from '@azure-tools/codegen';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { Access, Modifier, StringExpression, Expression, System } from '@azure-tools/codegen-csharp';
@@ -22,7 +24,7 @@ import { Ternery } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 
 import { dotnet } from '@azure-tools/codegen-csharp';
-import { ModelClass } from './model-class';
+import { ModelClass, NewModelClass } from './model-class';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
 import { popTempVar, pushTempVar } from '../schema/primitive';
 
@@ -96,7 +98,8 @@ export class JsonSerializableClass extends Class {
 
     for (const each of values(modelClass.backingFields)) {
       serializeStatements.add(`${each.field.value}?.ToJson(${container}, ${mode.use});`);
-      if ((<EnhancedTypeDeclaration>each.typeDeclaration).schema.additionalProperties) {
+      const sch = (<EnhancedTypeDeclaration>each.typeDeclaration).schema;
+      if (!(sch instanceof NewSchema) && (sch.additionalProperties)) {
         deserializeStatements.add(`${each.field.value} = new ${each.className}(json${this.excludes});`);
       } else {
         deserializeStatements.add(`${each.field.value} = new ${each.className}(json);`);
@@ -184,6 +187,218 @@ export class JsonSerializableClass extends Class {
             }
           });
         }
+        yield Return($this.new(json, toExpression($excludes.substring(1))));
+      } else {
+        // just tell it to create the instance (providing that it's a JSonObject)
+        yield Return(Ternery(json.check, $this.new(json), dotnet.Null));
+      }
+    });
+
+    return super.definition;
+  }
+
+  public get fileName(): string {
+    return `${super.fileName}.json`;
+  }
+
+  protected addPartialMethods() {
+    // add partial methods for future customization
+    this.btj = this.addMethod(new PartialMethod('BeforeToJson', dotnet.Void, {
+      access: Access.Default,
+      parameters: [
+        new Parameter('container', ClientRuntime.JsonObject, { modifier: ParameterModifier.Ref, description: 'The JSON container that the serialization result will be placed in.' }),
+        new Parameter('returnNow', dotnet.Bool, { modifier: ParameterModifier.Ref, description: 'Determines if the rest of the serialization should be processed, or if the method should return instantly.' }),
+      ],
+      description: `<c>BeforeToJson</c> will be called before the json serialization has commenced, allowing complete customization of the object before it is serialized.
+      If you wish to disable the default serialization entirely, return <c>true</c> in the <see "returnNow" /> output parameter.
+      Implement this method in a partial class to enable this behavior.`
+    }));
+
+    this.atj = this.addMethod(new PartialMethod('AfterToJson', dotnet.Void, {
+      access: Access.Default,
+      parameters: [
+        new Parameter('container', ClientRuntime.JsonObject, { modifier: ParameterModifier.Ref, description: 'The JSON container that the serialization result will be placed in.' }),
+      ],
+      description: `<c>AfterToJson</c> will be called after the json erialization has finished, allowing customization of the <see cref="${ClientRuntime.JsonObject}" /> before it is returned. Implement this method in a partial class to enable this behavior `
+    }));
+
+    this.bfj = this.addMethod(new PartialMethod('BeforeFromJson', dotnet.Void, {
+      access: Access.Default,
+      parameters: [
+        new Parameter('json', ClientRuntime.JsonObject, { description: 'The JsonNode that should be deserialized into this object.' }),
+        new Parameter('returnNow', dotnet.Bool, { modifier: ParameterModifier.Ref, description: 'Determines if the rest of the deserialization should be processed, or if the method should return instantly.' }),
+      ],
+      description: `<c>BeforeFromJson</c> will be called before the json deserialization has commenced, allowing complete customization of the object before it is deserialized.
+      If you wish to disable the default deserialization entirely, return <c>true</c> in the <see "returnNow" /> output parameter.
+      Implement this method in a partial class to enable this behavior.`
+    }));
+
+    this.afj = this.addMethod(new PartialMethod('AfterFromJson', dotnet.Void, {
+      access: Access.Default,
+      parameters: [
+        new Parameter('json', ClientRuntime.JsonObject, { description: 'The JsonNode that should be deserialized into this object.' }),
+      ],
+      description: '<c>AfterFromJson</c> will be called after the json deserialization has finished, allowing customization of the object before it is returned. Implement this method in a partial class to enable this behavior '
+    }));
+  }
+}
+
+export class NewJsonSerializableClass extends Class {
+  private btj!: Method;
+  private atj!: Method;
+  private bfj!: Method;
+  private afj!: Method;
+  private excludes: string;
+
+  constructor(protected modelClass: NewModelClass, objectInitializer?: DeepPartial<JsonSerializableClass>) {
+    super(modelClass.namespace, modelClass.name);
+    this.apply(objectInitializer);
+    this.partial = true;
+    this.description = modelClass.description;
+    this.addPartialMethods();
+
+    // set up the declaration for the toJson method.
+    const container = new Parameter('container', ClientRuntime.JsonObject, { description: `The <see cref="${ClientRuntime.JsonObject}"/> container to serialize this object into. If the caller passes in <c>null</c>, a new instance will be created and returned to the caller.` });
+    const mode = new Parameter('serializationMode', ClientRuntime.SerializationMode, { description: `Allows the caller to choose the depth of the serialization. See <see cref="${ClientRuntime.SerializationMode}"/>.` });
+
+    const toJsonMethod = this.addMethod(new Method('ToJson', ClientRuntime.JsonNode, {
+      parameters: [container, mode],
+      description: `Serializes this instance of <see cref="${this.name}" /> into a <see cref="${ClientRuntime.JsonNode}" />.`,
+      returnsDescription: `a serialized instance of <see cref="${this.name}" /> as a <see cref="${ClientRuntime.JsonNode}" />.`
+    }));
+
+    // setup the declaration for the json deserializer constructor
+    const jsonParameter = new Parameter('json', ClientRuntime.JsonObject, { description: `A ${ClientRuntime.JsonObject} instance to deserialize from.` });
+    const deserializerConstructor = this.addMethod(new Constructor(this, {
+      parameters: [jsonParameter], access: Access.Internal,
+      description: `Deserializes a ${ClientRuntime.JsonObject} into a new instance of <see cref="${this.name}" />.`
+    }));
+
+
+    const serializeStatements = new Statements();
+    const deserializeStatements = new Statements();
+    this.excludes = '';
+
+    if (this.modelClass.dictionaryImpl) {
+      const vType = this.modelClass.dictionaryImpl.valueType;
+      // we have to ensure that all the known wire-names are excluded on deserialization.
+      const exclusions = new Parameter('exclusions', System.Collections.Generic.HashSet(dotnet.String), { defaultInitializer: dotnet.Null });
+      deserializerConstructor.parameters.push(exclusions);
+
+      this.excludes = [...values(newGetAllProperties(<ObjectSchema>this.modelClass.schema)).select(each => each.serializedName).select(each => new StringExpression(each))].join();
+      this.excludes = this.excludes ? `,${System.Collections.Generic.HashSet(dotnet.String).new()}{ ${this.excludes} }` : '';
+
+      const ap = `((${ClientRuntime}.IAssociativeArray<${vType.declaration}>)this).AdditionalProperties`;
+
+      if (this.modelClass.dictionaryImpl.ownsDictionary) {
+        // we have to implement the deserializer for it.
+
+        serializeStatements.push(new Statements(`${ClientRuntime.JsonSerializable}.ToJson( ${ap}, ${container});`));
+
+        if (vType === System.Object) {
+          // wildcard style
+          deserializeStatements.push(new Statements(`${ClientRuntime.JsonSerializable}.FromJson( json, ${ap}, ${ClientRuntime.JsonSerializable}.DeserializeDictionary(()=>${System.Collections.Generic.Dictionary(System.String, System.Object).new()}),${exclusions.value} );`));
+
+        } else if (vType instanceof ObjectImplementation) {
+          deserializeStatements.push(new Statements(`${ClientRuntime.JsonSerializable}.FromJson( json, ${ap}, (j) => ${this.modelClass.fullName}.FromJson(j) ,${exclusions.value} );`));
+        } else {
+          deserializeStatements.push(new Statements(`${ClientRuntime.JsonSerializable}.FromJson( json, ${ap}, null ,${exclusions.value} );`));
+        }
+      }
+    }
+
+
+    for (const each of values(modelClass.backingFields)) {
+      serializeStatements.add(`${each.field.value}?.ToJson(${container}, ${mode.use});`);
+      const sch = (<EnhancedTypeDeclaration>each.typeDeclaration).schema;
+      if (!(sch instanceof NewSchema) && (sch.additionalProperties)) {
+        deserializeStatements.add(`${each.field.value} = new ${each.className}(json${this.excludes});`);
+      } else {
+        deserializeStatements.add(`${each.field.value} = new ${each.className}(json);`);
+      }
+    }
+
+    pushTempVar();
+    for (const prop of values(modelClass.ownedProperties)) {
+      if (prop.details.csharp.HeaderProperty === 'Header') {
+        continue;
+      }
+      const serializeStatement = (<EnhancedTypeDeclaration>prop.type).serializeToContainerMember(KnownMediaType.Json, prop.valuePrivate, container, prop.serializedName, mode);
+
+      if (prop.details.csharp.readOnly) {
+        serializeStatements.add(If(`${mode.use}.HasFlag(${ClientRuntime.SerializationMode.IncludeReadOnly})`, serializeStatement));
+      } else {
+        serializeStatements.add(serializeStatement);
+      }
+      deserializeStatements.add(prop.assignPrivate((<EnhancedTypeDeclaration>prop.type).deserializeFromContainerMember(KnownMediaType.Json, jsonParameter, prop.serializedName, prop)));
+    }
+    popTempVar();
+
+    const $this = this;
+
+    // generate the implementation for toJson
+    toJsonMethod.add(function* () {
+      yield `${container} = ${container} ?? new ${ClientRuntime.JsonObject.declaration}();`;
+      yield EOL;
+
+      yield 'bool returnNow = false;';
+      yield `${$this.btj.name}(ref ${container}, ref returnNow);`;
+
+      yield If(toExpression('returnNow'), `return ${container};`);
+
+      // get serialization statements
+      yield serializeStatements;
+
+      yield `${$this.atj.name}(ref ${container});`;
+      yield Return(container);
+    });
+
+    // and let's fill in the deserializer constructor statements now.
+    deserializerConstructor.add(function* () {
+      yield 'bool returnNow = false;';
+      yield `${$this.bfj.name}(json, ref returnNow);`;
+      yield If(toExpression('returnNow'), 'return;');
+
+      yield deserializeStatements;
+      yield `${$this.afj.name}(json);`;
+    });
+  }
+
+  public get definition(): string {
+    const $this = this.modelClass;
+    // gotta write this just before we write out the class, since we had to wait until everyone had reported to their parents.
+    const d = this.modelClass.discriminators;
+    const isp = this.modelClass.isPolymorphic;
+    // create the FromJson method
+    const node = new Parameter('node', ClientRuntime.JsonNode, { description: `a <see cref="${ClientRuntime.JsonNode}" /> to deserialize from.` });
+    const fromJson = this.addMethod(new Method('FromJson', this.modelClass.modelInterface, {
+      parameters: [node], static: Modifier.Static,
+      description: `Deserializes a <see cref="${ClientRuntime.JsonNode}"/> into an instance of ${this.modelClass.modelInterface}.`,
+      returnsDescription: `an instance of ${this.modelClass.modelInterface}.`
+    }));
+
+    if (isp) {
+      fromJson.description = fromJson.description + `\n Note: the ${this.modelClass.modelInterface} interface is polymorphic, and the precise model class that will get deserialized is determined at runtime based on the payload.`;
+    }
+    const $excludes = this.excludes;
+    fromJson.add(function* () {
+
+      const json = IsDeclaration(node, ClientRuntime.JsonObject, 'json');
+
+      if (isp) {
+        yield If(Not(json.check), Return(dotnet.Null));
+        yield '// Polymorphic type -- select the appropriate constructor using the discriminator';
+        /** go thru the list of polymorphic values for the discriminator, and call the target class's constructor for that */
+        // skip-for-time-being
+        // if ($this.schema.discriminator) {
+        //   yield Switch(toExpression(`json.StringProperty("${$this.schema.discriminator.propertyName}")`), function* () {
+        //     for (const { key, value } of items(d)) {
+        //       yield TerminalCase(`"${key}"`, function* () {
+        //         yield Return(value.new(json));
+        //       });
+        //     }
+        //   });
+        // }
         yield Return($this.new(json, toExpression($excludes.substring(1))));
       } else {
         // just tell it to create the instance (providing that it's a JSonObject)

--- a/powershell/llcsharp/model/model-class-serializer.ts
+++ b/powershell/llcsharp/model/model-class-serializer.ts
@@ -30,6 +30,7 @@ import { popTempVar, pushTempVar } from '../schema/primitive';
 import { ModelProperty } from './property';
 import { ObjectImplementation } from '../schema/object';
 import { Schema } from '../code-model';
+import { Schema as NewSchema } from '@azure-tools/codemodel';
 
 import { getVirtualPropertyName } from './model-class';
 
@@ -70,6 +71,42 @@ export class SerializationPartialClass extends Initializer {
 
 }
 
+export class NewSerializationPartialClass extends Initializer {
+  constructor(protected targetClass: Class, protected targetInterface: TypeDeclaration, protected serializationType: TypeDeclaration, protected serializationFormat: string, protected schema: NewSchema, protected resolver: (s: NewSchema, req: boolean) => EnhancedTypeDeclaration, objectInitializer?: DeepPartial<SerializationPartialClass>) {
+    super();
+    this.apply(objectInitializer);
+  }
+
+  protected get virtualProperties() {
+    return this.schema.language.csharp?.virtualProperties || {
+      owned: [],
+      inherited: [],
+      inlined: []
+    };
+  }
+  protected get allVirtualProperties() {
+    const vp = this.virtualProperties;
+    // return [...vp.owned, ...vp.inherited, ...vp.inlined];
+    return values(vp.owned, vp.inherited, vp.inlined).toArray();
+  }
+
+  protected contentParameter = new Parameter('content', this.serializationType, { description: `The ${this.serializationType.declaration} content that should be used.` });
+  protected refContainerParameter = new Parameter('container', this.serializationType, { modifier: ParameterModifier.Ref, description: `The ${this.serializationType.declaration} container that the serialization result will be placed in.` });
+  protected returnNowParameter = new Parameter('returnNow', dotnet.Bool, { modifier: ParameterModifier.Ref, description: 'Determines if the rest of the serialization should be processed, or if the method should return instantly.' });
+
+  protected get typeCref() {
+    return `<see cref="${this.serializationType.declaration}" />`;
+  }
+
+  protected get thisCref() {
+    return `<see cref="${this.targetClass.declaration}" />`;
+  }
+
+  protected get interfaceCref() {
+    return `<see cref="${this.targetInterface.declaration}" />`;
+  }
+
+}
 export class DeserializerPartialClass extends SerializationPartialClass {
   private beforeDeserialize!: Method;
   private afterDeserialize!: Method;
@@ -176,6 +213,113 @@ export class DeserializerPartialClass extends SerializationPartialClass {
   }
 }
 
+export class NewDeserializerPartialClass extends NewSerializationPartialClass {
+  private beforeDeserialize!: Method;
+  private afterDeserialize!: Method;
+  constructor(targetClass: Class, targetInterface: TypeDeclaration, protected serializationType: TypeDeclaration, protected serializationFormat: string, protected schema: NewSchema, resolver: (s: NewSchema, req: boolean) => EnhancedTypeDeclaration, objectInitializer?: DeepPartial<DeserializerPartialClass>) {
+    super(targetClass, targetInterface, serializationType, serializationFormat, schema, resolver);
+    this.apply(objectInitializer);
+  }
+
+  async init() {
+    // add partial methods for extensibility
+    this.addPartialMethods();
+    this.addDeserializerConstructor();
+    this.addDeserializerMethod();
+  }
+
+  protected addDeserializerConstructor() {
+    const $this = this;
+
+    const deserializerConstructor = this.targetClass.addMethod(new Constructor(this.targetClass, {
+      parameters: [this.contentParameter], access: Access.Internal,
+      description: `Deserializes a ${this.typeCref} into a new instance of ${this.thisCref}.`
+    }));
+
+    deserializerConstructor.add(function* () {
+      const returnNow = new LocalVariable('returnNow', dotnet.Bool, { initializer: dotnet.False });
+      yield returnNow.declarationStatement;
+
+      yield `${$this.beforeDeserialize.name}(${$this.contentParameter}, ref ${returnNow.value});`;
+      yield If(returnNow, 'return;');
+      yield $this.deserializeStatements;
+      // skip-for-time-being
+      // if ($this.hasAadditionalProperties($this.schema)) {
+      //   // this type has an additional properties dictionary
+      //   yield '// this type is a dictionary; copy elements from source to here.';
+      //   yield `CopyFrom(${$this.contentParameter.value});`;
+      // }
+
+      yield `${$this.afterDeserialize.name}(${$this.contentParameter});`;
+    });
+  }
+
+  private hasAadditionalProperties(aSchema: Schema): boolean {
+    if (aSchema.additionalProperties) {
+      return true;
+    } else
+      for (const each of values(aSchema.allOf)) {
+        const r = this.hasAadditionalProperties(each);
+        if (r) {
+          return r;
+        }
+      }
+    return false;
+  }
+
+  get deserializeStatements() {
+    const $this = this;
+
+    return function* () {
+      yield '// actually deserialize ';
+      // skip-for-time-being
+      // for (const virtualProperty of values($this.allVirtualProperties)) {
+      //   // yield `// deserialize ${virtualProperty.name} from ${$this.serializationFormat}`;
+      //   const type = $this.resolver(<Schema>virtualProperty.property.schema, virtualProperty.property.details.default.required);
+
+      //   const cvt = type.convertObjectMethod;
+      //   const t = `((${virtualProperty.originalContainingSchema.details.csharp.fullInternalInterfaceName})this)`;
+      //   const tt = type ? `(${type.declaration})` : '';
+
+      //   yield `${t}.${getVirtualPropertyName(virtualProperty)} = ${tt} ${$this.contentParameter}.GetValueForProperty("${getVirtualPropertyName(virtualProperty)}",${t}.${getVirtualPropertyName(virtualProperty)}, ${cvt});`;
+      // }
+    };
+  }
+
+  protected addDeserializerMethod() {
+    const $this = this;
+
+    const deserialzeMethod = this.targetClass.addMethod(new Method(`DeserializeFrom${this.serializationFormat}`, this.targetInterface, {
+      parameters: [this.contentParameter], static: Modifier.Static,
+      description: `Deserializes a ${this.typeCref} into an instance of ${this.thisCref}.`,
+      returnsDescription: `an instance of ${this.interfaceCref}.`
+    }));
+
+    deserialzeMethod.add(function* () {
+      yield Return($this.targetClass.new($this.contentParameter));
+    });
+
+  }
+
+  protected addPartialMethods() {
+    const before = `BeforeDeserialize${this.serializationFormat}`;
+    const after = `AfterDeserialize${this.serializationFormat}`;
+    this.beforeDeserialize = this.targetClass.addMethod(new PartialMethod(before, dotnet.Void, {
+      access: Access.Default,
+      parameters: [this.contentParameter, this.returnNowParameter],
+      description: `<c>${before}</c> will be called before the deserialization has commenced, allowing complete customization of the object before it is deserialized.
+      If you wish to disable the default deserialization entirely, return <c>true</c> in the <see "returnNow" /> output parameter.
+      Implement this method in a partial class to enable this behavior.`
+    }));
+
+    this.afterDeserialize = this.targetClass.addMethod(new PartialMethod(after, dotnet.Void, {
+      access: Access.Default,
+      parameters: [this.contentParameter],
+      description: `<c>${after}</c> will be called after the deserialization has finished, allowing customization of the object before it is returned. Implement this method in a partial class to enable this behavior `
+    }));
+  }
+}
+
 export class SerializerPartialClass extends SerializationPartialClass {
   private beforeSerialize!: Method;
   private afterSerialize!: Method;
@@ -218,3 +362,4 @@ export class SerializerPartialClass extends SerializationPartialClass {
     }));
   }
 }
+

--- a/powershell/llcsharp/model/model-class.ts
+++ b/powershell/llcsharp/model/model-class.ts
@@ -8,15 +8,16 @@ import { camelCase, deconstruct, DeepPartial } from '@azure-tools/codegen';
 import { items, values } from '@azure-tools/linq';
 import { Access, Class, Constructor, Expression, ExpressionOrLiteral, Field, If, Method, Modifier, Namespace, OneOrMoreStatements, Parameter, Statements, System, TypeDeclaration, valueOf, Variable, BackedProperty, Property, Virtual, toExpression, StringExpression, LiteralExpression, Attribute } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
-import { State } from '../generator';
+import { State, NewState } from '../generator';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
-import { ObjectImplementation } from '../schema/object';
-import { ModelInterface } from './interface';
-import { JsonSerializableClass } from './model-class-json';
+import { ObjectImplementation, NewObjectImplementation } from '../schema/object';
+import { ModelInterface, NewModelInterface } from './interface';
+import { JsonSerializableClass, NewJsonSerializableClass } from './model-class-json';
 import { ModelProperty } from './property';
 import { PropertyOriginAttribute, DoNotFormatAttribute, FormatTableAttribute } from '../csharp-declarations';
 import { Schema } from '../code-model';
 import { DictionaryImplementation } from './model-class-dictionary';
+import { Languages, Language } from '@azure-tools/codemodel';
 
 export function getVirtualPropertyName(vp?: VirtualProperty): string {
 
@@ -469,6 +470,473 @@ export class ModelClass extends Class implements EnhancedTypeDeclaration {
       const td = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>headerProperty.property.schema, false, this.state.path('schema'));
       readHeaders.add(If(`${valueOf(headers)}.TryGetValues("${headerProperty.property.serializedName}", out var ${values})`, `${t}.${headerProperty.name} = ${td.deserializeFromContainerMember(KnownMediaType.Header, headers, values, td.defaultOfType)};`));
     }
+    if (used) {
+      this.interfaces.push(ClientRuntime.IHeaderSerializable);
+      this.add(readHeaders);
+    }
+  }
+
+  public validateValue(eventListener: Variable, property: Variable): OneOrMoreStatements {
+    return this.featureImplementation.validateValue(eventListener, property);
+  }
+  public validatePresence(eventListener: Variable, property: Variable): OneOrMoreStatements {
+    return this.featureImplementation.validatePresence(eventListener, property);
+  }
+
+  public addDiscriminator(discriminatorValue: string, modelClass: ModelClass) {
+    this.discriminators.set(discriminatorValue, modelClass);
+
+    // tell any polymorphic parents incase we're doing subclass of a subclass.
+    for (const each of this.parentModelClasses) {
+      each.addDiscriminator(discriminatorValue, modelClass);
+    }
+  }
+}
+
+export class NewModelClass extends Class implements EnhancedTypeDeclaration {
+  deserializeFromContainerMember(mediaType: KnownMediaType, container: ExpressionOrLiteral, serializedName: string, defaultValue: Expression): Expression {
+    return this.featureImplementation.deserializeFromContainerMember(mediaType, container, serializedName, defaultValue);
+  }
+  deserializeFromNode(mediaType: KnownMediaType, node: ExpressionOrLiteral, defaultValue: Expression): Expression {
+    return this.featureImplementation.deserializeFromNode(mediaType, node, defaultValue);
+  }
+  serializeToNode(mediaType: KnownMediaType, value: ExpressionOrLiteral, serializedName: string, mode: Expression): Expression {
+    return this.featureImplementation.serializeToNode(mediaType, value, serializedName, mode);
+  }
+
+  get defaultOfType() {
+    return toExpression('null /* model class */');
+  }
+
+  get convertObjectMethod() {
+    return this.featureImplementation.convertObjectMethod;
+  }
+  /** emits an expression serialize this to a HttpContent */
+  serializeToContent(mediaType: KnownMediaType, value: ExpressionOrLiteral, mode: Expression): Expression {
+    return this.featureImplementation.serializeToContent(mediaType, value, mode);
+  }
+
+  /** emits an expression to deserialize content from a string */
+  deserializeFromString(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    return this.featureImplementation.deserializeFromString(mediaType, content, defaultValue);
+  }
+  /** emits an expression to deserialize content from a content/response */
+  deserializeFromResponse(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    return this.featureImplementation.deserializeFromResponse(mediaType, content, defaultValue);
+  }
+  serializeToContainerMember(mediaType: KnownMediaType, value: ExpressionOrLiteral, container: Variable, serializedName: string, mode: Expression): OneOrMoreStatements {
+    return this.featureImplementation.serializeToContainerMember(mediaType, value, container, serializedName, mode);
+  }
+
+  get isXmlAttribute(): boolean {
+    return this.featureImplementation.isXmlAttribute;
+  }
+
+  public isNullable = true;
+
+  get isRequired(): boolean {
+    return this.featureImplementation.isRequired;
+  }
+
+  public isPolymorphic = false;
+  public get schema() { return this.featureImplementation.schema; }
+
+  /* @internal */ validateMethod?: Method;
+  /* @internal */ discriminators: Map<string, ModelClass> = new Map<string, ModelClass>();
+  /* @internal */ parentModelClasses: Array<ModelClass> = new Array<ModelClass>();
+  /* @internal */ get modelInterface(): ModelInterface { return <ModelInterface>this.schema.language.csharp?.interfaceImplementation; }
+  /* @internal */ get internalModelInterface(): ModelInterface { return <ModelInterface>this.schema.language.csharp?.internalInterfaceImplementation; }
+
+  /* @internal */  state: NewState;
+  /* @internal */  backingFields = new Array<BackingField>();
+  /* @internal */  featureImplementation: NewObjectImplementation;
+  /* @internal */  validationEventListener: Parameter = new Parameter('eventListener', ClientRuntime.IEventListener, { description: `an <see cref="${ClientRuntime.IEventListener}" /> instance that will receive validation events.` });
+  /* @internal */  jsonSerializer?: NewJsonSerializableClass;
+  // /* @internal */  xmlSerializer?: XmlSerializableClass;
+  /* @internal */  dictionaryImpl?: DictionaryImplementation;
+
+  private readonly validationStatements = new Statements();
+  public ownedProperties = new Array<ModelProperty>();
+  private pMap = new Map<VirtualProperty, ModelProperty>();
+
+  // public hasHeaderProperties: boolean;
+
+  constructor(namespace: Namespace, schemaWithFeatures: NewObjectImplementation, state: NewState, objectInitializer?: DeepPartial<ModelClass>) {
+    super(namespace, schemaWithFeatures.schema.language.csharp?.name || '');
+    this.featureImplementation = schemaWithFeatures;
+    this.schema.language.csharp = this.schema.language.csharp || new Language();
+    this.schema.language.csharp.classImplementation = this; // mark the code-model with the class we're creating.
+    this.state = state;
+    this.apply(objectInitializer);
+
+    if (this.state.getValue('powershell') && this.schema.language.csharp.suppressFormat) {
+      this.add(new Attribute(DoNotFormatAttribute));
+    }
+
+    // must be a partial class
+    this.partial = true;
+
+    //skip-for-time-being
+    //this.handleDiscriminator();
+
+    // create an interface for this model class
+    if (!this.schema.language.csharp.interfaceImplementation) {
+      (this.schema.language.csharp.interfaceImplementation = new NewModelInterface(this.namespace, this.schema.language.csharp.interfaceName || `I${this.schema.language.csharp.name}`, this, this.state));
+
+    }
+    this.interfaces.push(this.modelInterface);
+
+    if (!this.schema.language.csharp.internalInterfaceImplementation) {
+      (this.schema.language.csharp.internalInterfaceImplementation = new NewModelInterface(this.namespace, this.schema.language.csharp.internalInterfaceName || `I${this.schema.language.csharp.name}Internal`, this, this.state, { accessModifier: Access.Internal }));
+
+    }
+
+    this.interfaces.push(this.internalModelInterface);
+
+    this.schema.language.csharp.internalInterfaceImplementation.init();
+    this.schema.language.csharp.interfaceImplementation.init();
+
+    // add default constructor
+    this.addMethod(new Constructor(this, { description: `Creates an new <see cref="${this.name}" /> instance.` })); // default constructor for fits and giggles.
+
+    // skip-for-time-being
+    // handle parent interface implementation
+    // if (!this.handleAllOf()) {
+    //   // handle the AdditionalProperties if used
+    //   if (this.schema.additionalProperties) {
+    //     this.dictionaryImpl = new DictionaryImplementation(this).init();
+    //   }
+    // }
+
+    // create the properties for ths schema
+    this.createProperties();
+
+    // add validation implementation
+    this.addValidation();
+
+    // add header properties for this model.
+    // DISABLED.
+    this.addHeaderDeserializer();
+
+    if (this.state.project.jsonSerialization) {
+      this.jsonSerializer = new NewJsonSerializableClass(this);
+    }
+  }
+
+  private nested(virtualProperty: VirtualProperty, internal: boolean): string {
+    if (virtualProperty.accessViaProperty) {
+      if (virtualProperty.accessViaProperty.accessViaProperty) {
+        // return `/*1*/${getVirtualPropertyName(virtualProperty.accessViaMember)}.${this.nested(virtualProperty.accessViaProperty.accessViaProperty, internal)}`;
+        return `${getVirtualPropertyName(virtualProperty.accessViaMember)}.${this.nested(virtualProperty.accessViaProperty.accessViaProperty, internal)}`;
+      }
+    }
+    //return `/*2*/${getVirtualPropertyName(virtualProperty.accessViaMember)}`;
+    return `${getVirtualPropertyName(virtualProperty.accessViaMember)}`;
+  }
+
+  private accessor(virtualProperty: VirtualProperty, internal = false): string {
+    if (virtualProperty.accessViaProperty) {
+      const prefix = virtualProperty.accessViaProperty.accessViaProperty ? this.nested(virtualProperty.accessViaProperty.accessViaProperty, internal) : '';
+      const containingProperty = this.pMap.get(virtualProperty.accessViaProperty);
+      if (containingProperty && virtualProperty.accessViaMember) {
+        //return `/*3*/((${virtualProperty.accessViaMember.originalContainingSchema.details.csharp.fullInternalInterfaceName})${containingProperty.name}${prefix}).${getVirtualPropertyName(virtualProperty.accessViaMember)}`;
+        return `((${virtualProperty.accessViaMember.originalContainingSchema.details.csharp.fullInternalInterfaceName})${containingProperty.name}${prefix}).${getVirtualPropertyName(virtualProperty.accessViaMember)}`;
+      }
+    }
+    //    return `/*4* ${virtualProperty.name}/${virtualProperty.accessViaMember?.name}/${virtualProperty.accessViaProperty?.name} */${getVirtualPropertyName(virtualProperty.accessViaMember) || '/*!!*/' + virtualProperty.name}`;
+    return `${getVirtualPropertyName(virtualProperty.accessViaMember) || virtualProperty.name}`;
+  }
+
+  private createProperties() {
+    // generate a protected backing field for each
+    // and then expand the nested properties into this class forwarding to the member.  
+
+    // add properties
+    if (this.schema.language.csharp?.virtualProperties) {
+      const addFormatAttributesToProperty = (property: Property, virtualProperty: VirtualProperty) => {
+        if (virtualProperty.format) {
+          if (virtualProperty.format.suppressFormat) {
+            property.add(new Attribute(DoNotFormatAttribute));
+          } else {
+            const parameters = [];
+            if (virtualProperty.format.index !== undefined) {
+              parameters.push(`Index = ${virtualProperty.format.index}`);
+            }
+
+            if (virtualProperty.format.label !== undefined) {
+              parameters.push(`Label = ${new StringExpression(virtualProperty.format.label)}`);
+            }
+
+            if (virtualProperty.format.width !== undefined) {
+              parameters.push(`Width = ${virtualProperty.format.width}`);
+            }
+
+            property.add(new Attribute(FormatTableAttribute, { parameters }));
+          }
+        }
+      };
+      // skip-for-time-being
+      // /* Owned Properties */
+      // for (const virtualProperty of values(this.schema.language.csharp.virtualProperties.owned)) {
+      //   const actualProperty = virtualProperty.property;
+      //   let n = 0;
+      //   const decl = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>actualProperty.schema, actualProperty.details.csharp.required, this.state.path('schema'));
+
+      //   /* public property */
+      //   const myProperty = new ModelProperty(virtualProperty.name, <Schema>actualProperty.schema, actualProperty.details.csharp.required, actualProperty.serializedName, actualProperty.details.csharp.description, this.state.path('properties', n++), {
+      //     initializer: actualProperty.details.csharp.constantValue ? typeof actualProperty.details.csharp.constantValue === 'string' ? new StringExpression(actualProperty.details.csharp.constantValue) : new LiteralExpression(actualProperty.details.csharp.constantValue) : undefined
+      //   });
+
+      //   if (actualProperty.details.csharp.readOnly) {
+      //     myProperty.set = undefined;
+      //   }
+      //   myProperty.details = virtualProperty.property.details;
+
+      //   if (actualProperty.details.csharp.constantValue !== undefined) {
+      //     myProperty.setAccess = Access.Internal;
+      //     myProperty.set = undefined;
+      //   }
+
+      //   if (virtualProperty.private) {
+      //     // when properties are inlined, the container accessor can be internalized. I think.
+      //     myProperty.setAccess = Access.Internal;
+      //     myProperty.getAccess = Access.Internal;
+      //     this.pMap.set(virtualProperty, myProperty);
+      //   }
+
+      //   this.ownedProperties.push(this.add(myProperty));
+
+      //   if (myProperty.getAccess !== Access.Public || myProperty.setAccess !== Access.Public || myProperty.set === undefined) {
+      //     /* internal interface property */
+
+      //     this.add(new Property(`${virtualProperty.originalContainingSchema.details.csharp.internalInterfaceImplementation.fullName}.${virtualProperty.name}`, decl, {
+      //       description: `Internal Acessors for ${virtualProperty.name}`,
+      //       getAccess: Access.Explicit,
+      //       setAccess: Access.Explicit,
+      //       get: myProperty.get,
+      //       set: myProperty.assignPrivate('value')
+      //     }));
+      //   }
+
+      //   if (this.state.getValue('powershell')) {
+      //     myProperty.add(new Attribute(PropertyOriginAttribute, { parameters: [`${this.state.project.serviceNamespace}.PropertyOrigin.Owned`] }));
+      //     addFormatAttributesToProperty(myProperty, virtualProperty);
+      //   }
+      // }
+
+      // /* Inherited properties. */
+      // for (const virtualProperty of values(this.schema.details.csharp.virtualProperties.inherited)) {
+      //   // so each parent property that is getting exposed
+      //   // has to be accessed via the field in this.backingFields
+      //   const parentField = <BackingField>this.backingFields.find(each => virtualProperty.accessViaSchema ? virtualProperty.accessViaSchema.details.csharp.interfaceImplementation.fullName === each.typeDeclaration.declaration : false);
+
+      //   const propertyType = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>virtualProperty.property.schema, virtualProperty.property.details.csharp.required, this.state);
+      //   const opsType = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>virtualProperty.originalContainingSchema, false, this.state);
+      //   const via = <VirtualProperty>virtualProperty.accessViaProperty;
+      //   const parentCast = `(${virtualProperty.originalContainingSchema.details.csharp.internalInterfaceImplementation.fullName})`;
+      //   const vp = this.add(new Property(virtualProperty.name, propertyType, {
+      //     description: virtualProperty.property.details.csharp.description,
+      //     get: toExpression(`(${parentCast}${parentField.field.name}).${this.accessor(virtualProperty)}`),
+      //     set: (virtualProperty.property.details.csharp.readOnly || virtualProperty.property.details.csharp.constantValue) ? undefined : toExpression(`(${parentCast}${parentField.field.name}).${this.accessor(virtualProperty)} = value`)
+      //   }));
+
+      //   if (virtualProperty.property.details.csharp.constantValue !== undefined) {
+      //     vp.setAccess = Access.Internal;
+      //     vp.set = undefined;
+      //   }
+
+      //   if (vp.getAccess !== Access.Public || vp.setAccess !== Access.Public || vp.set === undefined) {
+
+      //     this.add(new Property(`${virtualProperty.originalContainingSchema.details.csharp.internalInterfaceImplementation.fullName}.${virtualProperty.name}`, propertyType, {
+      //       description: `Internal Acessors for ${virtualProperty.name}`,
+      //       getAccess: Access.Explicit,
+      //       setAccess: Access.Explicit,
+      //       get: toExpression(`(${parentCast}${parentField.field.name}).${via.name}`),
+      //       set: toExpression(`(${parentCast}${parentField.field.name}).${via.name} = value`)
+      //     }));
+      //   }
+
+      //   if (this.state.getValue('powershell')) {
+      //     vp.add(new Attribute(PropertyOriginAttribute, { parameters: [`${this.state.project.serviceNamespace}.PropertyOrigin.Inherited`] }));
+      //     addFormatAttributesToProperty(vp, virtualProperty);
+      //   }
+      // }
+
+      // /* Inlined properties. */
+      // for (const virtualProperty of values(this.schema.details.csharp.virtualProperties.inlined)) {
+      //   if (virtualProperty.private) {
+      //     // continue;
+      //     // can't remove it, it has to be either public or internally implemented.
+      //   }
+
+      //   if (virtualProperty.accessViaProperty) {
+      //     const containingProperty = this.pMap.get(virtualProperty.accessViaProperty);
+      //     if (containingProperty) {
+
+      //       const propertyType = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>virtualProperty.property.schema, virtualProperty.property.details.csharp.required, this.state);
+
+      //       // regular inlined property
+      //       const vp = new Property(virtualProperty.name, propertyType, {
+      //         description: virtualProperty.property.details.csharp.description,
+      //         get: toExpression(`${this.accessor(virtualProperty)}`),
+      //         set: (virtualProperty.property.details.csharp.readOnly || virtualProperty.property.details.csharp.constantValue) ? undefined : toExpression(`${this.accessor(virtualProperty)} = value`)
+      //       });
+
+      //       if (!virtualProperty.private) {
+      //         this.add(vp);
+      //       }
+
+      //       if (virtualProperty.private || vp.getAccess !== Access.Public || vp.setAccess !== Access.Public || vp.set === undefined) {
+      //         this.add(new Property(`${virtualProperty.originalContainingSchema.details.csharp.internalInterfaceImplementation.fullName}.${virtualProperty.name}`, propertyType, {
+      //           description: `Internal Acessors for ${virtualProperty.name}`,
+      //           getAccess: Access.Explicit,
+      //           setAccess: Access.Explicit,
+      //           get: vp.get,
+      //           set: toExpression(`${this.accessor(virtualProperty)} = value`)
+      //         }));
+      //       }
+
+      //       if (virtualProperty.property.details.csharp.constantValue !== undefined) {
+      //         vp.setAccess = Access.Internal;
+      //         vp.set = undefined;
+      //       }
+
+      //       if (this.state.getValue('powershell')) {
+      //         vp.add(new Attribute(PropertyOriginAttribute, { parameters: [`${this.state.project.serviceNamespace}.PropertyOrigin.Inlined`] }));
+      //         addFormatAttributesToProperty(vp, virtualProperty);
+      //       }
+      //     }
+      //   }
+      // }
+
+    }
+  }
+
+  private addValidation() {
+    if (this.validationStatements.implementation.trim()) {
+      // we do have something to valdiate!
+
+      // add the IValidates implementation to this object.
+      this.interfaces.push(ClientRuntime.IValidates);
+      this.validateMethod = this.addMethod(new Method('Validate', System.Threading.Tasks.Task(), {
+        async: Modifier.Async,
+        parameters: [this.validationEventListener],
+        description: 'Validates that this object meets the validation criteria.',
+        returnsDescription: `A < see cref = "${System.Threading.Tasks.Task()}" /> that will be complete when validation is completed.`
+      }));
+      this.validateMethod.add(this.validationStatements);
+    }
+  }
+
+  private additionalPropertiesType(aSchema: Schema): TypeDeclaration | undefined {
+    // skip-for-time-being
+    // if (aSchema.additionalProperties) {
+
+    //   if (aSchema.additionalProperties === true) {
+    //     return System.Object;
+
+    //   } else {
+    //     // we're going to implement IDictionary<string, schema.additionalProperties>
+    //     return this.state.project.modelsNamespace.resolveTypeDeclaration(aSchema.additionalProperties, true, this.state);
+    //   }
+    // } else
+    //   for (const each of values(aSchema.allOf)) {
+    //     const r = this.additionalPropertiesType(each);
+    //     if (r) {
+    //       return r;
+    //     }
+    //   }
+    return undefined;
+  }
+
+  // skip-for-time-being
+  // private handleAllOf() {
+  //   let hasAdditionalPropertiesInParent = false;
+  //   // handle <allOf>s
+  //   // add an 'implements' for the interface for the allOf.
+  //   for (const { key: eachSchemaIndex, value: eachSchemaValue } of items(this.schema.allOf)) {
+  //     const aSchema = eachSchemaValue;
+  //     const aState = this.state.path('allOf', eachSchemaIndex);
+
+  //     const td = this.state.project.modelsNamespace.resolveTypeDeclaration(aSchema, true, aState);
+  //     const parentClass = (<ModelClass>aSchema.details.csharp.classImplementation);
+  //     const className = parentClass.fullName;
+  //     const fieldName = camelCase(deconstruct(className.replace(/^.*\./, '')));
+
+  //     // add the interface as a parent to our interface.
+  //     const iface = <ModelInterface>aSchema.details.csharp.interfaceImplementation;
+
+  //     // add a field for the inherited values
+  //     const backingField = this.addField(new Field(`__${fieldName}`, td, { initialValue: `new ${className}()`, access: Access.Private, description: `Backing field for Inherited model <see cref= "${td.declaration}" /> ` }));
+  //     this.backingFields.push({
+  //       className,
+  //       typeDeclaration: td,
+  //       field: backingField
+  //     });
+  //     this.validationStatements.add(td.validatePresence(this.validationEventListener, backingField));
+  //     this.validationStatements.add(td.validateValue(this.validationEventListener, backingField));
+
+  //     this.internalModelInterface.interfaces.push(<ModelInterface>aSchema.details.csharp.internalInterfaceImplementation);
+  //     this.modelInterface.interfaces.push(iface);
+
+  //     //
+  //     const addlPropType = this.additionalPropertiesType(aSchema);
+  //     if (addlPropType) {
+  //       this.dictionaryImpl = new DictionaryImplementation(this).init(addlPropType, backingField);
+  //       hasAdditionalPropertiesInParent = true;
+  //     }
+  //   }
+  //   return hasAdditionalPropertiesInParent;
+  // }
+
+  // private handleDiscriminator() {
+  //   if (this.schema.discriminator) {
+  //     // this has a discriminator property.
+  //     // our children are expected to tell us who they are
+  //     this.isPolymorphic = true;
+  //     // we'll add a deserializer factory method a bit later..
+  //   }
+
+  //   if (this.schema.details.csharp.discriminatorValue) {
+  //     // we have a discriminator value, and we should tell our parent who we are so that they can build a proper deserializer method.
+  //     // um. just how do we *really* know which allOf is polymorphic?
+  //     // that's really sad.
+  //     for (const { key: eachAllOfIndex, value: eachAllOfValue } of items(this.schema.allOf)) {
+  //       const parentSchema = eachAllOfValue;
+  //       const aState = this.state.path('allOf', eachAllOfIndex);
+
+  //       // ensure the parent schema has it's class created first.
+  //       this.state.project.modelsNamespace.resolveTypeDeclaration(parentSchema, true, aState);
+
+  //       const parentClass = <ModelClass>parentSchema.details.csharp.classImplementation;
+  //       if (parentClass.isPolymorphic) {
+  //         // remember this class for later.
+  //         this.parentModelClasses.push(parentClass);
+
+  //         // tell that parent who we are.
+  //         parentClass.addDiscriminator(this.schema.details.csharp.discriminatorValue, this);
+  //       }
+  //     }
+  //   }
+  // }
+  private addHeaderDeserializer() {
+    const avp = getAllVirtualProperties(this.schema.language.csharp?.virtualProperties);
+    const headers = new Parameter('headers', System.Net.Http.Headers.HttpResponseHeaders);
+    const readHeaders = new Method(`${ClientRuntime.IHeaderSerializable}.ReadHeaders`, undefined, {
+      access: Access.Explicit,
+      parameters: [headers],
+    });
+
+    const used = false;
+
+    // skip-for-time-being
+    // for (const headerProperty of values(avp).where(each => each.property.details.csharp[HeaderProperty] === HeaderPropertyType.HeaderAndBody || each.property.details.csharp[HeaderProperty] === HeaderPropertyType.Header)) {
+    //   used = true;
+    //   const t = `((${headerProperty.originalContainingSchema.details.csharp.fullInternalInterfaceName})this)`;
+    //   const values = `__${camelCase([...deconstruct(headerProperty.property.serializedName), 'Header'])}`;
+    //   const td = this.state.project.modelsNamespace.resolveTypeDeclaration(<Schema>headerProperty.property.schema, false, this.state.path('schema'));
+    //   readHeaders.add(If(`${valueOf(headers)}.TryGetValues("${headerProperty.property.serializedName}", out var ${values})`, `${t}.${headerProperty.name} = ${td.deserializeFromContainerMember(KnownMediaType.Header, headers, values, td.defaultOfType)};`));
+    // }
     if (used) {
       this.interfaces.push(ClientRuntime.IHeaderSerializable);
       this.add(readHeaders);

--- a/powershell/llcsharp/model/namespace.ts
+++ b/powershell/llcsharp/model/namespace.ts
@@ -3,19 +3,20 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Schema as NewSchema, Schemas as NewSchemas, Language } from '@azure-tools/codemodel';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
-import { State } from '../generator';
+import { State, NewState } from '../generator';
 import { EnumImplementation } from '../schema/enum';
 import { EnhancedTypeDeclaration } from '../schema/extended-type-declaration';
-import { ObjectImplementation } from '../schema/object';
-import { SchemaDefinitionResolver } from '../schema/schema-resolver';
+import { ObjectImplementation, NewObjectImplementation } from '../schema/object';
+import { SchemaDefinitionResolver, NewSchemaDefinitionResolver } from '../schema/schema-resolver';
 import { EnumClass } from '../enums/enum';
 import * as validation from '../validations';
 import { ModelInterface } from './interface';
-import { ModelClass } from './model-class';
+import { ModelClass, NewModelClass } from './model-class';
 import { DeepPartial } from '@azure-tools/codegen';
 
 
@@ -35,8 +36,8 @@ export class ModelsNamespace extends Namespace {
   private subNamespaces = new Dictionary<Namespace>();
 
   resolver = new SchemaDefinitionResolver();
-
-  constructor(parent: Namespace, private schemas: Dictionary<Schema>, private state: State, objectInitializer?: DeepPartial<ModelsNamespace>) {
+  newResolver = new NewSchemaDefinitionResolver();
+  constructor(parent: Namespace, private schemas: Dictionary<Schema> | NewSchemas, private state: State | NewState, objectInitializer?: DeepPartial<ModelsNamespace>) {
     super('Models', parent);
     this.subNamespaces[this.fullName] = this;
 
@@ -46,15 +47,28 @@ export class ModelsNamespace extends Namespace {
 
     // special case... hook this up before we get anywhere.
     state.project.modelsNamespace = this;
+    if (!(schemas instanceof NewSchemas)) {
+      for (const { key: index, value: schema } of items(schemas)) {
+        const state = this.state.path(index);
 
-    for (const { key: index, value: schema } of items(schemas)) {
-      const state = this.state.path(index);
-
-      // verify that the model isn't in a bad state
-      if (validation.objectWithFormat(schema, state)) {
-        continue;
+        // verify that the model isn't in a bad state
+        if (validation.objectWithFormat(schema, <State>state)) {
+          continue;
+        }
+        this.resolveTypeDeclaration(schema, true, <State>state);
       }
-      this.resolveTypeDeclaration(schema, true, state);
+    } else {
+      if (schemas.objects) {
+        for (const schema of schemas.objects) {
+          this.NewResolveTypeDeclaration(schema, true, <NewState>state);
+        }
+      }
+      if (schemas.strings) {
+        for (const schema of schemas.strings) {
+          this.NewResolveTypeDeclaration(schema, true, <NewState>state);
+        }
+      }
+      //todo, need to add support for other types
     }
   }
 
@@ -78,7 +92,7 @@ export class ModelsNamespace extends Namespace {
 
         const ns = this.subNamespaces[fullname] || this.add(new ApiVersionNamespace(fullname));
 
-        const mc = schema.details.csharp.classImplementation || new ModelClass(ns, td, this.state, { description: schema.details.csharp.description });
+        const mc = schema.details.csharp.classImplementation || new ModelClass(ns, td, <State>this.state, { description: schema.details.csharp.description });
 
         // this gets implicity created during class creation:
         return <ModelInterface>schema.details.csharp.interfaceImplementation;
@@ -98,6 +112,124 @@ export class ModelsNamespace extends Namespace {
         }
 
         return schema.details.csharp.typeDeclaration = td;
+      }
+    }
+    return td;
+  }
+  public NewResolveTypeDeclaration(schema: NewSchema | undefined, required: boolean, state: NewState): EnhancedTypeDeclaration {
+    if (!schema) {
+      throw new Error('SCHEMA MISSING?');
+    }
+
+    const td = this.newResolver.resolveTypeDeclaration(schema, required, state);
+
+    if (!schema.language.csharp?.skip) {
+      if (td instanceof NewObjectImplementation) {
+        // it's a class object.
+        // create it if necessary
+
+        const fullname = schema.language.csharp?.namespace || this.fullName;
+
+        const ns = this.subNamespaces[fullname] || this.add(new ApiVersionNamespace(fullname));
+
+        const mc = schema.language.csharp?.classImplementation || new NewModelClass(ns, td, <NewState>this.state, { description: schema.language.csharp?.description });
+
+        // this gets implicity created during class creation:
+        return <ModelInterface>schema.language.csharp?.interfaceImplementation;
+      }
+
+      if (state.project.azure && /^api-?version$/i.exec(schema.language.csharp?.name || '')) {
+        return td;
+      }
+
+      if (td instanceof EnumImplementation) {
+        if (schema.language.csharp?.enum) {
+          const ec = state.project.supportNamespace.findClassByName(schema.language.csharp.enum.name);
+          if (length(ec) === 0) {
+            // skip-for-time-being
+            //new EnumClass(td, state);
+            // return schema.details.csharp.typeDeclaration = <EnumClass>ec[0];
+          }
+        }
+        schema.language.csharp = schema.language.csharp || new Language();
+        return schema.language.csharp.typeDeclaration = td;
+      }
+    }
+    return td;
+  }
+}
+
+export class NewModelsNamespace extends Namespace {
+  private subNamespaces = new Dictionary<Namespace>();
+
+  resolver = new SchemaDefinitionResolver();
+  newResolver = new NewSchemaDefinitionResolver();
+  constructor(parent: Namespace, private schemas: NewSchemas, private state: State | NewState, objectInitializer?: DeepPartial<ModelsNamespace>) {
+    super('Models', parent);
+    this.subNamespaces[this.fullName] = this;
+
+
+    this.apply(objectInitializer);
+    this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
+
+    // special case... hook this up before we get anywhere.
+    state.project.modelsNamespace = this;
+
+    if (schemas.objects) {
+      for (const schema of schemas.objects) {
+        this.NewResolveTypeDeclaration(schema, true, <NewState>state);
+      }
+    }
+    if (schemas.strings) {
+      for (const schema of schemas.strings) {
+        this.NewResolveTypeDeclaration(schema, true, <NewState>state);
+      }
+    }
+    //todo, need to add support for other types
+
+  }
+
+  get outputFolder() {
+    return 'Models';
+  }
+
+  public NewResolveTypeDeclaration(schema: NewSchema | undefined, required: boolean, state: NewState): EnhancedTypeDeclaration {
+    if (!schema) {
+      throw new Error('SCHEMA MISSING?');
+    }
+
+    const td = this.newResolver.resolveTypeDeclaration(schema, required, state);
+
+    if (!schema.language.csharp?.skip) {
+      if (td instanceof NewObjectImplementation) {
+        // it's a class object.
+        // create it if necessary
+
+        const fullname = schema.language.csharp?.namespace || this.fullName;
+
+        const ns = this.subNamespaces[fullname] || this.add(new ApiVersionNamespace(fullname));
+
+        const mc = schema.language.csharp?.classImplementation || new NewModelClass(ns, td, <NewState>this.state, { description: schema.language.csharp?.description });
+
+        // this gets implicity created during class creation:
+        return <ModelInterface>schema.language.csharp?.interfaceImplementation;
+      }
+
+      if (state.project.azure && /^api-?version$/i.exec(schema.language.csharp?.name || '')) {
+        return td;
+      }
+
+      if (td instanceof EnumImplementation) {
+        if (schema.language.csharp?.enum) {
+          const ec = state.project.supportNamespace.findClassByName(schema.language.csharp.enum.name);
+          if (length(ec) === 0) {
+            // skip-for-time-being
+            //new EnumClass(td, state);
+            // return schema.details.csharp.typeDeclaration = <EnumClass>ec[0];
+          }
+        }
+        schema.language.csharp = schema.language.csharp || new Language();
+        return schema.language.csharp.typeDeclaration = td;
       }
     }
     return td;

--- a/powershell/llcsharp/operation/api-class.ts
+++ b/powershell/llcsharp/operation/api-class.ts
@@ -6,48 +6,76 @@
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { Class, Namespace } from '@azure-tools/codegen-csharp';
 
-import { State } from '../generator';
-import { CallMethod, OperationMethod, ValidationMethod } from '../operation/method';
+import { State, NewState } from '../generator';
+import { CallMethod, OperationMethod, NewOperationMethod, ValidationMethod, NewCallMethod, NewValidationMethod } from '../operation/method';
 import { ParameterLocation } from '@azure-tools/codemodel-v3';
 import { DeepPartial } from '@azure-tools/codegen';
 
 export class ApiClass extends Class {
 
   // protected sender: Property;
-  constructor(namespace: Namespace, protected state: State, objectInitializer?: DeepPartial<ApiClass>) {
-    super(namespace, state.model.details.csharp.name);
+  constructor(namespace: Namespace, protected state: State | NewState, objectInitializer?: DeepPartial<ApiClass>) {
+    super(namespace, (state instanceof NewState) ? state.model.language.csharp?.name || '' : state.model.details.csharp.name);
     this.apply(objectInitializer);
 
     // add basics
     // this.sender = this.add(new Property("Sender", ClientRuntime.ISendAsync));
 
     // add operations from code model
-    for (const { key: operationIndex, value: operation } of items(state.model.http.operations)) {
-      // an operation has parameters for parameters, body, callbacks, listener and sender
-      // we need to make sure that the parameters for a given operation are consistent between the operation method, the call method, and the validation method.
-      // can we generate the common parameters here and just give them to the methods? (ie, can we share the instances between the methods?)
-      // code-dom doesn't store references from the child to the parent, so as long as the definitions work without modification, it looks like we can.
+    if (!(state instanceof NewState)) {
+      for (const { key: operationIndex, value: operation } of items(state.model.http.operations)) {
+        // an operation has parameters for parameters, body, callbacks, listener and sender
+        // we need to make sure that the parameters for a given operation are consistent between the operation method, the call method, and the validation method.
+        // can we generate the common parameters here and just give them to the methods? (ie, can we share the instances between the methods?)
+        // code-dom doesn't store references from the child to the parent, so as long as the definitions work without modification, it looks like we can.
 
-      // we'll do that work in the OM and expose them as public properties.
-      const operationMethod = new OperationMethod(this, operation, false, state.path('components', 'operations', operationIndex));
-      this.addMethod(operationMethod);
-      if ([...values(operation.parameters).select(each => each.in === ParameterLocation.Path)].length > 0) {
-        // method has parameters in the path, so it could support '...ViaIdentity' 
-        const identityMethod = new OperationMethod(this, operation, true, state.path('components', 'operations', operationIndex));
-        identityMethod.emitCall(false);
-        this.addMethod(identityMethod);
+        // we'll do that work in the OM and expose them as public properties.
+        const operationMethod = new OperationMethod(this, operation, false, state.path('components', 'operations', operationIndex));
+        this.addMethod(operationMethod);
+        if ([...values(operation.parameters).select(each => each.in === ParameterLocation.Path)].length > 0) {
+          // method has parameters in the path, so it could support '...ViaIdentity' 
+          const identityMethod = new OperationMethod(this, operation, true, state.path('components', 'operations', operationIndex));
+          identityMethod.emitCall(false);
+          this.addMethod(identityMethod);
 
+        }
+
+        // check if this exact method is been created before (because _call and _validate have less specific parameters than the api) 
+        const cm = new CallMethod(this, operationMethod, state.path('components', 'operations', operationIndex));
+        if (!this.hasMethodWithSameDeclaration(cm)) {
+          this.addMethod(cm);
+        }
+
+        const vm = new ValidationMethod(this, operationMethod, state.path('components', 'operations', operationIndex));
+        if (!this.hasMethodWithSameDeclaration(vm)) {
+          this.addMethod(vm);
+        }
       }
+    } else {
+      // todo
+      for (const operationGroup of state.model.operationGroups) {
+        for (const operation of operationGroup.operations) {
+          const operationMethod = new NewOperationMethod(this, operation, false, state);
+          this.addMethod(operationMethod);
+          if ([...values(operation.parameters).where(each => each.protocol.http?.in === ParameterLocation.Path)].length > 0) {
+            // method has parameters in the path, so it could support '...ViaIdentity' 
+            const identityMethod = new NewOperationMethod(this, operation, true, state);
+            identityMethod.emitCall(false);
+            this.addMethod(identityMethod);
 
-      // check if this exact method is been created before (because _call and _validate have less specific parameters than the api) 
-      const cm = new CallMethod(this, operationMethod, state.path('components', 'operations', operationIndex));
-      if (!this.hasMethodWithSameDeclaration(cm)) {
-        this.addMethod(cm);
-      }
+          }
 
-      const vm = new ValidationMethod(this, operationMethod, state.path('components', 'operations', operationIndex));
-      if (!this.hasMethodWithSameDeclaration(vm)) {
-        this.addMethod(vm);
+          // check if this exact method is been created before (because _call and _validate have less specific parameters than the api) 
+          const cm = new NewCallMethod(this, operationMethod, state);
+          if (!this.hasMethodWithSameDeclaration(cm)) {
+            this.addMethod(cm);
+          }
+
+          const vm = new NewValidationMethod(this, operationMethod, state);
+          if (!this.hasMethodWithSameDeclaration(vm)) {
+            this.addMethod(vm);
+          }
+        }
       }
     }
   }

--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { NewResponse, ParameterLocation } from '@azure-tools/codemodel-v3';
+import { Operation, SchemaResponse, Schema as NewSchema, Response } from '@azure-tools/codemodel';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { EOL, DeepPartial } from '@azure-tools/codegen';
 import { Access, Modifier } from '@azure-tools/codegen-csharp';
@@ -23,8 +24,8 @@ import { Using } from '@azure-tools/codegen-csharp';
 import { Local, LocalVariable, Variable } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { HttpOperation, Schema } from '../code-model';
-import { State } from '../generator';
-import { CallbackParameter, OperationBodyParameter, OperationParameter } from '../operation/parameter';
+import { State, NewState } from '../generator';
+import { CallbackParameter, NewCallbackParameter, OperationBodyParameter, OperationParameter, NewOperationParameter } from '../operation/parameter';
 
 import { isMediaTypeJson, isMediaTypeXml, KnownMediaType, knownMediaType, normalizeMediaType, parseMediaType } from '@azure-tools/codemodel-v3';
 import { ClassType, dotnet, System } from '@azure-tools/codegen-csharp';
@@ -224,7 +225,7 @@ export class OperationMethod extends Method {
         ${queryParams.length > 0 ? '+ "?"' : ''}${queryParams.joinWith(pp => `
         + ${removeEncoding(pp, pp.param.name, KnownMediaType.QueryParameter)}`, `
         + "&"`
-)}
+        )}
         ,"\\\\?&*$|&*$|(\\\\?)&+|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, ''))
       });
       yield urlV.declarationStatement;
@@ -284,6 +285,236 @@ export class OperationMethod extends Method {
   }
 }
 
+export class NewOperationMethod extends Method {
+  public methodParameters: Array<NewOperationParameter>;
+  public bodyParameter?: OperationBodyParameter;
+  public contextParameter!: Parameter;
+  public senderParameter!: Parameter;
+  public resourceUri!: Parameter;
+  public callbacks = new Array<CallbackParameter>();
+
+  protected callName: string;
+
+  constructor(public parent: Class, public operation: Operation, public viaIdentity: boolean, protected state: NewState, objectInitializer?: DeepPartial<OperationMethod>) {
+    super(viaIdentity ? `${operation.language.csharp?.name}ViaIdentity` : operation.language.csharp?.name || '', System.Threading.Tasks.Task());
+    this.apply(objectInitializer);
+    this.async = Modifier.Async;
+    this.returnsDescription = `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the response is completed.`;
+    const $this = this;
+
+    this.callName = `${operation.language.csharp?.name}_Call`;
+    this.push(Using('NoSynchronizationContext', ''));
+
+    // add parameters
+    this.methodParameters = [];
+
+    const identity = new Parameter('viaIdentity', System.String);
+    if (this.viaIdentity) {
+      this.addParameter(identity);
+    }
+    let baseUrl = '';
+    for (let index = 0; index < length(this.operation.parameters) && this.operation.parameters; index++) {
+      const value = this.operation.parameters[index];
+
+      if (value.language.default.name === '$host') {
+        baseUrl = value.clientDefaultValue;
+        continue;
+      }
+      const p = new NewOperationParameter(this, value, this.state.path('parameters', index));
+
+      if (value.language.csharp?.constantValue) {
+        const constTd = state.project.modelsNamespace.NewResolveTypeDeclaration(value.schema, true, state);
+        p.defaultInitializer = constTd.deserializeFromString(KnownMediaType.UriParameter, new StringExpression(`${value.language.csharp.constantValue}`), toExpression(constTd.defaultOfType));
+      }
+
+      // don't add path parameters  when we're in identity mode
+      if (!this.viaIdentity || value.protocol.http?.in !== ParameterLocation.Path) {
+        this.addParameter(p);
+      } else {
+        this.add(function* () {
+          yield '';
+        });
+      }
+      this.methodParameters.push(p);
+    }
+
+    this.description = this.operation.language.csharp?.description || '';
+
+    // add body paramter if there should be one.
+    // skip-for-time-being
+    // if (this.operation.requestBody) {
+    //   // this request does have a request body.
+    //   this.bodyParameter = new OperationBodyParameter(this, 'body', this.operation.requestBody.description || '', <Schema>this.operation.requestBody.schema, this.operation.requestBody.required, this.state.path('requestBody'), {
+    //     mediaType: knownMediaType(this.operation.requestBody.contentType),
+    //     contentType: this.operation.requestBody.contentType
+    //   });
+    //   this.addParameter(this.bodyParameter);
+    // }
+
+    for (const response of values(this.operation.responses)) {
+
+      const responseType = (<SchemaResponse>response).schema ? state.project.modelsNamespace.NewResolveTypeDeclaration(<NewSchema>((<SchemaResponse>response).schema), true, state) : null;
+      //skip-for-time-being
+      //const headerType = response.headerSchema ? state.project.modelsNamespace.NewResolveTypeDeclaration(<Schema>response.headerSchema, true, state) : null;
+      const headerType = null;
+      const newCallbackParameter = new NewCallbackParameter(response.language.csharp?.name || '', responseType, headerType, this.state, { description: response.language.csharp?.description });
+      this.addParameter(newCallbackParameter);
+      this.callbacks.push(newCallbackParameter);
+
+
+    }
+
+    // add eventhandler parameter
+    this.contextParameter = this.addParameter(new Parameter('eventListener', ClientRuntime.IEventListener, { description: `an <see cref="${ClientRuntime.IEventListener}" /> instance that will receive events.` }));
+
+    // add optional parameter for sender
+    this.senderParameter = this.addParameter(new Parameter('sender', ClientRuntime.ISendAsync, { description: `an instance of an ${ClientRuntime.ISendAsync} pipeline to use to make the request.` }));
+
+    let rx = this.operation.requests ? this.operation.requests[0].protocol.http?.path : '';
+    // For post API, Some URI may contain an action string .e.x '/start' at the end
+    // of the URI, for such cases, we will drop the action string if identityCorrection
+    // is set in the configuration
+    // skip-for-time-being
+    // if (this.operation.method === 'post' && this.state.project.identityCorrection) {
+    //   const idx = rx.lastIndexOf('/');
+    //   rx = rx.substr(0, idx);
+    // }
+
+
+    let url = `${baseUrl}/${rx.startsWith('/') ? rx.substr(1) : rx}`;
+
+
+    const serverParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Uri);
+
+    const headerParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Header);
+    const pathParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Path);
+    const queryParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Query);
+    const cookieParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Cookie);
+
+    // replace any server params in the uri
+    // skip-for-time-being
+    // for (const pp of serverParams) {
+    //   url = url.replace(`{${pp.param.name}}`, `"
+    //     + ${pp.name}
+    //     + "`);
+    // }
+
+    // for (const pp of pathParams) {
+    //   rx = rx.replace(`{${pp.param.name}}`, `(?<${pp.param.name}>[^/]+)`);
+
+    //   if (this.viaIdentity) {
+    //     url = url.replace(`{${pp.param.name}}`, `"
+    //     + ${pp.name}
+    //     + "`);
+    //   } else {
+    //     url = url.replace(`{${pp.param.name}}`, `"
+    //     + ${removeEncoding(pp, '', KnownMediaType.UriParameter)}
+    //     + "`);
+    //   }
+    // }
+    rx = `"^${rx}$"`;
+    url = url.replace(/\s*\+ ""/gm, '');
+
+    const bp = this.bodyParameter;
+    // add method implementation...
+
+    this.add(function* () {
+      const eventListener = new EventListener($this.contextParameter, $this.state.project.emitSignals);
+
+      yield EOL;
+
+      if ($this.viaIdentity) {
+        yield '// verify that Identity format is an exact match for uri';
+        yield EOL;
+
+        const match = Local('_match', `${System.Text.RegularExpressions.Regex.new(rx).value}.Match(${identity.value})`);
+        yield match.declarationStatement;
+        yield If(`!${match}.Success`, `throw new global::System.Exception("Invalid identity for URI '${rx}'");`);
+        yield EOL;
+        yield '// replace URI parameters with values from identity';
+        // skip-for-time-being
+        // for (const pp of pathParams) {
+        //   yield `var ${pp.name} = ${match.value}.Groups["${pp.param.name}"].Value;`;
+        // }
+      }
+
+      yield '// construct URL';
+      // const urlV = new LocalVariable('_url', dotnet.Var, {
+      //   initializer: System.Uri.new(`${System.Text.RegularExpressions.Regex.declaration}.Replace(
+      //   "${url}"
+      //   ${queryParams.length > 0 ? '+ "?"' : ''}${queryParams.joinWith(pp => `
+      //   + ${removeEncoding(pp, pp.param.name, KnownMediaType.QueryParameter)}`, `
+      //   + "&"`
+      //   )}
+      //   ,"\\\\?&*$|&*$|(\\\\?)&+|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, ''))
+      // });
+      const urlV = new LocalVariable('_url', dotnet.Var, {
+        initializer: System.Uri.new(`${System.Text.RegularExpressions.Regex.declaration}.Replace(
+        "${url}"
+        ${queryParams.length > 0 ? '+ "?"' : ''}${queryParams.joinWith(pp => `
+        + ${''}`, `
+        + "&"`
+        )}
+        ,"\\\\?&*$|&*$|(\\\\?)&+|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, ''))
+      });
+      yield urlV.declarationStatement;
+
+      yield EOL;
+
+      yield eventListener.signal(ClientRuntime.Events.URLCreated, urlV.value);
+      yield EOL;
+
+      yield '// generate request object ';
+      const method = $this.operation.requests ? $this.operation.requests[0].protocol.http?.method : '';
+      yield `var request =  ${System.Net.Http.HttpRequestMessage.new(`${ClientRuntime.fullName}.Method.${method.capitalize()}, ${urlV.value}`)};`;
+      yield eventListener.signal(ClientRuntime.Events.RequestCreated, urlV.value);
+      yield EOL;
+
+      // skip-for-time-being
+      // if (length(headerParams) > 0) {
+      //   yield '// add headers parameters';
+      //   for (const hp of headerParams) {
+      //     if (hp.param.name === 'Content-Length') {
+      //       // content length is set when the request body is set
+      //       continue;
+      //     }
+      //     yield hp.serializeToContainerMember(KnownMediaType.Header, new LocalVariable('request.Headers', dotnet.Var), hp.param.name, ClientRuntime.SerializationMode.None);
+      //   }
+      //   yield EOL;
+      // }
+      yield eventListener.signal(ClientRuntime.Events.HeaderParametersAdded, urlV.value);
+
+      if (bp) {
+        yield '// set body content';
+        yield `request.Content = ${bp.serializeToContent(bp.mediaType, ClientRuntime.SerializationMode.None)};`;
+        yield `request.Content.Headers.ContentType = ${System.Net.Http.Headers.MediaTypeHeaderValue.Parse(bp.contentType)};`;
+        yield eventListener.signal(ClientRuntime.Events.BodyContentSet, urlV.value);
+      }
+
+      yield '// make the call ';
+    });
+  }
+
+  emitCall(returnFromCall: boolean) {
+
+    // storage will return from the call for download, etc.
+    if (returnFromCall) {
+      this.returnType = System.Threading.Tasks.Task(System.Net.Http.HttpResponseMessage);
+    }
+
+    this.add(`await this.${this.callName}(request,${this.callbacks.joinWith(each => each.use, ',')},${this.contextParameter.use},${this.senderParameter.use});`);
+
+    // remove constant parameters and make them locals instead.
+    this.insert('// Constant Parameters');
+    for (let i = length(this.parameters); i--; i < 0) {
+      const p = this.parameters[i];
+      if (p && p.defaultInitializer) {
+        this.parameters.splice(i, 1);
+        this.insert(new LocalVariable(p.name, dotnet.Var, { initializer: p.defaultInitializer }));
+      }
+    }
+  }
+}
 export class CallMethod extends Method {
   public returnNull = false;
   constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
@@ -425,12 +656,12 @@ export class CallMethod extends Method {
 
             yield EOL;
             yield '// while we wait, let\'s grab the headers and get ready to poll. ';
-            yield 'if (!System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Azure-AsyncOperation"))) {'
+            yield 'if (!System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Azure-AsyncOperation"))) {';
             yield '    ' + asyncOperation.assign(response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
-            yield '}'
-            yield 'if (!global::System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Location"))) {'
+            yield '}';
+            yield 'if (!global::System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Location"))) {';
             yield '    ' + location.assign(response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
-            yield '}'
+            yield '}';
             const uriLocal = Local('_uri', Ternery(
               System.String.IsNullOrEmpty(asyncOperation),
               Ternery(System.String.IsNullOrEmpty(location),
@@ -618,17 +849,458 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
     yield `await ${eachResponse.details.csharp.name}(_response${callbackParameters.length === 0 ? '' : ','}${callbackParameters.joinWith(valueOf)});`;
   }
 
-  private responseHandler(mimetype: string, eachResponse: NewResponse, callbackParameter: CallbackParameter) {
+  public responseHandler(mimetype: string, eachResponse: NewResponse, callbackParameter: CallbackParameter) {
     return this.responseHandlerForNormalPipeline(mimetype, eachResponse, callbackParameter);
   }
 }
+export class NewCallMethod extends Method {
+  public returnNull = false;
+  constructor(protected parent: Class, protected opMethod: NewOperationMethod, protected state: NewState, objectInitializer?: DeepPartial<OperationMethod>) {
+    super(`${opMethod.name}_Call`, System.Threading.Tasks.Task());
+    this.description = `Actual wire call for <see cref="${opMethod.name}" /> method.`;
+    this.returnsDescription = opMethod.returnsDescription;
 
+    this.apply(objectInitializer);
+    this.access = Access.Internal;
+    this.async = Modifier.Async;
+    this.push(Using('NoSynchronizationContext', ''));
+
+    const $this = this;
+    // add parameters
+    // request, listener, sender
+    const reqParameter = this.addParameter(new Parameter('request', System.Net.Http.HttpRequestMessage, { description: 'the prepared HttpRequestMessage to send.' }));
+    opMethod.callbacks.forEach(each => this.addParameter(each));
+
+    this.addParameter(opMethod.contextParameter);
+    this.addParameter(opMethod.senderParameter);
+
+    // add statements to this method
+    this.add(function* () {
+      const eventListener = new EventListener(opMethod.contextParameter, $this.state.project.emitSignals);
+
+      const response = Local('_response', dotnet.Null, System.Net.Http.HttpResponseMessage);
+      yield response;
+      yield Try(function* () {
+
+        const responder = function* () {
+          // TODO: omit generating _contentType var if it will never be used
+          // const contentType = new LocalVariable('_contentType', dotnet.Var, { initializer: `_response.Content.Headers.ContentType?.MediaType` });
+          const contentType = Local('_contentType', `${response}.Content.Headers.ContentType?.MediaType`);
+
+          yield contentType;
+
+          // add response handlers
+          yield Switch(`${response}.StatusCode`, function* () {
+            for (const responses of values(opMethod.operation.responses)) {
+              if (responses.protocol.http?.statusCodes[0] !== 'default') {
+                const responseCode = responses.protocol.http?.statusCodes[0];
+                // will use enum when it can, fall back to casting int when it can't
+                yield Case(System.Net.HttpStatusCode[responseCode] ? System.Net.HttpStatusCode[responseCode].value : `(${System.Net.HttpStatusCode.declaration})${responseCode}`, $this.NewResponsesEmitter($this, opMethod, [responses], eventListener));
+              } else {
+                yield DefaultCase($this.NewResponsesEmitter($this, opMethod, [responses], eventListener));
+              }
+            }
+
+            // missing default response?
+            if (!opMethod.operation.exceptions) {
+              // if no default, we need one that handles the rest of the stuff.
+              yield TerminalDefaultCase(function* () {
+                yield `throw new ${ClientRuntime.fullName}.UndeclaredResponseException(_response);`;
+              });
+            }
+          });
+        };
+
+        // try statements
+        yield eventListener.signal(ClientRuntime.Events.BeforeCall, reqParameter.use);
+        yield `${response.value} = await ${opMethod.senderParameter.value}.SendAsync(${reqParameter.use}, ${opMethod.contextParameter.value});`;
+
+        yield eventListener.signal(ClientRuntime.Events.ResponseCreated, response.value);
+        const EOL = 'EOL';
+        // LRO processing (if appropriate)
+        if ($this.opMethod.operation.language.csharp?.lro) {
+          yield '// this operation supports x-ms-long-running-operation';
+          const originalUri = Local('_originalUri', new LiteralExpression(`${reqParameter.use}.RequestUri.AbsoluteUri`));
+          yield originalUri;
+
+          yield `// declared final-state-via: ${$this.opMethod.operation.language.csharp.lro['final-state-via']}`;
+          const fsv = $this.opMethod.operation.language.csharp.lro['final-state-via'];
+          let finalUri: LocalVariable;
+
+          switch (fsv) {
+            case 'original-uri':
+              // perform a final GET on the original URI.
+              finalUri = originalUri;
+              break;
+
+            case 'location':
+              // perform a final GET on the uri in Location header
+              finalUri = Local('_finalUri', response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+              yield finalUri;
+              break;
+            // skip-for-time-being
+            // case 'azure-asyncoperation':
+            // case 'azure-async-operation':
+            //   // depending on the type of request, do the appropriate behavior
+            //   switch ($this.opMethod.operation.method.toLowerCase()) {
+            //     case 'post':
+            //     case 'delete':
+            //       finalUri = Local('_finalUri', response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
+            //       yield finalUri;
+            //       break;
+            //     case 'patch':
+            //     case 'put':
+            //       // perform a final GET on the original URI.
+            //       finalUri = originalUri;
+            //       break;
+            //   }
+            //   break;
+
+            default:
+              // depending on the type of request, fall back to the appropriate behavior
+              if ($this.opMethod.operation.requests) {
+                switch ($this.opMethod.operation.requests[0].protocol.http?.method.toLowerCase()) {
+                  case 'post':
+                  case 'delete':
+                    finalUri = Local('_finalUri', response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+                    yield finalUri;
+                    break;
+                  case 'patch':
+                  case 'put':
+                    // perform a final GET on the original URI.
+                    finalUri = originalUri;
+                    break;
+                }
+              }
+              break;
+
+          }
+
+          const asyncOperation = Local('asyncOperation', response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
+          yield asyncOperation;
+          const location = Local('location', response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+          yield location;
+
+          yield While(new LiteralExpression(`${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `), function* () {
+            yield EOL;
+            yield '// get the delay before polling. (default to 30 seconds if not present)';
+            yield `int delay = (int)(${response.value}.Headers.RetryAfter?.Delta?.TotalSeconds ?? 30);`;
+            // yield If(`!int.TryParse( ${response.invokeMethod('GetFirstHeader', new StringExpression(`Retry-After`)).value}, out int delay)`, `delay = 30;`);
+
+            yield eventListener.signal(ClientRuntime.Events.DelayBeforePolling, '$"Delaying {delay} seconds before polling."', response.value);
+
+            yield EOL;
+            yield '// start the delay timer (we\'ll await later...)';
+            const waiting = Local('waiting', new LiteralExpression(`${System.Threading.Tasks.Task()}.Delay(delay * 1000, ${$this.opMethod.contextParameter}.Token )`));
+            yield waiting;
+
+            yield EOL;
+            yield '// while we wait, let\'s grab the headers and get ready to poll. ';
+            yield 'if (!System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Azure-AsyncOperation"))) {';
+            yield '    ' + asyncOperation.assign(response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
+            yield '}';
+            yield 'if (!global::System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Location"))) {';
+            yield '    ' + location.assign(response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+            yield '}';
+            const uriLocal = Local('_uri', Ternery(
+              System.String.IsNullOrEmpty(asyncOperation),
+              Ternery(System.String.IsNullOrEmpty(location),
+                originalUri,
+                location),
+              asyncOperation));
+            yield uriLocal;
+
+            yield `${reqParameter.use} = ${reqParameter.use}.CloneAndDispose(${System.Uri.new(uriLocal)}, ${ClientRuntime.Method.Get});`;
+
+            yield EOL;
+            yield '// and let\'s look at the current response body and see if we have some information we can give back to the listener';
+            const content = Local('content', new LiteralExpression(`await ${response.value}.Content.ReadAsStringAsync()`));
+            yield content;
+
+            yield 'await waiting;';
+
+            yield EOL;
+            yield '// check for cancellation';
+            yield `if( ${$this.opMethod.contextParameter}.Token.IsCancellationRequested ) { return; }`;
+
+            yield eventListener.signal(ClientRuntime.Events.Polling, `$"Polling {${uriLocal}}."`, response.value);
+
+            yield EOL;
+            yield '// drop the old response';
+            yield `${response.value}?.Dispose();`;
+
+            yield EOL;
+            yield '// make the polling call';
+            yield `${response.value} = await ${opMethod.senderParameter}.SendAsync(${reqParameter.value}, ${opMethod.contextParameter});`;
+
+
+            yield EOL;
+            yield `
+// if we got back an OK, take a peek inside and see if it's done
+if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
+{
+    try {
+        if( ${ClientRuntime.JsonNode.Parse(toExpression(`await ${response.value}.Content.ReadAsStringAsync()`))} is ${ClientRuntime.JsonObject} json)
+        {
+            var state = json.Property("properties")?.PropertyT<${ClientRuntime.JsonString}>("provisioningState") ?? json.PropertyT<${ClientRuntime.JsonString}>("status");
+            if( state is null ) 
+            {
+              // the body doesn't contain any information that has the state of the LRO
+              // we're going to just get out, and let the consumer have the result
+              break;
+            }
+            await ${$this.opMethod.contextParameter}.Signal(${ClientRuntime.Events.Polling}, $"Polled {${uriLocal}} provisioning state  {state}.", ${response.value}); if( ${$this.opMethod.contextParameter}.Token.IsCancellationRequested ) { return; }
+
+            switch( state?.ToString()?.ToLower() )
+            {
+              case "succeeded":
+              case "failed":
+              case "canceled":
+                // we're done polling.
+                break;
+
+              default: 
+                // need to keep polling!
+                ${response.value}.StatusCode = ${System.Net.HttpStatusCode.Created};
+                continue;
+            }
+        }
+    } catch {
+        // if we run into a problem peeking into the result, 
+        // we really don't want to do anything special.
+    }
+}`;
+
+            yield EOL;
+            yield '// check for terminal status code';
+            yield If(new LiteralExpression(`${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `), 'continue;');
+
+            yield '// we are done polling, do a request on final target?';
+
+            switch (fsv) {
+              case 'original-uri':
+              case 'azure-asyncoperation':
+              case 'azure-async-operation':
+              case 'location':
+                // perform a final GET on the specified final URI.
+                yield $this.finalGet(finalUri, reqParameter, response);
+                break;
+
+              default:
+                yield If(`!string.IsNullOrWhiteSpace(${finalUri})`, function* () {
+                  yield $this.finalGet(finalUri, reqParameter, response);
+                });
+                break;
+            }
+          });
+
+        }
+        yield responder();
+      });
+
+      yield Finally(function* () {
+        yield '// finally statements';
+        yield eventListener.signalNoCheck(ClientRuntime.Events.Finally, 'request', '_response');
+        yield `${response.value}?.Dispose();`;
+        yield `${reqParameter.use}?.Dispose();`;
+      });
+
+      if ($this.returnNull) {
+        yield Return('result');
+        $this.insert(new LocalVariable('result', System.Net.Http.HttpResponseMessage, { initializer: dotnet.Null }));
+      }
+    });
+
+    this.opMethod.emitCall($this.returnNull);
+  }
+
+  private * finalGet(finalLocation: ExpressionOrLiteral, reqParameter: Variable, response: Variable) {
+    yield '// create a new request with the final uri';
+    yield reqParameter.assign(`${valueOf(reqParameter)}.CloneAndDispose(${System.Uri.new(finalLocation)}, ${ClientRuntime.Method.Get})`);
+
+    yield EOL;
+    yield '// drop the old response';
+    yield `${response.value}?.Dispose();`;
+
+    yield EOL;
+    yield '// make the final call';
+    yield response.assign(`await ${this.opMethod.senderParameter}.SendAsync(${valueOf(reqParameter)},  ${this.opMethod.contextParameter})`);
+
+    // make sure we're not polling anymore.
+    yield 'break;';
+  }
+
+  private * responsesEmitter($this: CallMethod, opMethod: OperationMethod, responses: Array<NewResponse>, eventListener: EventListener) {
+    if (length(responses) > 1) {
+      yield Switch('_contentType', function* () {
+        for (const eachResponse of values(responses)) {
+          const mimetype = length(eachResponse.mimeTypes) > 0 ? eachResponse.mimeTypes[0] : '';
+          const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === eachResponse.details.csharp.name);
+
+          let count = length(eachResponse.mimeTypes);
+          for (const mt of values(eachResponse.mimeTypes)) {
+            count--;
+            const mediaType = normalizeMediaType(mt);
+            if (mediaType) {
+              if (count === 0) {
+                yield Case(new StringExpression(mediaType).toString(), $this.responseHandler(mimetype, eachResponse, callbackParameter));
+              } else {
+                yield TerminalCase(new StringExpression(mediaType).toString(), '');
+              }
+            }
+          }
+        }
+      });
+    } else {
+      const response = responses[0];
+      const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === response.details.csharp.name);
+      // all mimeTypes per for this response code.
+      yield eventListener.signal(ClientRuntime.Events.BeforeResponseDispatch, '_response');
+      yield $this.responseHandler(values(response.mimeTypes).first() || '', response, callbackParameter);
+    }
+  }
+
+  private * NewResponsesEmitter($this: NewCallMethod, opMethod: NewOperationMethod, responses: Array<Response>, eventListener: EventListener) {
+    if (length(responses) > 1) {
+      yield Switch('_contentType', function* () {
+        for (const eachResponse of values(responses)) {
+          const mimetype = length(eachResponse.protocol.http?.mediaTypes) > 0 ? eachResponse.protocol.http?.mimeTypes[0] : '';
+          const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === eachResponse.language.csharp?.name);
+
+          let count = length(eachResponse.protocol.http?.mediaTypes);
+          for (const mt of values(eachResponse.protocol.http?.mediaTypes)) {
+            count--;
+            const mediaType = normalizeMediaType(<string>mt);
+            if (mediaType) {
+              if (count === 0) {
+                yield Case(new StringExpression(mediaType).toString(), $this.NewResponseHandler(mimetype, eachResponse, callbackParameter));
+              } else {
+                yield TerminalCase(new StringExpression(mediaType).toString(), '');
+              }
+            }
+          }
+        }
+      });
+    } else {
+      const response = responses[0];
+      const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === response.language.csharp?.name);
+      // all mimeTypes per for this response code.
+      yield eventListener.signal(ClientRuntime.Events.BeforeResponseDispatch, '_response');
+      yield $this.NewResponseHandler(<string>values(response.protocol.http?.mediaTypes).first() || '', response, callbackParameter);
+    }
+  }
+
+  private * responseHandlerForNormalPipeline(mimetype: string, eachResponse: NewResponse, callbackParameter: CallbackParameter) {
+    const callbackParameters = new Array<ExpressionOrLiteral>();
+
+    if (callbackParameter.responseType) {
+      // hande the body response
+      const r = callbackParameter.responseType.deserializeFromResponse(knownMediaType(mimetype), toExpression('_response'), toExpression('null'));
+      if (r) {
+
+        callbackParameters.push(r);
+      }
+
+      // if (parseMediaType(mimetype)) {
+      // this media type isn't directly supported by deserialization
+      // we can return a stream to the consumer instead
+      // }
+    }
+
+    if (callbackParameter.headerType) {
+      // header model deserialization...
+      const r = callbackParameter.headerType.deserializeFromResponse(KnownMediaType.Header, toExpression('_response'), toExpression('null'));
+      if (r) {
+        callbackParameters.push(r);
+      }
+    }
+    // make the callback with the appropriate parameters
+    yield `await ${eachResponse.details.csharp.name}(_response${callbackParameters.length === 0 ? '' : ','}${callbackParameters.joinWith(valueOf)});`;
+  }
+
+  private * NewResponseHandlerForNormalPipeline(mimetype: string, eachResponse: Response, callbackParameter: CallbackParameter) {
+    const callbackParameters = new Array<ExpressionOrLiteral>();
+
+    if (callbackParameter.responseType) {
+      // hande the body response
+      const r = callbackParameter.responseType.deserializeFromResponse(knownMediaType(mimetype), toExpression('_response'), toExpression('null'));
+      if (r) {
+
+        callbackParameters.push(r);
+      }
+
+      // if (parseMediaType(mimetype)) {
+      // this media type isn't directly supported by deserialization
+      // we can return a stream to the consumer instead
+      // }
+    }
+
+    if (callbackParameter.headerType) {
+      // header model deserialization...
+      const r = callbackParameter.headerType.deserializeFromResponse(KnownMediaType.Header, toExpression('_response'), toExpression('null'));
+      if (r) {
+        callbackParameters.push(r);
+      }
+    }
+    // make the callback with the appropriate parameters
+    yield `await ${eachResponse.language.csharp?.name}(_response${callbackParameters.length === 0 ? '' : ','}${callbackParameters.joinWith(valueOf)});`;
+  }
+
+  private responseHandler(mimetype: string, eachResponse: NewResponse, callbackParameter: CallbackParameter) {
+    return this.responseHandlerForNormalPipeline(mimetype, eachResponse, callbackParameter);
+  }
+  private NewResponseHandler(mimetype: string, eachResponse: Response, callbackParameter: CallbackParameter) {
+    return this.NewResponseHandlerForNormalPipeline(mimetype, eachResponse, callbackParameter);
+  }
+}
 export class ValidationMethod extends Method {
 
   constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
     super(`${opMethod.operation.details.csharp.name}_Validate`, System.Threading.Tasks.Task());
     this.apply(objectInitializer);
     this.description = `Validation method for <see cref="${opMethod.operation.details.csharp.name}" /> method. Call this like the actual call, but you will get validation events back.`;
+    this.returnsDescription = opMethod.returnsDescription;
+    this.access = Access.Internal;
+    this.async = Modifier.Async;
+    this.push(Using('NoSynchronizationContext', ''));
+
+    // add the method parameters
+    for (const parameter of opMethod.methodParameters) {
+      if (!parameter.defaultInitializer) {
+        this.addParameter(parameter);
+      }
+    }
+
+    if (opMethod.bodyParameter) {
+      this.addParameter(opMethod.bodyParameter);
+    }
+
+    this.addParameter(opMethod.contextParameter);
+
+    // add statements to this method
+    this.add(function* () {
+      for (const parameter of opMethod.methodParameters) {
+        if (!parameter.defaultInitializer) {
+          // spit out parameter validation
+          yield parameter.validatePresenceStatement(opMethod.contextParameter);
+          yield parameter.validationStatement(opMethod.contextParameter);
+        }
+      }
+
+      // spit out body parameter validation too
+      if (opMethod.bodyParameter) {
+        yield opMethod.bodyParameter.validatePresenceStatement(opMethod.contextParameter);
+        yield opMethod.bodyParameter.validationStatement(opMethod.contextParameter);
+      }
+    });
+  }
+}
+export class NewValidationMethod extends Method {
+
+  constructor(protected parent: Class, protected opMethod: NewOperationMethod, protected state: NewState, objectInitializer?: DeepPartial<OperationMethod>) {
+    super(`${opMethod.name}_Validate`, System.Threading.Tasks.Task());
+    this.apply(objectInitializer);
+    this.description = `Validation method for <see cref="${opMethod.name}" /> method. Call this like the actual call, but you will get validation events back.`;
     this.returnsDescription = opMethod.returnsDescription;
     this.access = Access.Internal;
     this.async = Modifier.Async;

--- a/powershell/llcsharp/operation/namespace.ts
+++ b/powershell/llcsharp/operation/namespace.ts
@@ -6,12 +6,12 @@
 import { ImportDirective } from '@azure-tools/codegen-csharp';
 import { Namespace } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
-import { State } from '../generator';
+import { State, NewState } from '../generator';
 import { DeepPartial } from '@azure-tools/codegen';
 
 export class ServiceNamespace extends Namespace {
-  constructor(public state: State, objectInitializer?: DeepPartial<ServiceNamespace>) {
-    super(state.model.details.csharp.namespace || 'INVALID.NAMESPACE', state.project);
+  constructor(public state: State | NewState, objectInitializer?: DeepPartial<ServiceNamespace>) {
+    super(state instanceof NewState ? state.model.language.csharp?.namespace : state.model.details.csharp.namespace || 'INVALID-NAMESPACE', state.project);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
   }

--- a/powershell/llcsharp/project.ts
+++ b/powershell/llcsharp/project.ts
@@ -7,12 +7,13 @@ import { Host } from '@azure-tools/autorest-extension-base';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { Project as codeDomProject } from '@azure-tools/codegen-csharp';
 
-import { State } from './generator';
-import { ModelsNamespace } from './model/namespace';
+import { State, NewState } from './generator';
+import { ModelsNamespace, NewModelsNamespace } from './model/namespace';
 import { ApiClass } from './operation/api-class';
 import { ServiceNamespace } from './operation/namespace';
 import { SupportNamespace } from './enums/namespace';
 import { DeepPartial } from '@azure-tools/codegen';
+
 
 export class Project extends codeDomProject {
 
@@ -89,5 +90,83 @@ export class Project extends codeDomProject {
 
   public serviceNamespace!: ServiceNamespace;
   public modelsNamespace!: ModelsNamespace;
+  public supportNamespace!: SupportNamespace;
+}
+
+export class NewProject extends codeDomProject {
+
+  public jsonSerialization = true;
+  public xmlSerialization = false;
+  public defaultPipeline = true;
+  public emitSignals = true;
+  public projectNamespace!: string;
+  public overrides!: Dictionary<string>;
+  protected state!: NewState;
+
+  apifolder!: string;
+  runtimefolder!: string;
+  azure!: boolean;
+  license!: string;
+  identityCorrection!: boolean;
+
+  constructor(protected service: Host, objectInitializer?: DeepPartial<Project>) {
+    super();
+    this.apply(objectInitializer);
+  }
+
+  public async init(): Promise<this> {
+    await super.init();
+
+    this.state = await new NewState(this.service).init(this);
+    this.apifolder = await this.state.getValue('api-folder', '');
+    this.runtimefolder = await this.state.getValue('runtime-folder', 'runtime');
+    this.azure = await this.state.getValue('azure', false) || await this.state.getValue('azure-arm', false);
+    this.identityCorrection = await this.state.getValue('identity-correction-for-post', false);
+    this.license = await this.state.getValue('header-text', '');
+
+
+    // add project namespace
+    this.projectNamespace = this.state.model.language.csharp?.namespace;
+    this.overrides = {
+      'Carbon.Json.Converters': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Internal.Extensions': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Internal': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Json.Parser': `${this.projectNamespace}.Runtime.Json`,
+      'Carbon.Data': `${this.projectNamespace}.Runtime.Json`,
+      'using Converters;': '',
+      'using Internal.Extensions;': '',
+      'using Data;': '',
+      'using Parser;': '',
+
+      'Carbon.Json': `${this.projectNamespace}.Runtime.Json`,
+      'Microsoft.Rest.ClientRuntime': `${this.projectNamespace}.Runtime`,
+      'Microsoft.Rest': this.projectNamespace
+    };
+
+    this.serviceNamespace = new ServiceNamespace(this.state);
+    this.serviceNamespace.header = this.license;
+    this.addNamespace(this.serviceNamespace);
+
+    // add support namespace
+    this.supportNamespace = new SupportNamespace(this.serviceNamespace, this.state);
+    this.supportNamespace.header = this.license;
+    this.addNamespace(this.supportNamespace);
+
+    // add model classes
+    this.modelsNamespace = new NewModelsNamespace(this.serviceNamespace, this.state.model.schemas, this.state.path('components', 'schemas'));
+    this.modelsNamespace.header = this.license;
+    this.addNamespace(this.modelsNamespace);
+
+    // create API class
+    new ApiClass(this.serviceNamespace, this.state, { description: `Low-level API implementation for the ${this.state.model.info.title} service. \n${this.state.model.info.description || ''}` });
+
+    // abort now if we have any errors.
+    this.state.checkpoint();
+
+    return this;
+  }
+
+  public serviceNamespace!: ServiceNamespace;
+  public modelsNamespace!: NewModelsNamespace;
   public supportNamespace!: SupportNamespace;
 }

--- a/powershell/llcsharp/schema/extended-type-declaration.ts
+++ b/powershell/llcsharp/schema/extended-type-declaration.ts
@@ -9,6 +9,7 @@ import { OneOrMoreStatements } from '@azure-tools/codegen-csharp';
 import { TypeDeclaration } from '@azure-tools/codegen-csharp';
 import { Variable } from '@azure-tools/codegen-csharp';
 import { Schema } from '../code-model';
+import { Schema as NewSchema } from '@azure-tools/codemodel';
 
 /** A TypeDeclaration that can assist in generating code for a variety of serialization, validation and other common use cases */
 export interface EnhancedTypeDeclaration extends TypeDeclaration {
@@ -48,7 +49,7 @@ export interface EnhancedTypeDeclaration extends TypeDeclaration {
   isXmlAttribute: boolean;
 
   /** the underlying schema for this type declarartion. */
-  schema: Schema;
+  schema: Schema | NewSchema;
 
   isNullable: boolean;
 

--- a/powershell/llcsharp/schema/object.ts
+++ b/powershell/llcsharp/schema/object.ts
@@ -14,6 +14,7 @@ import { Ternery } from '@azure-tools/codegen-csharp';
 import { Variable } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
+import { Schema as NewSchema } from '@azure-tools/codemodel';
 import { popTempVar, pushTempVar } from './primitive';
 import { EnhancedTypeDeclaration } from './extended-type-declaration';
 
@@ -177,5 +178,169 @@ export class ObjectImplementation implements EnhancedTypeDeclaration {
 
   get declaration(): string { return `${this.schema.details.csharp.namespace}.${this.schema.details.csharp.interfaceName}`; }
   get classDeclaration(): string { return `${this.schema.details.csharp.namespace}.${this.schema.details.csharp.name}`; }
+
+}
+
+export class NewObjectImplementation implements EnhancedTypeDeclaration {
+  public isXmlAttribute = false;
+
+  get defaultOfType() {
+    return toExpression('null /* object */');
+  }
+
+  get isNullable(): boolean {
+    return true;
+  }
+
+  get convertObjectMethod() {
+    return `${this.schema.language.csharp?.fullname}TypeConverter.ConvertFrom`;
+  }
+
+  deserializeFromContainerMember(mediaType: KnownMediaType, container: ExpressionOrLiteral, serializedName: string, defaultValue: Expression): Expression {
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        // JsonObject
+        const tmp = `__${camelCase(['json', ...deconstruct(serializedName)])}`;
+        return toExpression(`If( ${valueOf(container)}?.PropertyT<${ClientRuntime.JsonObject}>("${serializedName}"), out var ${tmp}) ? ${this.classDeclaration}.FromJson(${tmp}) : ${defaultValue}`);
+      }
+
+      case KnownMediaType.Xml: {
+        // XElement/XElement or XElement/XAttribute
+        const tmp = `__${camelCase(['xml', ...deconstruct(serializedName)])}`;
+        // prefer specified XML name if available
+        return toExpression(`If( ${valueOf(container)}?.Element("${this.schema.serialization?.xml ? this.schema.serialization.xml.name || serializedName : serializedName}"), out var ${tmp}) ? ${this.classDeclaration}.FromXml(${tmp}) : ${defaultValue}`);
+      }
+    }
+    return toExpression(`${defaultValue} /* deserializeFromContainerMember doesn't support '${mediaType}' ${__filename} */`);
+  }
+  /** emits an expression to deserialze a container as the value itself. */
+  deserializeFromNode(mediaType: KnownMediaType, node: ExpressionOrLiteral, defaultValue: Expression): Expression {
+    try {
+      const tmp = pushTempVar();
+      switch (mediaType) {
+        case KnownMediaType.Json: {
+          // we're always going to go thru FromJson; it'll handle nulls and polymorphism.
+          return toExpression(`${this.classDeclaration}.FromJson(${node}) `);
+        }
+        case KnownMediaType.Xml: {
+
+          return toExpression(`If( ${valueOf(node)}, out var ${tmp}) ? ${this.classDeclaration}.FromXml(${tmp}) : ${defaultValue}`);
+        }
+      }
+    } finally {
+      popTempVar();
+    }
+    return toExpression(`null /* deserializeFromNode doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  /** emits an expression serialize this to a HttpContent */
+  serializeToNode(mediaType: KnownMediaType, value: ExpressionOrLiteral, serializedName: string, mode: Expression): Expression {
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        return toExpression(`${value}?.ToJson(null, ${mode.value})`);
+      }
+      case KnownMediaType.Xml: {
+        return toExpression(`${value}?.ToXml(null, ${mode.value})`);
+      }
+    }
+    return toExpression(`null /* serializeToNode doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  /** emits an expression serialize this to the value required by the container */
+  serializeToContent(mediaType: KnownMediaType, value: ExpressionOrLiteral, mode: Expression): Expression {
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        return System.Net.Http.StringContent.new(
+          Ternery(
+            IsNotNull(value),
+            `${value}.ToJson(null).ToString()`,
+            new StringExpression('{}')),
+          System.Text.Encoding.UTF8);
+      }
+      case KnownMediaType.Xml: {
+        return System.Net.Http.StringContent.new(
+          Ternery(
+            IsNotNull(value),
+            `${value}.ToXml(null).ToString()`,
+            System.String.Empty),
+          System.Text.Encoding.UTF8);
+      }
+      //skip-for-time-being
+      //       case KnownMediaType.Multipart: {
+      //         let contents = '';
+      //         for (const p of values(this.schema.properties)) {
+      //           // to do -- add in a potential support for the filename too.
+      //           contents = `${contents}${EOL}    bodyContent.Add( ${System.Net.Http.StreamContent.new(`${value}.${p.details.csharp.name}`)},"${p.serializedName}");`;
+      //         }
+      //         // bodyContent.Add(new _ystem.Net.Http.StreamContent(body.AudioFile), "audioFile");
+      //         return toExpression(`new ${System.Func(System.Net.Http.MultipartFormDataContent)}(() =>
+      // {
+      //     var bodyContent = ${System.Net.Http.MultipartFormDataContent.new()};
+      //     ${contents}
+      //     return bodyContent;
+      // })()`);
+      //       }
+    }
+    return toExpression(`null /* serializeToContent doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  /** emits an expression to deserialize content from a string */
+  deserializeFromString(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        return this.deserializeFromNode(mediaType, ClientRuntime.JsonNode.Parse(content), defaultValue);
+      }
+      case KnownMediaType.Xml: {
+        return this.deserializeFromNode(mediaType, `${System.Xml.Linq.XElement}.Parse(${content})`, defaultValue);
+      }
+    }
+    return undefined;
+  }
+
+  /** emits an expression to deserialize content from a content/response */
+  deserializeFromResponse(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        if (this.schema.language.csharp?.hasHeaders) {
+          return toExpression(`${content}.Content.ReadAsStringAsync().ContinueWith( body => ${this.deserializeFromString(mediaType, 'body.Result', defaultValue)}.ReadHeaders(_response.Headers))`);
+        }
+        return toExpression(`${content}.Content.ReadAsStringAsync().ContinueWith( body => ${this.deserializeFromString(mediaType, 'body.Result', defaultValue)})`);
+      }
+      case KnownMediaType.Xml: {
+        return toExpression(`${content}.Content.ReadAsStringAsync().ContinueWith( body => ${this.deserializeFromString(mediaType, 'body.Result', defaultValue)})`);
+      }
+    }
+    return toExpression(`null /* deserializeFromResponse doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  /** emits the code required to serialize this into a container */
+  serializeToContainerMember(mediaType: KnownMediaType, value: ExpressionOrLiteral, container: Variable, serializedName: string, mode: Expression): OneOrMoreStatements {
+    // const v = (<any>value).valuePrivate || value;
+    switch (mediaType) {
+      case KnownMediaType.Json:
+        return `AddIf( null != ${value} ? (${ClientRuntime.JsonNode}) ${value}.ToJson(null,${mode.value}) : null, "${serializedName}" ,${container}.Add );`;
+
+      case KnownMediaType.Xml:
+        // prefer specified XML name if available
+        return `AddIf( null != ${value} ? ${value}.ToXml(new ${System.Xml.Linq.XElement}("${this.schema.serialization?.xml ? this.schema.serialization.xml.name || serializedName : serializedName}")) : null, ${container}.Add );`;
+
+    }
+    return `/* serializeToContainerMember doesn't support '${mediaType}' ${__filename}*/`;
+  }
+
+  isRequired = false;
+
+  constructor(public schema: NewSchema) {
+  }
+
+  public validatePresence(eventListener: Variable, property: Variable): OneOrMoreStatements {
+    return `await ${eventListener}.AssertNotNull(${nameof(property.value)}, ${property}); `.trim();
+  }
+  public validateValue(eventListener: Variable, property: Variable): OneOrMoreStatements {
+    return `await ${eventListener}.AssertObjectIsValid(${nameof(property.value)}, ${property}); `;
+  }
+
+  get declaration(): string { return `${this.schema.language.csharp?.namespace}.${this.schema.language.csharp?.interfaceName}`; }
+  get classDeclaration(): string { return `${this.schema.language.csharp?.namespace}.${this.schema.language.csharp?.name}`; }
 
 }

--- a/powershell/llcsharp/schema/schema-resolver.ts
+++ b/powershell/llcsharp/schema/schema-resolver.ts
@@ -3,6 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { codeModelSchema, ArraySchema, CodeModel, Schema as NewSchema, StringSchema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
+
 import { ModelState, codemodel, IntegerFormat, NumberFormat, StringFormat, JsonType } from '@azure-tools/codemodel-v3';
 import { Schema } from '../code-model';
 import * as message from '../messages';
@@ -16,10 +18,13 @@ import { DateTime, DateTime1123, UnixTime } from './date-time';
 import { Duration } from './duration';
 import { EnumImplementation } from './enum';
 import { Numeric } from './integer';
-import { ObjectImplementation } from './object';
-import { String } from './string';
+import { ObjectImplementation, NewObjectImplementation } from './object';
+import { String, NewString } from './string';
 import { Uuid } from './Uuid';
 import { EnhancedTypeDeclaration } from './extended-type-declaration';
+import { PwshModel } from '../../utils/PwshModel';
+import { NewModelState } from '../../utils/model-state';
+import { Channel, Host, Session, startSession } from '@azure-tools/autorest-extension-base';
 
 export class SchemaDefinitionResolver {
   private readonly cache = new Map<string, EnhancedTypeDeclaration>();
@@ -142,6 +147,86 @@ export class SchemaDefinitionResolver {
 
     }
     state.error(`Schema '${schema.details.csharp.name}' is declared with invalid type '${schema.type}'`, message.UnknownJsonType);
+    throw new Error('Unknown Model. Fatal.');
+  }
+
+}
+
+export class NewSchemaDefinitionResolver {
+  private readonly cache = new Map<string, EnhancedTypeDeclaration>();
+  private add(schema: NewSchema, value: EnhancedTypeDeclaration): EnhancedTypeDeclaration {
+    this.cache.set(schema.language?.csharp?.fullname || '', value);
+    return value;
+  }
+
+  resolveTypeDeclaration(schema: NewSchema | undefined, required: boolean, state: NewModelState<PwshModel>): EnhancedTypeDeclaration {
+    if (!schema) {
+      throw new Error('SCHEMA MISSING?');
+    }
+
+    // determine if we need a new model class for the type or just a known type object
+    switch (schema.type) {
+      // case SchemaType.Array: {
+      //   // can be recursive!
+      //   // handle boolean arrays as booleans (powershell will try to turn it into switches!)
+      //   const ar = <ArraySchema>schema;
+      //   const elementType = (ar.elementType.type === SchemaType.Boolean) ? new Boolean(schema, true) : this.resolveTypeDeclaration(<Schema>schema.items, true, state.path('items'));
+      //   return new ArrayOf(schema, required, elementType, ar.minItems, ar.maxItems, ar.uniqueItems);
+      // }
+
+      case SchemaType.Object: {
+        const result = schema.language.csharp && this.cache.get(schema.language.csharp.fullname || '');
+        if (result) {
+          return result;
+        }
+        return this.add(schema, new NewObjectImplementation(schema));
+      }
+      case SchemaType.String: {
+        return new NewString(<StringSchema>schema, required);
+
+      }
+
+      // case JsonType.Boolean:
+      //   return new Boolean(schema, required);
+
+      // case JsonType.Integer:
+      //   switch (schema.format) {
+      //     case IntegerFormat.Int64:
+      //     case IntegerFormat.None:
+      //       return new Numeric(schema, required, required ? 'long' : 'long?');
+      //     case IntegerFormat.UnixTime:
+      //       return new UnixTime(schema, required);
+      //     case IntegerFormat.Int32:
+      //       return new Numeric(schema, required, required ? 'int' : 'int?');
+      //   }
+      //   // fallback to int if the format isn't recognized
+      //   return new Numeric(schema, required, required ? 'int' : 'int?');
+
+      // case JsonType.Number:
+      //   switch (schema.format) {
+      //     case NumberFormat.None:
+      //     case NumberFormat.Double:
+      //       return new Numeric(schema, required, required ? 'double' : 'double?');
+      //     case NumberFormat.Float:
+      //       return new Numeric(schema, required, required ? 'float' : 'float?');
+      //     case NumberFormat.Decimal:
+      //       return new Numeric(schema, required, required ? 'decimal' : 'decimal?');
+      //   }
+      //   // fallback to float if the format isn't recognized
+      //   return new Numeric(schema, required, required ? 'float' : 'float?');
+
+      // case undefined:
+      //   if (schema.extensions && schema.extensions['x-ms-enum']) {
+      //     return new EnumImplementation(schema, required);
+      //   }
+
+      // "any" case
+      // this can happen when a model is just an all-of something else. (sub in the other type?)
+      case undefined:
+        break;
+
+    }
+    state.error(`Schema '${schema.language.csharp?.name}' is declared with invalid type '${schema.type}'`, message.UnknownJsonType);
     throw new Error('Unknown Model. Fatal.');
   }
 }

--- a/powershell/llcsharp/schema/string.ts
+++ b/powershell/llcsharp/schema/string.ts
@@ -12,6 +12,7 @@ import { OneOrMoreStatements } from '@azure-tools/codegen-csharp';
 import { Variable } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
+import { Schema as NewSchema, StringSchema } from '@azure-tools/codemodel';
 import { popTempVar, pushTempVar } from './primitive';
 import { EnhancedTypeDeclaration } from './extended-type-declaration';
 import { length } from '@azure-tools/linq';
@@ -206,4 +207,196 @@ ${this.validateEnum(eventListener, property)}
     }
     return `await ${eventListener}.AssertEnum(${nameof(property.value)},${property},${this.schema.enum.joinWith((v) => `@"${v}"`)});`;
   }
+}
+
+/** A ETD for the c# string type. */
+export class NewString implements EnhancedTypeDeclaration {
+  public isXmlAttribute = false;
+
+  get defaultOfType() {
+    return toExpression('null');
+  }
+  get convertObjectMethod() {
+    return 'global::System.Convert.ToString';
+  }
+
+  get isNullable(): boolean {
+    return true;
+  }
+
+  get encode(): string {
+    return this.schema.extensions && this.schema.extensions['x-ms-skip-url-encoding'] ? '' : 'global::System.Uri.EscapeDataString';
+  }
+
+  deserializeFromContainerMember(mediaType: KnownMediaType, container: ExpressionOrLiteral, serializedName: string, defaultValue: Expression): Expression {
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        // container should be a JsonObject
+        const tmpVar = `__${camelCase(['json', ...deconstruct(serializedName)])}`;
+        return toExpression(`If( ${valueOf(container)}?.PropertyT<${ClientRuntime.JsonString}>("${serializedName}"), out var ${tmpVar}) ? (string)${tmpVar} : (string)${defaultValue}`);
+      }
+      case KnownMediaType.Xml: {
+        const xTmp = `__${camelCase(['xml', ...deconstruct(serializedName)])}`;
+        return toExpression(`If( ${valueOf(container)}?.Element("${serializedName}"), out var ${xTmp}) ? (string)${xTmp} : (string)${defaultValue}`);
+      }
+      case KnownMediaType.Header: {
+        // HttpResponseHeaders
+        const tmp = `__${camelCase(['header', ...deconstruct(serializedName)])}`;
+        return toExpression(`System.Linq.Enumerable.FirstOrDefault(${serializedName}) is string ${tmp} ? ${tmp} : (string)${defaultValue}`);
+      }
+    }
+    return toExpression(`${defaultValue} /* deserializeFromContainerMember doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  deserializeFromNode(mediaType: KnownMediaType, node: ExpressionOrLiteral, defaultValue: Expression): Expression {
+    try {
+      const tmp = pushTempVar();
+      switch (mediaType) {
+        case KnownMediaType.Json:
+          // node should be a JsonString
+          return toExpression(`${node} is ${ClientRuntime.JsonString} ${tmp} ? (${this.declaration})(${tmp}.ToString()) : ${defaultValue}`);
+
+        case KnownMediaType.Xml:
+          return toExpression(`${node} is ${System.Xml.Linq.XElement} ${tmp} ? (string)${tmp} : ${defaultValue}`);
+      }
+    } finally {
+      popTempVar();
+    }
+    return toExpression(`null /* deserializeFromContainer doesn't support '${mediaType}' ${__filename}*/`);
+  }
+  /** emits an expression serialize this to a HttpContent */
+  serializeToContent(mediaType: KnownMediaType, value: ExpressionOrLiteral, mode: Expression): Expression {
+    return toExpression(`null /* serializeToContent doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  serializeToNode(mediaType: KnownMediaType, value: ExpressionOrLiteral, serializedName: string, mode: Expression): Expression {
+    switch (mediaType) {
+      case KnownMediaType.Json:
+        return toExpression(`null != (((object)${value})?.ToString()) ? (${ClientRuntime.JsonNode}) new ${ClientRuntime.JsonString}(${value}.ToString()) : null`);
+
+      case KnownMediaType.Xml:
+        return toExpression(`null != (${value}?.ToString()) ? new ${System.Xml.Linq.XElement}("${serializedName}",${value}) : null`);
+
+      case KnownMediaType.QueryParameter:
+
+        if (this.isRequired) {
+          return toExpression(`"${serializedName}=" + ${this.encode}(${value})`);
+        } else {
+          return toExpression(`(string.IsNullOrEmpty(${value}) ? ${System.String.Empty} : "${serializedName}=" + ${this.encode}(${valueOf(value)}))`);
+        }
+
+      case KnownMediaType.Cookie:
+      case KnownMediaType.Header:
+      case KnownMediaType.Text:
+      case KnownMediaType.UriParameter:
+        if (this.isRequired) {
+          return toExpression(`${this.encode}(${value})`);
+        }
+        return toExpression(`(string.IsNullOrEmpty(${value}) ? ${System.String.Empty} : ${this.encode}(${value}) )`);
+
+    }
+    return toExpression(`null /* serializeToNode doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  /** emits an expression to deserialize content from a string */
+  deserializeFromString(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+
+    switch (mediaType) {
+      case KnownMediaType.Json: {
+        return this.deserializeFromNode(mediaType, ClientRuntime.JsonNode.Parse(content), defaultValue);
+      }
+      case KnownMediaType.Xml: {
+        return this.deserializeFromNode(mediaType, `${System.Xml.Linq.XElement}.Parse(${content})`, defaultValue);
+      }
+      case KnownMediaType.UriParameter: {
+        return toExpression(content);
+      }
+    }
+    return toExpression(`null /* deserializeFromString doesn't support '${mediaType}' ${__filename}`);
+  }
+
+  /** emits an expression to deserialize content from a content/response */
+  deserializeFromResponse(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    switch (mediaType) {
+      case KnownMediaType.Json:
+        return toExpression(`${content}.Content.ReadAsStringAsync().ContinueWith( body => ${this.deserializeFromString(mediaType, 'body.Result', defaultValue)})`);
+
+    }
+    return toExpression(`null /* deserializeFromResponse doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  serializeToContainerMember(mediaType: KnownMediaType, value: ExpressionOrLiteral, container: Variable, serializedName: string, mode: Expression): OneOrMoreStatements {
+    switch (mediaType) {
+      case KnownMediaType.Json:
+        return `AddIf( ${this.serializeToNode(mediaType, value, serializedName, mode)}, "${serializedName}" ,${container}.Add );`;
+
+      case KnownMediaType.Xml:
+        return `AddIf( ${this.serializeToNode(mediaType, value, serializedName, mode)}, ${container}.Add );`;
+
+      case KnownMediaType.Header:
+        // container : HttpRequestHeaders
+        return this.isRequired ?
+          `${valueOf(container)}.Add("${serializedName}",${value}.ToString());` :
+          If(`null != ${value}`, `${valueOf(container)}.Add("${serializedName}",${value});`);
+
+      case KnownMediaType.QueryParameter:
+        // gives a name=value for use inside a c# template string($"foo{someProperty}") as a query parameter
+        return this.isRequired ?
+          `${serializedName}={${value}.ToString()}` :
+          `{null == ${value} ? ${System.String.Empty} : $"${serializedName}={${value}.ToString()}"}`;
+
+      case KnownMediaType.UriParameter:
+        // gives a name=value for use inside a c# template string($"foo{someProperty}") as a query parameter
+        return this.isRequired ?
+          `(${serializedName}={${value}.ToString()})` :
+          `(null == ${value} ? ${System.String.Empty}: $"${serializedName}={${value}.ToString()}")`;
+    }
+    return (`/* serializeToContainerMember doesn't support '${mediaType}' ${__filename}*/`);
+  }
+
+  constructor(public schema: StringSchema, public isRequired: boolean) {
+
+  }
+
+  get declaration(): string {
+    return 'string';
+  }
+
+  validateValue(eventListener: Variable, property: Variable): string {
+    return `
+${this.validateMinLength(eventListener, property)}
+${this.validateMaxLength(eventListener, property)}
+${this.validateRegex(eventListener, property)}
+    `.trim();
+
+  }
+
+  public validatePresence(eventListener: Variable, property: Variable): string {
+    return `await ${eventListener}.AssertNotNull(${nameof(property.value)},${property});`.trim();
+  }
+
+  private validateMinLength(eventListener: Variable, property: Variable): string {
+    if (!this.schema.minLength) {
+      return '';
+    }
+    return `await ${eventListener}.AssertMinimumLength(${nameof(property.value)},${property},${this.schema.minLength});`;
+  }
+  private validateMaxLength(eventListener: Variable, property: Variable): string {
+    if (!this.schema.maxLength) {
+      return '';
+    }
+    return `await ${eventListener}.AssertMaximumLength(${nameof(property.value)},${property},${this.schema.maxLength});`;
+  }
+  private validateRegex(eventListener: Variable, property: Variable): string {
+    if (!this.schema.pattern) {
+      return '';
+    }
+    return `await ${eventListener}.AssertRegEx(${nameof(property.value)},${property},@"${this.schema.pattern}");`;
+  }
+  // private validateEnum(eventListener: Variable, property: Variable): string {
+  //   if (!this.schema.enum || length(this.schema.enum) === 0) {
+  //     return '';
+  //   }
+  //   return `await ${eventListener}.AssertEnum(${nameof(property.value)},${property},${this.schema.enum.joinWith((v) => `@"${v}"`)});`;
+  // }
 }

--- a/powershell/main.ts
+++ b/powershell/main.ts
@@ -11,6 +11,14 @@ import { powershell } from './plugins/powershell';
 import { addCompleter } from './plugins/add-azure-completers';
 import { csnamer } from './plugins/cs-namer';
 import { llcsharp } from './plugins/llcsharp';
+import { createInlinedPropertiesPlugin } from './plugins/plugin-create-inline-properties';
+import { tweakModelPlugin } from './plugins/plugin-tweak-model';
+import { tweakModelAzurePlugin } from './plugins/plugin-tweak-model-azure';
+import { createCommandsV2 } from './plugins/create-commands-v2';
+import { csnamerV2 } from './plugins/cs-namer-v2';
+import { namerV2 } from './plugins/ps-namer-v2';
+import { llcsharpV2 } from './plugins/llcsharp-v2';
+import { powershellV2 } from './plugins/powershell-v2';
 
 require('source-map-support').install();
 
@@ -23,6 +31,16 @@ export async function main() {
   pluginHost.Add('add-azure-completers', addCompleter);
   pluginHost.Add('csnamer', csnamer);
   pluginHost.Add('llcsharp', llcsharp);
+  // Following are plugins moved from remodeler
+  pluginHost.Add('tweakcodemodel-v2', tweakModelPlugin);
+  pluginHost.Add('tweakcodemodelazure-v2', tweakModelAzurePlugin);
+  pluginHost.Add('create-virtual-properties-v2', createInlinedPropertiesPlugin);
+  pluginHost.Add('create-commands-v2', createCommandsV2);
+  pluginHost.Add('csnamer-v2', csnamerV2);
+  pluginHost.Add('psnamer-v2', namerV2);
+  pluginHost.Add('llcsharp-v2', llcsharpV2);
+  pluginHost.Add('powershell-v2', powershellV2);
+
   await pluginHost.Run();
 }
 

--- a/powershell/models/model-extensions.ts
+++ b/powershell/models/model-extensions.ts
@@ -268,7 +268,7 @@ export class NewModelExtensionsNamespace extends Namespace {
   }
   resolver = new NewSchemaDefinitionResolver();
 
-  constructor(parent: Namespace, private schemas: Dictionary<NewSchema>, private state: NewState, objectInitializer?: DeepPartial<ModelExtensionsNamespace>) {
+  constructor(parent: Namespace, private schemas: Dictionary<Array<NewSchema>>, private state: NewState, objectInitializer?: DeepPartial<ModelExtensionsNamespace>) {
     super('Models', parent);
     this.apply(objectInitializer);
     this.add(new ImportDirective(`${ClientRuntime.name}.PowerShell`));
@@ -278,210 +278,212 @@ export class NewModelExtensionsNamespace extends Namespace {
     const resolver = (s: NewSchema, req: boolean) => this.resolver.resolveTypeDeclaration(s, req, state);
 
     // Add typeconverters to model classes (partial)
-    for (const schema of values(schemas)) {
-      if (!schema || (schema.language.csharp && schema.language.csharp.skip)) {
-        continue;
-      }
-
-      const td = this.resolver.resolveTypeDeclaration(schema, true, state);
-      if (td instanceof ObjectImplementation) {
-
-        // it's a class object.
-        const className = td.schema.details.csharp.name;
-        const interfaceName = td.schema.details.csharp.interfaceName || '';
-        const converterClass = `${className}TypeConverter`;
-
-        if (this.findClassByName(className).length > 0) {
+    for (const schemaGroup of values(schemas)) {
+      for (const schema of values(schemaGroup)) {
+        if (!schema || (schema.language.csharp && schema.language.csharp.skip)) {
           continue;
         }
 
-        // get the actual full namespace for the schema
-        const fullname = schema.language.csharp?.namespace || this.fullName;
-        const ns = this.subNamespaces[fullname] || this.add(new ApiVersionModelExtensionsNamespace(this.outputFolder, fullname));
+        const td = this.resolver.resolveTypeDeclaration(schema, true, state);
+        if (td instanceof ObjectImplementation) {
 
-        // create the model extensions for each object model
-        // 2. A partial interface with the type converter attribute
-        const modelInterface = new Interface(ns, interfaceName, {
-          partial: true,
-          description: td.schema.details.csharp.description,
-          fileName: `${interfaceName}.PowerShell` // make sure that the interface ends up in the same file as the class.
-        });
-        modelInterface.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+          // it's a class object.
+          const className = td.schema.details.csharp.name;
+          const interfaceName = td.schema.details.csharp.interfaceName || '';
+          const converterClass = `${className}TypeConverter`;
 
-        // 1. A partial class with the type converter attribute
-        const model = new Class(ns, className, undefined, {
-          partial: true,
-          description: td.schema.details.csharp.description,
-          fileName: `${className}.PowerShell`
-        });
+          if (this.findClassByName(className).length > 0) {
+            continue;
+          }
 
-        // if the model is supposed to be use 'by-reference' we should create an I*Reference interface for that
-        // and add that interface to the extension class
-        if (schema.language.csharp?.byReference) {
-          const refInterface = `${interfaceName}_Reference`;
-          schema.language.csharp.referenceInterface = `${ns.fullName}.${refInterface}`;
+          // get the actual full namespace for the schema
+          const fullname = schema.language.csharp?.namespace || this.fullName;
+          const ns = this.subNamespaces[fullname] || this.add(new ApiVersionModelExtensionsNamespace(this.outputFolder, fullname));
 
-          const referenceInterface = new Interface(ns, refInterface, {
+          // create the model extensions for each object model
+          // 2. A partial interface with the type converter attribute
+          const modelInterface = new Interface(ns, interfaceName, {
             partial: true,
-            description: `Reference for model ${fullname}`,
+            description: td.schema.details.csharp.description,
             fileName: `${interfaceName}.PowerShell` // make sure that the interface ends up in the same file as the class.
           });
-          referenceInterface.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
-          referenceInterface.add(new InterfaceProperty('Id', dotnet.String, { setAccess: Access.Internal }));
-          model.interfaces.push(referenceInterface);
+          modelInterface.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
 
-          // add it to the generic reference type.
-          // referenceType = referenceType || this.CreateReferenceType();
-          // referenceType.interfaces.push(referenceInterface);
-        }
-
-
-        model.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
-        model.add(new LambdaMethod('FromJsonString', modelInterface, new LiteralExpression(`FromJson(${ClientRuntime.JsonNode.declaration}.Parse(jsonText))`), {
-          static: Modifier.Static,
-          parameters: [new Parameter('jsonText', dotnet.String, { description: 'a string containing a JSON serialized instance of this model.' })],
-          description: `Creates a new instance of <see cref="${td.schema.details.csharp.name}" />, deserializing the content from a json string.`,
-          returnsDescription: 'an instance of the <see cref="className" /> model class.'
-        }));
-
-        model.add(new LambdaMethod('ToJsonString', dotnet.String, new LiteralExpression(`ToJson(${dotnet.Null}, ${ClientRuntime.SerializationMode.IncludeAll})?.ToString()`), {
-          description: 'Serializes this instance to a json string.',
-          returnsDescription: 'a <see cref="System.String" /> containing this model serialized to JSON text.'
-        }));
-
-        const hashDeseralizer = new NewDeserializerPartialClass(model, modelInterface, System.Collections.IDictionary, 'Dictionary', schema, resolver).init();
-        const psDeseralizer = new NewDeserializerPartialClass(model, modelInterface, PSObject, 'PSObject', schema, resolver).init();
-
-        // + static <interfaceType> FromJsonString(string json);
-        // + string ToJsonString()
-
-        // 3. A TypeConverter class
-        const typeConverter = new Class(ns, converterClass, PSTypeConverter, {
-          description: `A PowerShell PSTypeConverter to support converting to an instance of <see cref="${className}" />`,
-          fileName: `${className}.TypeConverter`
-        });
-        typeConverter.add(new LambdaMethod('CanConvertTo', dotnet.Bool, dotnet.False, {
-          override: Modifier.Override,
-          parameters: [
-            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
-            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
-          ],
-          description: 'Determines if the <see cref="sourceValue" /> parameter can be converted to the <see cref="destinationType" /> parameter',
-          returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>',
-        }));
-        typeConverter.add(new LambdaMethod('ConvertTo', dotnet.Object, dotnet.Null, {
-          override: Modifier.Override,
-          parameters: [
-            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
-            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
-            new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
-            new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
-          ], description: 'NotImplemented -- this will return <c>null</c>',
-          returnsDescription: 'will always return <c>null</c>.'
-        }));
-        typeConverter.add(new LambdaMethod('CanConvertFrom', dotnet.Bool, new LiteralExpression('CanConvertFrom(sourceValue)'), {
-          override: Modifier.Override,
-          parameters: [
-            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
-            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
-          ],
-          description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
-          returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
-        }));
-        typeConverter.add(new LambdaMethod('ConvertFrom', dotnet.Object, new LiteralExpression('ConvertFrom(sourceValue)'), {
-          override: Modifier.Override,
-          parameters: [
-            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
-            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
-            new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
-            new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
-          ],
-          description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" /> ',
-          returnsDescription: `an instance of <see cref="${className}" />, or <c>null</c> if there is no suitable conversion.`
-        }));
-
-        typeConverter.add(new Method('CanConvertFrom', dotnet.Bool, {
-          static: Modifier.Static,
-          parameters: [
-            new Parameter('sourceValue', dotnet.Dynamic, { description: `the <see cref="System.Object" /> instance to check if it can be converted to the <see cref="${className}" /> type.` }),
-          ],
-          description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
-          returnsDescription: `<c>true</c> if the instance could be converted to a <see cref="${className}" /> type, otherwise <c>false</c> `
-        })).add(function* () {
-          yield If('null == sourceValue', Return(dotnet.True));
-
-          const t = new LocalVariable('type', System.Type, { initializer: 'sourceValue.GetType()' });
-          yield t.declarationStatement;
-
-          if (schema.language.default.uid === 'universal-parameter-type' || schema.language.csharp?.byReference) {
-            yield '// we allow string conversion too.';
-            yield If(`${t.value} == typeof(${System.String})`, Return(dotnet.True));
-          }
-
-          yield If(IsAssignableFrom(PSObject, t), function* () {
-            yield '// we say yest to PSObjects';
-            yield Return(dotnet.True);
-          });
-          yield If(IsAssignableFrom(System.Collections.IDictionary, t), function* () {
-            yield '// we say yest to Hashtables/dictionaries';
-            yield Return(dotnet.True);
+          // 1. A partial class with the type converter attribute
+          const model = new Class(ns, className, undefined, {
+            partial: true,
+            description: td.schema.details.csharp.description,
+            fileName: `${className}.PowerShell`
           });
 
-          yield Try(If('null != sourceValue.ToJsonString()', Return(dotnet.True)));
-          yield Catch(undefined, '// Not one of our objects');
-
-          yield Try(function* () {
-            const t = new LocalVariable('text', dotnet.String, { initializer: 'sourceValue.ToString()?.Trim()' });
-            yield t.declarationStatement;
-            yield Return(`${dotnet.True} == ${t.value}?.StartsWith("{") && ${dotnet.True} == ${t.value}?.EndsWith("}") && ${ClientRuntime.JsonNode.Parse(t)}.Type == ${ClientRuntime.JsonType.Object}`);
-          });
-          yield Catch(undefined, '// Doesn\'t look like it can be treated as JSON');
-
-          yield Return(dotnet.False);
-        });
-
-        typeConverter.add(new Method('ConvertFrom', modelInterface, {
-          static: Modifier.Static,
-          parameters: [
-            new Parameter('sourceValue', dotnet.Dynamic, {
-              description: `the value to convert into an instance of <see cref="${className}" />.`
-            }),
-          ],
-          description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" />',
-          returnsDescription: `an instance of <see cref="${className}" />, or <c>null</c> if there is no suitable conversion.`
-        })).add(function* () {
-          // null begets null
-          yield If('null == sourceValue', Return(dotnet.Null));
-
-          const t = new LocalVariable('type', System.Type, { initializer: 'sourceValue.GetType()' });
-          yield t.declarationStatement;
-
-          if (($this.state.project.azure && schema.language.default.uid === 'universal-parameter-type') || schema.language.csharp?.byReference) {
-            yield '// support direct string to id type conversion.';
-            yield If(`${t.value} == typeof(${System.String})`, function* () {
-              yield Return(`new ${className} { Id = sourceValue }`);
-            });
-          }
-
+          // if the model is supposed to be use 'by-reference' we should create an I*Reference interface for that
+          // and add that interface to the extension class
           if (schema.language.csharp?.byReference) {
-            yield '// if Id is present with by-reference schemas, just return the type with Id ';
-            yield Try(Return(`new ${className} { Id = sourceValue.Id }`));
-            yield Catch(undefined, '// Not an Id reference parameter');
+            const refInterface = `${interfaceName}_Reference`;
+            schema.language.csharp.referenceInterface = `${ns.fullName}.${refInterface}`;
+
+            const referenceInterface = new Interface(ns, refInterface, {
+              partial: true,
+              description: `Reference for model ${fullname}`,
+              fileName: `${interfaceName}.PowerShell` // make sure that the interface ends up in the same file as the class.
+            });
+            referenceInterface.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+            referenceInterface.add(new InterfaceProperty('Id', dotnet.String, { setAccess: Access.Internal }));
+            model.interfaces.push(referenceInterface);
+
+            // add it to the generic reference type.
+            // referenceType = referenceType || this.CreateReferenceType();
+            // referenceType.interfaces.push(referenceInterface);
           }
 
-          // if the type can be assigned directly, do that 
-          yield If(IsAssignableFrom(td, t), Return('sourceValue'));
 
-          // try using json first (either from string or toJsonString())
-          yield Try(Return(`${className}.FromJsonString(typeof(string) == sourceValue.GetType() ? sourceValue : sourceValue.ToJsonString());`));
-          yield Catch(undefined, '// Unable to use JSON pattern');
+          model.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+          model.add(new LambdaMethod('FromJsonString', modelInterface, new LiteralExpression(`FromJson(${ClientRuntime.JsonNode.declaration}.Parse(jsonText))`), {
+            static: Modifier.Static,
+            parameters: [new Parameter('jsonText', dotnet.String, { description: 'a string containing a JSON serialized instance of this model.' })],
+            description: `Creates a new instance of <see cref="${td.schema.details.csharp.name}" />, deserializing the content from a json string.`,
+            returnsDescription: 'an instance of the <see cref="className" /> model class.'
+          }));
 
-          yield If(IsAssignableFrom(PSObject, t), Return(`${className}.DeserializeFromPSObject(sourceValue)`));
-          yield If(IsAssignableFrom(System.Collections.IDictionary, t), Return(`${className}.DeserializeFromDictionary(sourceValue)`));
+          model.add(new LambdaMethod('ToJsonString', dotnet.String, new LiteralExpression(`ToJson(${dotnet.Null}, ${ClientRuntime.SerializationMode.IncludeAll})?.ToString()`), {
+            description: 'Serializes this instance to a json string.',
+            returnsDescription: 'a <see cref="System.String" /> containing this model serialized to JSON text.'
+          }));
 
-          // null if not successful
-          yield Return(dotnet.Null);
-        });
+          const hashDeseralizer = new NewDeserializerPartialClass(model, modelInterface, System.Collections.IDictionary, 'Dictionary', schema, resolver).init();
+          const psDeseralizer = new NewDeserializerPartialClass(model, modelInterface, PSObject, 'PSObject', schema, resolver).init();
+
+          // + static <interfaceType> FromJsonString(string json);
+          // + string ToJsonString()
+
+          // 3. A TypeConverter class
+          const typeConverter = new Class(ns, converterClass, PSTypeConverter, {
+            description: `A PowerShell PSTypeConverter to support converting to an instance of <see cref="${className}" />`,
+            fileName: `${className}.TypeConverter`
+          });
+          typeConverter.add(new LambdaMethod('CanConvertTo', dotnet.Bool, dotnet.False, {
+            override: Modifier.Override,
+            parameters: [
+              new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+              new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+            ],
+            description: 'Determines if the <see cref="sourceValue" /> parameter can be converted to the <see cref="destinationType" /> parameter',
+            returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>',
+          }));
+          typeConverter.add(new LambdaMethod('ConvertTo', dotnet.Object, dotnet.Null, {
+            override: Modifier.Override,
+            parameters: [
+              new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+              new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+              new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+              new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+            ], description: 'NotImplemented -- this will return <c>null</c>',
+            returnsDescription: 'will always return <c>null</c>.'
+          }));
+          typeConverter.add(new LambdaMethod('CanConvertFrom', dotnet.Bool, new LiteralExpression('CanConvertFrom(sourceValue)'), {
+            override: Modifier.Override,
+            parameters: [
+              new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+              new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+            ],
+            description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+            returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
+          }));
+          typeConverter.add(new LambdaMethod('ConvertFrom', dotnet.Object, new LiteralExpression('ConvertFrom(sourceValue)'), {
+            override: Modifier.Override,
+            parameters: [
+              new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+              new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+              new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+              new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+            ],
+            description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" /> ',
+            returnsDescription: `an instance of <see cref="${className}" />, or <c>null</c> if there is no suitable conversion.`
+          }));
+
+          typeConverter.add(new Method('CanConvertFrom', dotnet.Bool, {
+            static: Modifier.Static,
+            parameters: [
+              new Parameter('sourceValue', dotnet.Dynamic, { description: `the <see cref="System.Object" /> instance to check if it can be converted to the <see cref="${className}" /> type.` }),
+            ],
+            description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+            returnsDescription: `<c>true</c> if the instance could be converted to a <see cref="${className}" /> type, otherwise <c>false</c> `
+          })).add(function* () {
+            yield If('null == sourceValue', Return(dotnet.True));
+
+            const t = new LocalVariable('type', System.Type, { initializer: 'sourceValue.GetType()' });
+            yield t.declarationStatement;
+
+            if (schema.language.default.uid === 'universal-parameter-type' || schema.language.csharp?.byReference) {
+              yield '// we allow string conversion too.';
+              yield If(`${t.value} == typeof(${System.String})`, Return(dotnet.True));
+            }
+
+            yield If(IsAssignableFrom(PSObject, t), function* () {
+              yield '// we say yest to PSObjects';
+              yield Return(dotnet.True);
+            });
+            yield If(IsAssignableFrom(System.Collections.IDictionary, t), function* () {
+              yield '// we say yest to Hashtables/dictionaries';
+              yield Return(dotnet.True);
+            });
+
+            yield Try(If('null != sourceValue.ToJsonString()', Return(dotnet.True)));
+            yield Catch(undefined, '// Not one of our objects');
+
+            yield Try(function* () {
+              const t = new LocalVariable('text', dotnet.String, { initializer: 'sourceValue.ToString()?.Trim()' });
+              yield t.declarationStatement;
+              yield Return(`${dotnet.True} == ${t.value}?.StartsWith("{") && ${dotnet.True} == ${t.value}?.EndsWith("}") && ${ClientRuntime.JsonNode.Parse(t)}.Type == ${ClientRuntime.JsonType.Object}`);
+            });
+            yield Catch(undefined, '// Doesn\'t look like it can be treated as JSON');
+
+            yield Return(dotnet.False);
+          });
+
+          typeConverter.add(new Method('ConvertFrom', modelInterface, {
+            static: Modifier.Static,
+            parameters: [
+              new Parameter('sourceValue', dotnet.Dynamic, {
+                description: `the value to convert into an instance of <see cref="${className}" />.`
+              }),
+            ],
+            description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" />',
+            returnsDescription: `an instance of <see cref="${className}" />, or <c>null</c> if there is no suitable conversion.`
+          })).add(function* () {
+            // null begets null
+            yield If('null == sourceValue', Return(dotnet.Null));
+
+            const t = new LocalVariable('type', System.Type, { initializer: 'sourceValue.GetType()' });
+            yield t.declarationStatement;
+
+            if (($this.state.project.azure && schema.language.default.uid === 'universal-parameter-type') || schema.language.csharp?.byReference) {
+              yield '// support direct string to id type conversion.';
+              yield If(`${t.value} == typeof(${System.String})`, function* () {
+                yield Return(`new ${className} { Id = sourceValue }`);
+              });
+            }
+
+            if (schema.language.csharp?.byReference) {
+              yield '// if Id is present with by-reference schemas, just return the type with Id ';
+              yield Try(Return(`new ${className} { Id = sourceValue.Id }`));
+              yield Catch(undefined, '// Not an Id reference parameter');
+            }
+
+            // if the type can be assigned directly, do that 
+            yield If(IsAssignableFrom(td, t), Return('sourceValue'));
+
+            // try using json first (either from string or toJsonString())
+            yield Try(Return(`${className}.FromJsonString(typeof(string) == sourceValue.GetType() ? sourceValue : sourceValue.ToJsonString());`));
+            yield Catch(undefined, '// Unable to use JSON pattern');
+
+            yield If(IsAssignableFrom(PSObject, t), Return(`${className}.DeserializeFromPSObject(sourceValue)`));
+            yield If(IsAssignableFrom(System.Collections.IDictionary, t), Return(`${className}.DeserializeFromDictionary(sourceValue)`));
+
+            // null if not successful
+            yield Return(dotnet.Null);
+          });
+        }
       }
     }
   }

--- a/powershell/models/model-extensions.ts
+++ b/powershell/models/model-extensions.ts
@@ -2,10 +2,11 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { Schema as NewSchema } from '@azure-tools/codemodel';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { Catch, Try, Else, ElseIf, If, Interface, Attribute, Parameter, Modifier, dotnet, Class, LambdaMethod, LiteralExpression, Method, Namespace, System, Return, LocalVariable, Constructor, IsAssignableFrom, ImportDirective, Property, Access, InterfaceProperty } from '@azure-tools/codegen-csharp';
-import { Schema, ClientRuntime, SchemaDefinitionResolver, ObjectImplementation, DeserializerPartialClass } from '../llcsharp/exports';
-import { State } from '../internal/state';
+import { Schema, ClientRuntime, SchemaDefinitionResolver, ObjectImplementation, DeserializerPartialClass, NewSchemaDefinitionResolver, NewDeserializerPartialClass } from '../llcsharp/exports';
+import { State, NewState } from '../internal/state';
 import { PSObject, PSTypeConverter, TypeConverterAttribute } from '../internal/powershell-declarations';
 import { join } from 'path';
 import { DeepPartial } from '@azure-tools/codegen';
@@ -231,6 +232,238 @@ export class ModelExtensionsNamespace extends Namespace {
           }
 
           if (schema.details.csharp.byReference) {
+            yield '// if Id is present with by-reference schemas, just return the type with Id ';
+            yield Try(Return(`new ${className} { Id = sourceValue.Id }`));
+            yield Catch(undefined, '// Not an Id reference parameter');
+          }
+
+          // if the type can be assigned directly, do that 
+          yield If(IsAssignableFrom(td, t), Return('sourceValue'));
+
+          // try using json first (either from string or toJsonString())
+          yield Try(Return(`${className}.FromJsonString(typeof(string) == sourceValue.GetType() ? sourceValue : sourceValue.ToJsonString());`));
+          yield Catch(undefined, '// Unable to use JSON pattern');
+
+          yield If(IsAssignableFrom(PSObject, t), Return(`${className}.DeserializeFromPSObject(sourceValue)`));
+          yield If(IsAssignableFrom(System.Collections.IDictionary, t), Return(`${className}.DeserializeFromDictionary(sourceValue)`));
+
+          // null if not successful
+          yield Return(dotnet.Null);
+        });
+      }
+    }
+  }
+}
+
+export class NewModelExtensionsNamespace extends Namespace {
+  CreateReferenceType(): Class {
+    const rt = new Class(this, 'ReferenceType');
+    rt.add(new Property('Id', dotnet.String, { setAccess: Access.Internal }));
+    return rt;
+  }
+  private subNamespaces = new Dictionary<Namespace>();
+
+  public get outputFolder(): string {
+    return join(this.state.project.apiFolder, 'Models');
+  }
+  resolver = new NewSchemaDefinitionResolver();
+
+  constructor(parent: Namespace, private schemas: Dictionary<NewSchema>, private state: NewState, objectInitializer?: DeepPartial<ModelExtensionsNamespace>) {
+    super('Models', parent);
+    this.apply(objectInitializer);
+    this.add(new ImportDirective(`${ClientRuntime.name}.PowerShell`));
+    this.subNamespaces[this.fullName] = this;
+
+    const $this = this;
+    const resolver = (s: NewSchema, req: boolean) => this.resolver.resolveTypeDeclaration(s, req, state);
+
+    // Add typeconverters to model classes (partial)
+    for (const schema of values(schemas)) {
+      if (!schema || (schema.language.csharp && schema.language.csharp.skip)) {
+        continue;
+      }
+
+      const td = this.resolver.resolveTypeDeclaration(schema, true, state);
+      if (td instanceof ObjectImplementation) {
+
+        // it's a class object.
+        const className = td.schema.details.csharp.name;
+        const interfaceName = td.schema.details.csharp.interfaceName || '';
+        const converterClass = `${className}TypeConverter`;
+
+        if (this.findClassByName(className).length > 0) {
+          continue;
+        }
+
+        // get the actual full namespace for the schema
+        const fullname = schema.language.csharp?.namespace || this.fullName;
+        const ns = this.subNamespaces[fullname] || this.add(new ApiVersionModelExtensionsNamespace(this.outputFolder, fullname));
+
+        // create the model extensions for each object model
+        // 2. A partial interface with the type converter attribute
+        const modelInterface = new Interface(ns, interfaceName, {
+          partial: true,
+          description: td.schema.details.csharp.description,
+          fileName: `${interfaceName}.PowerShell` // make sure that the interface ends up in the same file as the class.
+        });
+        modelInterface.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+
+        // 1. A partial class with the type converter attribute
+        const model = new Class(ns, className, undefined, {
+          partial: true,
+          description: td.schema.details.csharp.description,
+          fileName: `${className}.PowerShell`
+        });
+
+        // if the model is supposed to be use 'by-reference' we should create an I*Reference interface for that
+        // and add that interface to the extension class
+        if (schema.language.csharp?.byReference) {
+          const refInterface = `${interfaceName}_Reference`;
+          schema.language.csharp.referenceInterface = `${ns.fullName}.${refInterface}`;
+
+          const referenceInterface = new Interface(ns, refInterface, {
+            partial: true,
+            description: `Reference for model ${fullname}`,
+            fileName: `${interfaceName}.PowerShell` // make sure that the interface ends up in the same file as the class.
+          });
+          referenceInterface.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+          referenceInterface.add(new InterfaceProperty('Id', dotnet.String, { setAccess: Access.Internal }));
+          model.interfaces.push(referenceInterface);
+
+          // add it to the generic reference type.
+          // referenceType = referenceType || this.CreateReferenceType();
+          // referenceType.interfaces.push(referenceInterface);
+        }
+
+
+        model.add(new Attribute(TypeConverterAttribute, { parameters: [new LiteralExpression(`typeof(${converterClass})`)] }));
+        model.add(new LambdaMethod('FromJsonString', modelInterface, new LiteralExpression(`FromJson(${ClientRuntime.JsonNode.declaration}.Parse(jsonText))`), {
+          static: Modifier.Static,
+          parameters: [new Parameter('jsonText', dotnet.String, { description: 'a string containing a JSON serialized instance of this model.' })],
+          description: `Creates a new instance of <see cref="${td.schema.details.csharp.name}" />, deserializing the content from a json string.`,
+          returnsDescription: 'an instance of the <see cref="className" /> model class.'
+        }));
+
+        model.add(new LambdaMethod('ToJsonString', dotnet.String, new LiteralExpression(`ToJson(${dotnet.Null}, ${ClientRuntime.SerializationMode.IncludeAll})?.ToString()`), {
+          description: 'Serializes this instance to a json string.',
+          returnsDescription: 'a <see cref="System.String" /> containing this model serialized to JSON text.'
+        }));
+
+        const hashDeseralizer = new NewDeserializerPartialClass(model, modelInterface, System.Collections.IDictionary, 'Dictionary', schema, resolver).init();
+        const psDeseralizer = new NewDeserializerPartialClass(model, modelInterface, PSObject, 'PSObject', schema, resolver).init();
+
+        // + static <interfaceType> FromJsonString(string json);
+        // + string ToJsonString()
+
+        // 3. A TypeConverter class
+        const typeConverter = new Class(ns, converterClass, PSTypeConverter, {
+          description: `A PowerShell PSTypeConverter to support converting to an instance of <see cref="${className}" />`,
+          fileName: `${className}.TypeConverter`
+        });
+        typeConverter.add(new LambdaMethod('CanConvertTo', dotnet.Bool, dotnet.False, {
+          override: Modifier.Override,
+          parameters: [
+            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+          ],
+          description: 'Determines if the <see cref="sourceValue" /> parameter can be converted to the <see cref="destinationType" /> parameter',
+          returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>',
+        }));
+        typeConverter.add(new LambdaMethod('ConvertTo', dotnet.Object, dotnet.Null, {
+          override: Modifier.Override,
+          parameters: [
+            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+            new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+            new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+          ], description: 'NotImplemented -- this will return <c>null</c>',
+          returnsDescription: 'will always return <c>null</c>.'
+        }));
+        typeConverter.add(new LambdaMethod('CanConvertFrom', dotnet.Bool, new LiteralExpression('CanConvertFrom(sourceValue)'), {
+          override: Modifier.Override,
+          parameters: [
+            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' })
+          ],
+          description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+          returnsDescription: '<c>true</c> if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter, otherwise <c>false</c>.',
+        }));
+        typeConverter.add(new LambdaMethod('ConvertFrom', dotnet.Object, new LiteralExpression('ConvertFrom(sourceValue)'), {
+          override: Modifier.Override,
+          parameters: [
+            new Parameter('sourceValue', dotnet.Object, { description: 'the <see cref="System.Object"/> to convert from' }),
+            new Parameter('destinationType', System.Type, { description: 'the <see cref="System.Type" /> to convert to' }),
+            new Parameter('formatProvider', System.IFormatProvider, { description: 'not used by this TypeConverter.' }),
+            new Parameter('ignoreCase', dotnet.Bool, { description: 'when set to <c>true</c>, will ignore the case when converting.' }),
+          ],
+          description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" /> ',
+          returnsDescription: `an instance of <see cref="${className}" />, or <c>null</c> if there is no suitable conversion.`
+        }));
+
+        typeConverter.add(new Method('CanConvertFrom', dotnet.Bool, {
+          static: Modifier.Static,
+          parameters: [
+            new Parameter('sourceValue', dotnet.Dynamic, { description: `the <see cref="System.Object" /> instance to check if it can be converted to the <see cref="${className}" /> type.` }),
+          ],
+          description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+          returnsDescription: `<c>true</c> if the instance could be converted to a <see cref="${className}" /> type, otherwise <c>false</c> `
+        })).add(function* () {
+          yield If('null == sourceValue', Return(dotnet.True));
+
+          const t = new LocalVariable('type', System.Type, { initializer: 'sourceValue.GetType()' });
+          yield t.declarationStatement;
+
+          if (schema.language.default.uid === 'universal-parameter-type' || schema.language.csharp?.byReference) {
+            yield '// we allow string conversion too.';
+            yield If(`${t.value} == typeof(${System.String})`, Return(dotnet.True));
+          }
+
+          yield If(IsAssignableFrom(PSObject, t), function* () {
+            yield '// we say yest to PSObjects';
+            yield Return(dotnet.True);
+          });
+          yield If(IsAssignableFrom(System.Collections.IDictionary, t), function* () {
+            yield '// we say yest to Hashtables/dictionaries';
+            yield Return(dotnet.True);
+          });
+
+          yield Try(If('null != sourceValue.ToJsonString()', Return(dotnet.True)));
+          yield Catch(undefined, '// Not one of our objects');
+
+          yield Try(function* () {
+            const t = new LocalVariable('text', dotnet.String, { initializer: 'sourceValue.ToString()?.Trim()' });
+            yield t.declarationStatement;
+            yield Return(`${dotnet.True} == ${t.value}?.StartsWith("{") && ${dotnet.True} == ${t.value}?.EndsWith("}") && ${ClientRuntime.JsonNode.Parse(t)}.Type == ${ClientRuntime.JsonType.Object}`);
+          });
+          yield Catch(undefined, '// Doesn\'t look like it can be treated as JSON');
+
+          yield Return(dotnet.False);
+        });
+
+        typeConverter.add(new Method('ConvertFrom', modelInterface, {
+          static: Modifier.Static,
+          parameters: [
+            new Parameter('sourceValue', dotnet.Dynamic, {
+              description: `the value to convert into an instance of <see cref="${className}" />.`
+            }),
+          ],
+          description: 'Converts the <see cref="sourceValue" /> parameter to the <see cref="destinationType" /> parameter using <see cref="formatProvider" /> and <see cref="ignoreCase" />',
+          returnsDescription: `an instance of <see cref="${className}" />, or <c>null</c> if there is no suitable conversion.`
+        })).add(function* () {
+          // null begets null
+          yield If('null == sourceValue', Return(dotnet.Null));
+
+          const t = new LocalVariable('type', System.Type, { initializer: 'sourceValue.GetType()' });
+          yield t.declarationStatement;
+
+          if (($this.state.project.azure && schema.language.default.uid === 'universal-parameter-type') || schema.language.csharp?.byReference) {
+            yield '// support direct string to id type conversion.';
+            yield If(`${t.value} == typeof(${System.String})`, function* () {
+              yield Return(`new ${className} { Id = sourceValue }`);
+            });
+          }
+
+          if (schema.language.csharp?.byReference) {
             yield '// if Id is present with by-reference schemas, just return the type with Id ';
             yield Try(Return(`new ${className} { Id = sourceValue.Id }`));
             yield Catch(undefined, '// Not an Id reference parameter');

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -6,7 +6,7 @@
 import { Access, Alias, Class, ClassType, Constructor, dotnet, Field, LambdaMethod, LambdaProperty, LazyProperty, LiteralExpression, LocalVariable, MemberVariable, Method, Modifier, Namespace, Parameter, ParameterModifier, PartialMethod, Property, Return, Statements, StringExpression, System, TypeDeclaration, Using, valueOf, Variable } from '@azure-tools/codegen-csharp';
 
 import { InvocationInfo, PSCredential, IArgumentCompleter, CompletionResult, CommandAst, CompletionResultType, } from '../internal/powershell-declarations';
-import { State } from '../internal/state';
+import { State, NewState } from '../internal/state';
 import { ClientRuntime } from '../llcsharp/exports';
 import { DeepPartial } from '@azure-tools/codegen';
 
@@ -87,6 +87,256 @@ export class ModuleClass extends Class {
     }));
 
     const clientAPI = new ClassType(this.state.model.details.csharp.namespace, this.state.model.details.csharp.name);
+    const clientProperty = this.add(new Property('ClientAPI', clientAPI, { description: 'The instance of the Client API' }));
+
+    if (this.state.project.azure) {
+      this.createAzureInitAndPipeline(namespace);
+    } else {
+      this.createInitAndPipeline(namespace);
+    }
+
+    this.add(new Constructor(this, {
+      access: Access.Private,
+      description: 'Creates the module instance.',
+      body: function* () {
+        yield '/// constructor';
+        yield clientProperty.assignPrivate(clientAPI.new());
+        yield `${$this.fHandler}.Proxy = ${$this.fWebProxy};`;
+
+        yield $this.fPipeline.assignPrivate(ClientRuntime.HttpPipeline.new(ClientRuntime.HttpClientFactory.new(System.Net.Http.HttpClient.new())));
+        yield $this.fPipelineWithProxy.assignPrivate(ClientRuntime.HttpPipeline.new(ClientRuntime.HttpClientFactory.new(System.Net.Http.HttpClient.new($this.fHandler))));
+      }
+    }));
+
+    /* extensibility points */
+    this.add(new PartialMethod('BeforeCreatePipeline', dotnet.Void, { parameters: [this.pInvocationInfo, this.pPipeline] }));
+    this.add(new PartialMethod('AfterCreatePipeline', dotnet.Void, { parameters: [this.pInvocationInfo, this.pPipeline] }));
+    this.add(new PartialMethod('CustomInit', dotnet.Void));
+
+    /* Setting the Proxy */
+    this.add(new Method('SetProxyConfiguration', dotnet.Void, {
+      parameters: [this.pProxy, this.pProxyCredential, this.pUseDefaultCredentials],
+      *body() {
+        yield '// set the proxy configuration';
+        yield `${$this.fWebProxy}.Address = proxy;`;
+        yield `${$this.fWebProxy}.BypassProxyOnLocal = false;`;
+        yield `${$this.fWebProxy}.Credentials = proxyCredential ?.GetNetworkCredential();`;
+        yield `${$this.fWebProxy}.UseDefaultCredentials = proxyUseDefaultCredentials;`;
+        yield `${$this.fHandler}.UseProxy = proxy != null;`;
+      }
+    }));
+  }
+
+  createInitAndPipeline(namespace: Namespace) {
+    const $this = this;
+    // non-azure init method
+    this.initMethod.add(function* () {
+      yield '// called at module init time...';
+      yield 'CustomInit();';
+    });
+
+    this.createPipelineMethod = this.add(new Method('CreatePipeline', ClientRuntime.HttpPipeline, {
+      parameters: [this.pInvocationInfo, this.pParameterSetNameWithDefault],
+      description: 'Creates an instance of the HttpPipeline for each call.',
+      returnsDescription: `An instance of ${ClientRuntime.HttpPipeline} for the remote call.`
+    }));
+
+    // non-azure createPipeline method
+    this.createPipelineMethod.add(function* () {
+      const pip = new LocalVariable('pipeline', ClientRuntime.HttpPipeline, { initializer: 'null' });
+      yield pip.declarationStatement;
+      yield `BeforeCreatePipeline(${$this.pInvocationInfo.use}, ref ${pip});`;
+      yield pip.assign(`(${pip} ?? (${$this.fHandler}.UseProxy ? ${$this.fPipelineWithProxy} : ${$this.fPipeline})).Clone()`);
+      yield `AfterCreatePipeline(${$this.pInvocationInfo.use}, ref ${pip});`;
+      yield Return(pip);
+    });
+
+    this.add(new LambdaProperty('Name', dotnet.String, new StringExpression(this.state.project.moduleName), { description: 'The Name of this module ' }));
+  }
+
+  createAzureInitAndPipeline(namespace: Namespace) {
+    const $this = this;
+
+    const sendAsyncStep = namespace.add(new Alias('SendAsyncStepDelegate',
+      System.Func(
+        System.Net.Http.HttpRequestMessage,
+        ...this.IEventListenerExpanded,
+        this.nextStep,                                  /* Next( ...) */
+        /* returns */ this.TaskOfHttpResponseMessage)));
+
+    const pipelineChangeDelegate = namespace.add(new Alias('PipelineChangeDelegate', System.Action(sendAsyncStep.fullDefinition)));
+
+    const getParameterDelegate = namespace.add(new Alias('GetParameterDelegate', System.Func(
+      dotnet.String, /* resourceId */
+      dotnet.String, /* moduleName */
+      InvocationInfo, /* invocationInfo */
+      dotnet.String, /* correlationId */
+      dotnet.String, /* parameterName */
+      /* returns */ dotnet.Object)));
+
+    const moduleLoadPipelineDelegate = namespace.add(new Alias('ModuleLoadPipelineDelegate', System.Action(
+      dotnet.String, /* resourceId */
+      dotnet.String, /* moduleName */
+      pipelineChangeDelegate.fullDefinition, /* prependStep */
+      pipelineChangeDelegate.fullDefinition))); /* appendStep */
+
+    const newRequestPipelineDelegate = namespace.add(new Alias('NewRequestPipelineDelegate', System.Action(
+      InvocationInfo,  /* invocationInfo */
+      dotnet.String,   /* correlationId */
+      dotnet.String,  /* processRecordId */
+      pipelineChangeDelegate.fullDefinition,    /* prependStep */
+      pipelineChangeDelegate.fullDefinition))); /* appendStep */
+
+    const argumentCompleterDelegate = namespace.add(new Alias('ArgumentCompleterDelegate', System.Func(
+      dotnet.String, /* completerName */
+      InvocationInfo, /* invocationInfo */
+      dotnet.String, /* correlationId */
+      dotnet.StringArray, /* resourceTypes */
+      dotnet.StringArray, /* parentResourceParameterNames */
+      /* returns */ dotnet.StringArray,
+    )));
+
+    const incomingSignalDelegate = namespace.add(new Alias('SignalDelegate', this.incomingSignalFunc));
+    const eventListenerDelegate = namespace.add(new Alias('EventListenerDelegate', this.eventListenerFunc));
+
+    namespace.add(new Alias('NextDelegate', this.nextStep));
+
+    /* AzAccounts VTable properties  */
+    const OnModuleLoad = this.add(new Property('OnModuleLoad', moduleLoadPipelineDelegate, { description: 'The delegate to call when this module is loaded (supporting a commmon module).' }));
+    const OnNewRequest = this.add(new Property('OnNewRequest', newRequestPipelineDelegate, { description: 'The delegate to call before each new request (supporting a commmon module).' }));
+    const GetParameterValue = this.add(new Property('GetParameterValue', getParameterDelegate, { description: 'The delegate to call to get parameter data from a common module.' }));
+    const EventListener = this.add(new Property('EventListener', eventListenerDelegate, { description: 'A delegate that gets called for each signalled event' }));
+    const ArgumentCompleter = this.add(new Property('ArgumentCompleter', argumentCompleterDelegate, { description: 'Gets completion data for azure specific fields' }));
+    const ProfileName = this.add(new Property('ProfileName', System.String, { description: 'The name of the currently selected Azure profile' }));
+
+    const moduleIdentity = this.add(new LambdaProperty('Name', dotnet.String, new StringExpression(this.state.project.moduleName), { description: 'The Name of this module ' }));
+    const currentProfile = this.add(new Field('Profile', dotnet.String, { initialValue: System.String.Empty, description: 'The currently selected profile.' }));
+    const moduleResourceId = this.add(new LambdaProperty('ResourceId', dotnet.String, new StringExpression(this.state.project.moduleName), { description: 'The ResourceID for this module (azure arm).' }));
+
+    /* get parameter method (calls azAccounts) */
+    this.add(new LambdaMethod('GetParameter', dotnet.Object, new LiteralExpression(`${GetParameterValue.value}?.Invoke( ${moduleResourceId.value}, ${moduleIdentity.value}, ${$this.pInvocationInfo.value}, ${$this.pCorrelationId.value},${$this.pParameterName.value} )`), {
+      parameters: [this.pInvocationInfo, this.pCorrelationId, this.pParameterName],
+      description: 'Gets parameters from a common module.',
+      returnsDescription: 'The parameter value from the common module. (Note: this should be type converted on the way back)'
+    }));
+
+    /* signal method (calls azAccounts) */
+    const pSignal = new Parameter('signal', incomingSignalDelegate, { description: 'The callback for the event dispatcher ' });
+    const signalImpl = this.add(new Method('Signal', System.Threading.Tasks.Task(), {
+      parameters: [this.pId, this.pToken, this.pGetEventData, pSignal, this.pInvocationInfo, this.pParameterSetName, this.pCorrelationId, this.pProcessRecordId, this.pException], async: Modifier.Async,
+      description: 'Called to dispatch events to the common module listener',
+      returnsDescription: `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the event is completed.`
+    }));
+
+    signalImpl.push(Using('NoSynchronizationContext', ''));
+    signalImpl.add(function* () {
+      yield `await ${EventListener.value}?.Invoke(${$this.pId.value},${$this.pToken.value},${$this.pGetEventData.value}, ${pSignal.value}, ${$this.pInvocationInfo}, ${$this.pParameterSetName}, ${$this.pCorrelationId},${$this.pProcessRecordId},${$this.pException});`;
+    });
+
+    /* init method */
+    this.initMethod.add(function* () {
+      yield `${OnModuleLoad.value}?.Invoke( ${moduleResourceId.value}, ${moduleIdentity.value} ,(step)=> { ${$this.fPipeline.value}.Prepend(step); } , (step)=> { ${$this.fPipeline.value}.Append(step); } );`;
+      yield `${OnModuleLoad.value}?.Invoke( ${moduleResourceId.value}, ${moduleIdentity.value} ,(step)=> { ${$this.fPipelineWithProxy.value}.Prepend(step); } , (step)=> { ${$this.fPipelineWithProxy.value}.Append(step); } );`;
+      yield 'CustomInit();';
+    });
+
+    this.createPipelineMethod = this.add(new Method('CreatePipeline', ClientRuntime.HttpPipeline, {
+      parameters: [this.pInvocationInfo, this.pCorrelationId, this.pProcessRecordId, this.pParameterSetNameWithDefault],
+      description: 'Creates an instance of the HttpPipeline for each call.',
+      returnsDescription: `An instance of ${ClientRuntime.HttpPipeline} for the remote call.`
+    }));
+
+    /* pipeline create method */
+    this.createPipelineMethod.add(function* () {
+      const pip = new LocalVariable('pipeline', ClientRuntime.HttpPipeline, { initializer: 'null' });
+      yield pip.declarationStatement;
+      yield `BeforeCreatePipeline(${$this.pInvocationInfo.use}, ref ${pip});`;
+      yield pip.assign(`(${pip} ?? (${$this.fHandler}.UseProxy ? ${$this.fPipelineWithProxy} : ${$this.fPipeline})).Clone()`);
+      yield `AfterCreatePipeline(${$this.pInvocationInfo.use}, ref ${pip});`;
+      yield `pipeline.Append(new Runtime.CmdInfoHandler(${$this.pProcessRecordId}, ${$this.pInvocationInfo.use}, ${$this.pParameterSetName}).SendAsync);`;
+      yield `${OnNewRequest.value}?.Invoke( ${$this.pInvocationInfo.use}, ${$this.pCorrelationId},${$this.pProcessRecordId}, (step)=> { ${pip}.Prepend(step); } , (step)=> { ${pip}.Append(step); } );`;
+      yield Return(pip);
+    });
+  }
+}
+
+export class NewModuleClass extends Class {
+
+  // get the name of the client API class
+  TaskOfHttpResponseMessage = System.Threading.Tasks.Task(System.Net.Http.HttpResponseMessage);
+
+  // lets the common code call the signal again (recursive! careful!)
+  incomingSignalFunc = System.Func(
+    dotnet.String,
+    System.Threading.CancellationToken,
+    System.Func(System.EventArgs),
+    /* returns */ System.Threading.Tasks.Task());
+
+  eventListenerFunc = System.Func(
+    dotnet.String,
+    System.Threading.CancellationToken,
+    System.Func(System.EventArgs),
+    this.incomingSignalFunc,
+    InvocationInfo,
+    dotnet.String,
+    dotnet.String,
+    dotnet.String,
+    System.Exception,
+    /* returns */ System.Threading.Tasks.Task());
+
+  IEventListenerExpanded = [
+    System.Threading.CancellationToken, /* token */
+    System.Action(),                    /* Cancel() */
+    this.incomingSignalFunc,
+  ];
+
+  nextStep = System.Func(
+    System.Net.Http.HttpRequestMessage,
+    ...this.IEventListenerExpanded,
+    /* returns */ this.TaskOfHttpResponseMessage);
+
+  initMethod = this.add(new Method('Init', dotnet.Void, { description: 'Initialization steps performed after the module is loaded.' }));
+  createPipelineMethod!: Method;
+
+  pInvocationInfo = new Parameter('invocationInfo', InvocationInfo, { description: 'The <see cref="System.Management.Automation.InvocationInfo" /> from the cmdlet' });
+  pPipeline = new Parameter('pipeline', ClientRuntime.HttpPipeline, { modifier: ParameterModifier.Ref, description: 'The HttpPipeline for the request' });
+  pProxy = new Parameter('proxy', System.Uri, { description: 'The HTTP Proxy to use.' });
+  pProxyCredential = new Parameter('proxyCredential', PSCredential, { description: 'The HTTP Proxy Credentials' });
+  pUseDefaultCredentials = new Parameter('proxyUseDefaultCredentials', dotnet.Bool, { description: 'True if the proxy should use default credentials' });
+
+  pCorrelationId = new Parameter('correlationId', dotnet.String, { description: 'the cmdlet\'s correlation id.' });
+  pParameterName = new Parameter('parameterName', dotnet.String, { description: 'The name of the parameter to get the value for.' });
+
+  pId = new Parameter('id', dotnet.String, { description: 'The ID of the event ' });
+  pToken = new Parameter('token', System.Threading.CancellationToken, { description: 'The cancellation token for the event ' });
+  pGetEventData = new Parameter('getEventData', System.Func(System.EventArgs), { description: 'A delegate to get the detailed event data' });
+
+  pParameterSetName = new Parameter('parameterSetName', dotnet.String, { description: 'the cmdlet\'s parameterset name.' });
+  pParameterSetNameWithDefault = new Parameter('parameterSetName', dotnet.String, { description: 'the cmdlet\'s parameterset name.', defaultInitializer: dotnet.Null });
+  pProcessRecordId = new Parameter('processRecordId', dotnet.String, { description: 'the cmdlet\'s process record correlation id.' });
+  pException = new Parameter('exception', System.Exception, { description: 'the exception that is being thrown (if available)' });
+
+  fPipeline = this.add(new Field('_pipeline', ClientRuntime.HttpPipeline, { access: Access.Private, description: 'the ISendAsync pipeline instance' }));
+  fPipelineWithProxy = this.add(new Field('_pipelineWithProxy', ClientRuntime.HttpPipeline, { access: Access.Private, description: 'the ISendAsync pipeline instance (when proxy is enabled)' }));
+  fHandler = this.add(new Field('_handler', System.Net.Http.HttpClientHandler, { initialValue: System.Net.Http.HttpClientHandler.new() }));
+  fWebProxy = this.add(new Field('_webProxy', System.Net.WebProxy, { initialValue: System.Net.WebProxy.new() }));
+
+  constructor(namespace: Namespace, private readonly state: NewState, objectInitializer?: DeepPartial<ModuleClass>) {
+    super(namespace, 'Module');
+    this.apply(objectInitializer);
+    this.partial = true;
+    this.description = 'A class that contains the module-common code and data.';
+
+    const $this = this;
+
+    // static instance property
+    this.add(new LazyProperty('Instance', this, new LiteralExpression(`new ${this.declaration}()`), {
+      instanceAccess: this.declaration,
+      static: Modifier.Static,
+      description: 'the singleton of this module class'
+    }));
+
+    const clientAPI = new ClassType(this.state.model.language.csharp?.namespace, this.state.model.language.csharp?.name || '');
     const clientProperty = this.add(new Property('ClientAPI', clientAPI, { description: 'The instance of the Client API' }));
 
     if (this.state.project.azure) {

--- a/powershell/module/module-namespace.ts
+++ b/powershell/module/module-namespace.ts
@@ -4,8 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../llcsharp/exports';
-import { State } from '../internal/state';
-import { ModuleClass } from './module-class';
+import { State, NewState } from '../internal/state';
+import { ModuleClass, NewModuleClass } from './module-class';
 import { DeepPartial } from '@azure-tools/codegen';
 
 export class ModuleNamespace extends Namespace {
@@ -22,5 +22,22 @@ export class ModuleNamespace extends Namespace {
 
     // module class
     this.moduleClass = new ModuleClass(this, state);
+  }
+}
+
+export class NewModuleNamespace extends Namespace {
+  public moduleClass: NewModuleClass;
+
+  public get outputFolder(): string {
+    return this.state.project.moduleFolder;
+  }
+
+  constructor(public state: NewState, objectInitializer?: DeepPartial<ModuleNamespace>) {
+    super(state.model.language.csharp?.namespace || 'INVALID.NAMESPACE', state.project);
+    this.apply(objectInitializer);
+    this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
+
+    // module class
+    this.moduleClass = new NewModuleClass(this, state);
   }
 }

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -54,9 +54,11 @@
     "eslint": "~6.2.2"
   },
   "dependencies": {
+    "js-yaml": "3.13.1",
     "@azure-tools/codegen": "~2.1.0",
     "@azure-tools/codegen-csharp": "~3.0.0",
     "@azure-tools/codemodel-v3": "~3.1.0",
+    "@azure-tools/codemodel": "~4.13.327",
     "@azure-tools/autorest-extension-base": "~3.1.0",
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/tasks": "~3.0.0",

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -1,0 +1,484 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { codeModelSchema, CodeModel, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
+//import { JsonType, processCodeModel, codemodel, components, command, http, getAllProperties, ModelState, ParameterLocation, } from '@azure-tools/codemodel-v3';
+import { JsonType, processCodeModel, codemodel, components, command, http, ModelState, Schema as SchemaV3 } from '@azure-tools/codemodel-v3';
+import { deconstruct, fixLeadingNumber, pascalCase, EnglishPluralizationService, fail, removeSequentialDuplicates, serialize } from '@azure-tools/codegen';
+import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
+import { Schema } from '../llcsharp/exports';
+import { Channel, Host, Session, startSession } from '@azure-tools/autorest-extension-base';
+import { Lazy } from '@azure-tools/tasks';
+import { clone } from '@azure-tools/linq';
+import { verbs } from '../internal/verbs';
+import { PwshModel } from '../utils/PwshModel';
+import { IParameterPwsh } from '../utils/components';
+import { NewModelState } from '../utils/model-state';
+
+type State = NewModelState<PwshModel>;
+
+
+// UNUSED: Moved to plugin-tweak-model.ts in remodeler
+// For now, we are not dynamically changing the service-name. Instead, we would figure out a method to change it during the creation of service readme's.
+export function titleToAzureServiceName(title: string): string {
+  const titleCamelCase = pascalCase(deconstruct(title)).trim();
+  const serviceName = titleCamelCase
+    // Remove: !StartsWith(Management)AndContains(Management), Client, Azure, Microsoft, APIs, API, REST
+    .replace(/(?!^Management)(?=.*)Management|Client|Azure|Microsoft|APIs|API|REST/g, '')
+    // Remove: EndsWith(ServiceResourceProvider), EndsWith(ResourceProvider), EndsWith(DataPlane), EndsWith(Data)
+    .replace(/ServiceResourceProvider$|ResourceProvider$|DataPlane$|Data$/g, '');
+  return serviceName || titleCamelCase;
+}
+
+
+const pluralizationService = new EnglishPluralizationService();
+pluralizationService.addWord('Database', 'Databases');
+pluralizationService.addWord('database', 'databases');
+
+
+interface CommandVariant {
+  alias: Array<string>;
+  verb: string;
+  subject: string;
+  subjectPrefix: string;
+  variant: string;
+  action: string;
+}
+
+
+function fn<T>(active: Array<T>, remaining: Array<T>, result: Array<Array<T>>): Array<Array<T>> {
+  if (length(active) || length(remaining)) {
+    if (length(remaining)) {
+      fn([...active, remaining[0]], remaining.slice(1), result);
+      fn(active, remaining.slice(1), result);
+    } else {
+      result.push(active);
+    }
+  }
+  return result;
+}
+function combinations<T>(elements: Array<T>) {
+  return fn([], elements, []);
+}
+
+function splitOnPreposition(preposition: string, parts: Array<string>) {
+  const i = parts.indexOf(preposition);
+  if (i > 0) {
+    return [
+      parts.slice(0, i),
+      parts.slice(i + 1)
+    ];
+  }
+  return undefined;
+}
+
+function splitOnAnyPreposition(parts: Array<string>) {
+  for (const p of ['with', 'at', 'by', 'for', 'in', 'of']) {
+    const result = splitOnPreposition(p, parts);
+    if (result && result[0].length > 0) {
+      // we found it, let's give it back.
+      return result;
+    }
+  }
+  return undefined;
+}
+
+
+export /* @internal */ class Inferrer {
+  commonParameters = new Array<string>();
+  verbMap!: { [operationIdMethod: string]: string };
+  prefix!: string;
+  serviceName!: string;
+  subjectPrefix!: string;
+  isAzure!: boolean;
+
+  constructor(private state: State) {
+  }
+  async init() {
+    this.commonParameters = await this.state.getValue('azure', false) ? [
+      // 'resourceGroupName',
+      'subscriptionId'
+    ] : [];
+
+    this.verbMap = await this.state.getValue('verb-mapping') || {};
+    this.isAzure = await this.state.getValue('azure', false);
+    this.prefix = await this.state.getValue('prefix');
+    this.serviceName = titleToAzureServiceName(await this.state.getValue('service-name'));
+    this.state.setValue('service-name', this.serviceName);
+
+    this.subjectPrefix = await this.state.getValue('subject-prefix');
+
+    this.state.setValue('isAzure', this.isAzure);
+    this.state.setValue('prefix', this.prefix);
+
+    const model = this.state.model;
+
+    this.state.message({
+      Channel: Channel.Debug, Text: `[CMDLET-PREFIX] => '${model.language.default.prefix}'`
+    });
+
+    model.language.default.serviceName = this.serviceName;
+    this.state.message({
+      Channel: Channel.Debug, Text: `[SERVICE-NAME] => '${model.language.default.serviceName}'`
+    });
+
+    model.language.default.subjectPrefix = this.subjectPrefix;
+    this.state.message({
+      Channel: Channel.Debug, Text: `[SUBJECT-PREFIX] => '${model.language.default.subjectPrefix}'`
+    });
+
+    return this;
+  }
+
+  async createCommands() {
+    const model = this.state.model;
+    this.state.model.commands = <any>{
+      operations: new Dictionary<any>(),
+      parameters: new Dictionary<any>(),
+    };
+
+    this.state.message({ Channel: Channel.Debug, Text: 'detecting high level commands...' });
+    for (const operationGroup of values(model.operationGroups)) {
+      for (const operation of values(operationGroup.operations)) {
+        for (const variant of await this.inferCommandNames(operation, operationGroup.$key, this.state)) {
+          await this.addVariants(operation.parameters, operation, variant, '', this.state);
+        }
+      }
+    }
+    // for (const operation of values(model.http.operations)) {
+    //   for (const variant of await this.inferCommandNames(operation, this.state)) {
+    //     // no common parameters (standard variations)
+    //     await this.addVariants(operation.parameters, operation, variant, '', this.state);
+    //   }
+    // }
+    return model;
+  }
+
+  inferCommand(operation: Array<string>, group: string, suffix: Array<string> = []): Array<CommandVariant> {
+    operation = operation.filter(each => each !== 'all');
+    // no instant match 
+    switch (length(operation)) {
+      case 0:
+        throw new Error('Missing operation id?');
+
+      case 1:
+        // simple operation, just an id with a single value
+        // OPERATION => OPERATION-GROUP
+        return [
+          this.createCommandVariant(operation[0], deconstruct(group), suffix, this.state.model)
+        ];
+
+      case 2:
+        // should try to infer [SUBJECT] and [ACTION] from operation
+        if (verbs.has(operation[0])) {
+          // [ACTION][SUBJECT]
+          return [
+            this.createCommandVariant(operation[0], [...deconstruct(group), operation[1]], suffix, this.state.model)
+          ];
+        }
+        if (verbs.has(operation[1])) {
+          // [SUBJECT][ACTION]
+          return [
+            this.createCommandVariant(operation[1], [...deconstruct(group), operation[0]], suffix, this.state.model)
+          ];
+
+        }
+        // can't tell which is the [ACTION] -- let's return it the way we used to, 
+        // but now let's mention that we are doing that.
+        this.state.warning(`Operation ${operation[0]}/${operation[1]} is inferred without finding action.`, [], {});
+        return [
+          this.createCommandVariant(operation[0], [...deconstruct(group), operation[1]], suffix, this.state.model)
+        ];
+
+    }
+    // three or more words.
+    // first, see if it's an 'or'
+    const either = splitOnPreposition('or', operation);
+    if (either) {
+      // looks like we got two sets of operations from this.
+      return [
+        ...this.inferCommand([...either[0], ...either[1].slice(1)], group, suffix),
+        ...this.inferCommand(either[1], group, suffix),
+      ];
+    }
+
+    // any other preposition?
+    const parts = splitOnAnyPreposition(operation);
+    if (parts) {
+      // so this is something like DoActionWithStyle
+      return [...this.inferCommand(parts[0], group, parts[1])];
+    }
+
+    // if not, then seek out a verb from there.
+    for (let i = 0; i < length(operation); i++) {
+      if (verbs.has(operation[i])) {
+        // if the action is first
+        if (i === 0) {
+          // everything else is the subject
+          return [this.createCommandVariant(operation[i], group ? [...deconstruct(group), ...operation.slice(i + 1)] : operation.slice(i + 1), suffix, this.state.model)];
+        }
+        if (i === length(operation) - 1) {
+          // if it's last, the subject would be the first thing
+          return [this.createCommandVariant(operation[i], group ? [...deconstruct(group), ...operation.slice(0, i)] : operation.slice(0, i), suffix, this.state.model)];
+        }
+
+        // otherwise          
+        // things before are part of the subject
+        // things after the verb should be part of the suffix
+        return [this.createCommandVariant(operation[i], group ? [...deconstruct(group), ...operation.slice(i, i)] : operation.slice(i, i), [...suffix, ...operation.slice(i + 1)], this.state.model)];
+      }
+    }
+
+    // so couldn't tell what the action was.
+    // fallback to the original behavior with a warning.
+    this.state.warning(`Operation ${operation[0]}/${operation[1]} is inferred without finding action.`, [], {});
+    return [this.createCommandVariant(operation[0], group ? [...deconstruct(group), ...operation.slice(1)] : operation.slice(1), [...suffix, ...operation.slice(1)], this.state.model)];
+  }
+
+  async inferCommandNames(op: Operation, group: string, state: State): Promise<Array<CommandVariant>> {
+
+    const method = op.language.default.name;
+    // skip-for-time-being
+    // if (!method) {
+    //   if (!group) {
+    //     // no operation id at all?
+    //     const path = op.path.replace(/{.*?}/g, '').replace(/\/+/g, '/').replace(/\/$/g, '');
+    //     method = path.split('/').last;
+    //   } else {
+    //     // no group given, use string as method
+    //     method = group;
+    //   }
+    //   group = pascalCase(op.tags) || '';
+
+    // }
+
+    const groupWords = deconstruct(group);
+    groupWords[groupWords.length - 1] = pluralizationService.singularize(groupWords.last);
+
+    group = pascalCase(groupWords);
+    const operation = deconstruct(method);
+
+    // instant match
+    if (this.verbMap[method]) {
+      return [this.createCommandVariant(method, [group], [], state.model)];
+    }
+
+    // dig deeper.
+    return this.inferCommand(operation, group);
+  }
+
+  async addVariant(vname: string, body: Parameter | null, bodyParameterName: string, parameters: Array<Parameter>, operation: Operation, variant: CommandVariant, state: State) {
+    const op = await this.addCommandOperation(vname, parameters, operation, variant, state);
+
+    // if this has a body with it, let's add that parameter
+    if (body && body.schema) {
+      op.details.default.hasBody = true;
+      op.parameters.push(new IParameterPwsh(bodyParameterName, new SchemaV3('not used'), body.schema, {
+        details: {
+          default: {
+            description: body.schema.language.default.description,
+            name: pascalCase(bodyParameterName),
+            isBodyParameter: true,
+          }
+        }
+      }));
+
+      // let's add a variant where it's expanded out.
+      // *IF* the body is an object
+      if (body.schema.type === SchemaType.Object) {
+        const opExpanded = await this.addCommandOperation(`${vname}Expanded`, parameters, operation, variant, state);
+        opExpanded.details.default.dropBodyParameter = true;
+        opExpanded.parameters.push(new IParameterPwsh(`${bodyParameterName}Body`, new SchemaV3('not used'), body.schema, {
+          details: {
+            default: {
+              description: body.schema.language.default.description,
+              name: pascalCase(`${bodyParameterName}Body`),
+              isBodyParameter: true,
+            }
+          }
+        }));
+      }
+    }
+  }
+
+
+  isNameConflict(model: codemodel.Model, variant: CommandVariant, vname: string) {
+    for (const each of values(model.commands.operations)) {
+      if (each.details.default.name === vname) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // for tracking unique operation identities 
+  operationIdentities = new Set<string>();
+
+  async addCommandOperation(vname: string, parameters: Array<Parameter>, operation: Operation, variant: CommandVariant, state: State): Promise<command.CommandOperation> {
+    // skip-for-time-being following code seems redundant -----
+    // let apiversion = '';
+
+    // for (const each of items(operation.responses)) {
+    //   for (const rsp of items(each)) {
+    //     if (rsp.schema && rsp.schema.details && rsp.schema.details.default && rsp.schema.details.default.apiversion) {
+    //       apiversion = rsp.schema.details.default.apiversion;
+    //       break;
+    //     }
+    //   }
+    // }
+    // ----------------------------------------------------------
+
+    // if vname is > 64 characters, let's trim it
+    // after trimming it, make sure there aren't any other operation with a name that's exactly the same
+    if (length(vname) > 64) {
+      const names = deconstruct(vname);
+      let newVName = '';
+      for (let i = 0; i < length(names); i++) {
+        newVName = pascalCase(names.slice(0, i));
+        if (length(newVName) > 60) {
+          break;
+        }
+      }
+      vname = newVName;
+    }
+
+    // if we have an identical vname, let's add 'etc'
+    let fname = `${variant.verb}-${variant.subject}-${vname}`;
+    let n = 1;
+    while (this.operationIdentities.has(fname)) {
+      vname = `${vname.replace(/\d*$/g, '')}${n++}`;
+      fname = `${variant.verb}-${variant.subject}-${vname}`;
+    }
+    this.operationIdentities.add(fname);
+
+    variant.variant = vname;
+    vname = pascalCase(vname);
+    // skip-for-time-being x-ms-metadata looks not supported any more.
+    //const xmsMetadata = operation.pathExtensions ? operation.pathExtensions['x-ms-metadata'] ? clone(operation.pathExtensions['x-ms-metadata']) : {} : {};
+
+    return state.model.commands.operations[`${length(state.model.commands.operations)}`] = new command.CommandOperation(operation.language.default.name, {
+      asjob: operation.language.default.asjob ? true : false,
+      extensions: {
+
+      },
+      ...variant,
+      details: {
+        ...operation.language,
+        default: {
+          ...operation.language.default,
+          subject: variant.subject,
+          subjectPrefix: variant.subjectPrefix,
+          verb: variant.verb,
+          name: vname,
+          alias: variant.alias
+        }
+      },
+      // operationId is not needed any more
+      operationId: '',
+      parameters: parameters.map(httpParameter => {
+        // make it's own copy of the parameter since after this, 
+        // the parameter can be altered for each operation individually.
+        const each = clone(httpParameter, false, undefined, undefined, ['schema', 'origin']);
+        each.language.default = {
+          ...each.language.default,
+          name: pascalCase(each.language.default.name),
+          httpParameter
+        };
+        each.details = {};
+        each.details.default = {
+          ...each.language.default,
+          name: pascalCase(each.language.default.name),
+          httpParameter
+        };
+        return each;
+      }),
+      // skip-for-time-being, this callGraph is used in the header comments
+      callGraph: [],
+    });
+  }
+
+  async addVariants(parameters: Array<Parameter> | undefined, operation: Operation, variant: CommandVariant, vname: string, state: State) {
+    // now synthesize parameter set variants multiplexed by the variants.
+    const [constants, requiredParameters] = values(parameters).bifurcate(parameter => parameter.language.default.constantValue || parameter.language.default.fromHost ? true : false);
+    const constantParameters = constants.map(each => `'${each.language.default.constantValue}'`);
+
+    // the body parameter
+    const body = (operation.requests && operation.requests[0].parameters) ? operation.requests[0].parameters[0] : null;
+    // skip-for-time-being, looks x-ms-requestBody-name is not supported any more
+    //const bodyParameterName = (operation.requestBody && operation.requestBody.extensions) ? operation.requestBody.extensions['x-ms-requestBody-name'] || 'bodyParameter' : '';
+    const bodyParameterName = body ? 'bodyParameter' : '';
+
+    // all the properties in the body parameter
+    const bodyProperties = (body && body.schema && isObjectSchema(body.schema)) ? values(getAllProperties(body.schema)).where(property => !property.language.default.readOnly).toArray() : [];
+
+    // smash body property names together
+    const bodyPropertyNames = bodyProperties.joinWith(each => each.language.default.name);
+
+    // for each polymorphic body, we should do a separate variant that takes the polymorphic body type instead of the base type
+    // skip-for-time-being, this is for polymorphism
+    //const polymorphicBodies = (body && body.schema && body.schema.details.default.polymorphicChildren && length(body.schema.details.default.polymorphicChildren)) ? (<Array<Schema>>body.schema.details.default.polymorphicChildren).joinWith(child => child.details.default.name) : '';
+
+    // wait! "update" should be "set" if it's a POST
+    if (variant.verb === 'Update' && operation.requests && operation.requests[0].protocol?.http?.method === http.HttpMethod.Put) {
+      variant.verb = 'Set';
+    }
+
+    // create variant 
+    // skip-for-time-being, since operationId looks not included in m4.
+    //state.message({ Channel: Channel.Debug, Text: `${variant.verb}-${variant.subject} //  ${operation.operationId} => ${JSON.stringify(variant)} taking ${requiredParameters.joinWith(each => each.name)}; ${constantParameters} ; ${bodyPropertyNames} ${polymorphicBodies ? `; Polymorphic bodies: ${polymorphicBodies} ` : ''}` });
+    await this.addVariant(pascalCase([variant.action, vname]), body, bodyParameterName, [...constants, ...requiredParameters], operation, variant, state);
+
+    const [pathParams, otherParams] = values(requiredParameters).bifurcate(each => each?.protocol?.http?.in === ParameterLocation.Path);
+    const dvi = await state.getValue('disable-via-identity', false);
+
+    if (!dvi && length(pathParams) > 0 && variant.action.toLowerCase() != 'list') {
+      // we have an operation that has path parameters, a good canididate for piping for identity.
+      await this.addVariant(pascalCase([variant.action, vname, 'via-identity']), body, bodyParameterName, [...constants, ...otherParams], operation, variant, state);
+    }
+
+  }
+
+  createCommandVariant(action: string, subject: Array<string>, variant: Array<string>, model: PwshModel): CommandVariant {
+    const verb = this.getPowerShellVerb(action);
+    if (verb === 'Invoke') {
+      // if the 'operation' name was  "post" -- it's kindof redundant.
+      // so, only include the operation name in the group name if it's anything else
+      if (action.toLowerCase() !== 'post') {
+        subject = [action, ...subject];
+      }
+    }
+
+    return {
+      alias: [],
+      subject: pascalCase([...removeSequentialDuplicates(subject.map(each => pluralizationService.singularize(each)))]),
+      variant: pascalCase(variant),
+      verb,
+      subjectPrefix: model.language.default.subjectPrefix,
+      action
+    };
+  }
+
+  getPowerShellVerb(action: string): string {
+    const verb = this.verbMap[pascalCase(action)];
+    if (verb) {
+      return verb;
+    } else {
+      return 'Invoke';
+    }
+  }
+}
+
+
+export async function createCommandsV2(service: Host) {
+  // return processCodeModel(commandCreator, service);
+  //const session = await startSession<PwshModel>(service, {}, codeModelSchema);
+  //const result = tweakModelV2(session);
+  const state = await new NewModelState<PwshModel>(service).init();
+  await service.WriteFile('code-model-v4-createcommands-v2.yaml', serialize(await (await new Inferrer(state).init()).createCommands()), undefined, 'code-model-v4');
+
+  // return processCodeModel(async (state) => {
+  //   return await (await new Inferrer(state).init()).createCommands();
+  // }, service, 'createCommands-v2');
+}

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -13,9 +13,9 @@ import { Lazy } from '@azure-tools/tasks';
 import { clone } from '@azure-tools/linq';
 import { verbs } from '../internal/verbs';
 import { PwshModel } from '../utils/PwshModel';
-import { IParameterPwsh } from '../utils/components';
+import { IParameter } from '../utils/components';
 import { NewModelState } from '../utils/model-state';
-import { Schema as SchemaV3 } from '../utils/schema';
+//import { Schema as SchemaV3 } from '../utils/schema';
 import { CommandOperation } from '../utils/command-operation';
 
 type State = NewModelState<PwshModel>;
@@ -276,7 +276,7 @@ export /* @internal */ class Inferrer {
     // if this has a body with it, let's add that parameter
     if (body && body.schema) {
       op.details.default.hasBody = true;
-      op.parameters.push(new IParameterPwsh(bodyParameterName, new SchemaV3('not used'), body.schema, {
+      op.parameters.push(new IParameter(bodyParameterName, body.schema, {
         details: {
           default: {
             description: body.schema.language.default.description,
@@ -291,7 +291,7 @@ export /* @internal */ class Inferrer {
       if (body.schema.type === SchemaType.Object) {
         const opExpanded = await this.addCommandOperation(`${vname}Expanded`, parameters, operation, variant, state);
         opExpanded.details.default.dropBodyParameter = true;
-        opExpanded.parameters.push(new IParameterPwsh(`${bodyParameterName}Body`, new SchemaV3('not used'), body.schema, {
+        opExpanded.parameters.push(new IParameter(`${bodyParameterName}Body`, body.schema, {
           details: {
             default: {
               description: body.schema.language.default.description,
@@ -396,7 +396,7 @@ export /* @internal */ class Inferrer {
         return each;
       }),
       // skip-for-time-being, this callGraph is used in the header comments
-      callGraph: [],
+      callGraph: [operation],
     });
   }
 

--- a/powershell/plugins/cs-namer-v2.ts
+++ b/powershell/plugins/cs-namer-v2.ts
@@ -1,0 +1,257 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { codeModelSchema, SchemaResponse, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
+//import { codemodel, JsonType, ModelState, processCodeModel, VirtualProperty } from '@azure-tools/codemodel-v3';
+import { ModelState } from '@azure-tools/codemodel-v3';
+import { camelCase, deconstruct, excludeXDash, fixLeadingNumber, pascalCase, lowest, maximum, minimum, getPascalIdentifier, serialize } from '@azure-tools/codegen';
+import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
+import { System } from '@azure-tools/codegen-csharp';
+
+import { Channel, Host, Session, startSession } from '@azure-tools/autorest-extension-base';
+import { SchemaDetails } from '../llcsharp/code-model';
+import { SchemaDefinitionResolver, NewSchemaDefinitionResolver } from '../llcsharp/schema/schema-resolver';
+import { PwshModel } from '../utils/PwshModel';
+import { NewModelState } from '../utils/model-state';
+
+type State = NewModelState<PwshModel>;
+
+
+function setPropertyNames(schema: Schema) {
+  // name each property in this schema
+  // skip-for-time-being
+  // for (const propertySchema of values(schema.properties)) {
+  //   const propertyDetails = propertySchema.details.default;
+
+  //   const className = schema.details.csharp.name;
+
+  //   let pname = getPascalIdentifier(propertyDetails.name);
+  //   if (pname === className) {
+  //     pname = `${pname}Property`;
+  //   }
+
+  //   if (pname === 'default') {
+  //     pname = '@default';
+  //   }
+
+  //   propertySchema.details.csharp = {
+  //     ...propertyDetails,
+  //     name: pname // and so are the propertyNmaes
+  //   };
+
+  //   if (propertyDetails.isNamedStream) {
+  //     propertySchema.details.csharp.namedStreamPropertyName = pascalCase(fixLeadingNumber([...deconstruct(propertyDetails.name), 'filename']));
+  //   }
+  // }
+
+}
+
+
+function setSchemaNames(schemaGroups: Dictionary<Array<Schema>>, azure: boolean, serviceNamespace: string) {
+  const baseNamespace = new Set<string>();
+  const subNamespace = new Map<string, Set<string>>();
+  // dolauli need to notice this -- schemas in the namespace of the lowest supported api version
+  // in Azure Mode, we want to always put schemas into the namespace of the lowest supported apiversion.
+  // otherwise, we just want to differientiate with a simple incremental numbering scheme.
+
+  for (const group of values(schemaGroups)) {
+    for (const schema of group) {
+      let thisNamespace = baseNamespace;
+      let thisApiversion = '';
+
+      // create the namespace if required
+      if (azure) {
+        const metadata = schema.extensions && schema.extensions['x-ms-metadata'];
+        if (metadata) {
+          const apiVersions = <Array<string> | undefined>metadata.apiVersions;
+          if (apiVersions && length(apiVersions) > 0) {
+            thisApiversion = minimum(apiVersions);
+            thisNamespace = subNamespace.get(thisApiversion) || new Set<string>();
+            subNamespace.set(thisApiversion, thisNamespace);
+          }
+        }
+      }
+
+      // for each schema, we're going to set the name
+      // to the suggested name, unless we have collisions
+      // at which point, we're going to add a number (for now?)
+      const details = schema.language.default;
+      let schemaName = getPascalIdentifier(details.name);
+      const apiName = (!thisApiversion) ? '' : getPascalIdentifier(`Api ${thisApiversion}`);
+      const ns = (!thisApiversion) ? [] : ['.', apiName];
+
+
+      let n = 1;
+      while (thisNamespace.has(schemaName)) {
+        schemaName = getPascalIdentifier(`${details.name}_${n++}`);
+      }
+      thisNamespace.add(schemaName);
+
+      // object types.
+      if (schema.type === SchemaType.Object) {
+        schema.language.csharp = {
+          ...details,
+          apiversion: thisApiversion,
+          apiname: apiName,
+          interfaceName: pascalCase(fixLeadingNumber(['I', ...deconstruct(schemaName)])), // objects have an interfaceName
+          internalInterfaceName: pascalCase(fixLeadingNumber(['I', ...deconstruct(schemaName), 'Internal'])), // objects have an ineternal interfaceName for setting private members. 
+          fullInternalInterfaceName: `${pascalCase([serviceNamespace, '.', 'Models', ...ns])}.${pascalCase(fixLeadingNumber(['I', ...deconstruct(schemaName), 'Internal']))}`,
+          name: getPascalIdentifier(schemaName),
+          namespace: pascalCase([serviceNamespace, '.', 'Models', ...ns]),  // objects have a namespace
+          fullname: `${pascalCase([serviceNamespace, '.', 'Models', ...ns])}.${getPascalIdentifier(schemaName)}`,
+        };
+      } else if (schema.type === SchemaType.String && schema.language.default.enum) {
+        // oh, it's an enum type
+        // Skip for time-being
+        // schema.language.csharp = <SchemaDetails>{
+        //   ...details,
+        //   interfaceName: pascalCase(fixLeadingNumber(['I', ...deconstruct(schemaName)])),
+        //   name: getPascalIdentifier(schema.language.default.enum.name),
+        //   namespace: pascalCase([serviceNamespace, '.', 'Support']),
+        //   fullname: `${pascalCase([serviceNamespace, '.', 'Support'])}.${getPascalIdentifier(schema.language.default.enum.name)}`,
+        //   enum: {
+        //     ...schema.language.default.enum,
+        //     name: getPascalIdentifier(schema.language.default.enum.name),
+        //     values: schema.language.default.enum.values.map(each => {
+        //       return {
+        //         ...each,
+        //         name: getPascalIdentifier(each.name),
+        //         description: each.description
+        //       };
+        //     })
+        //   }
+        // };
+      } else {
+        schema.language.csharp = <SchemaDetails>{
+          ...details,
+          interfaceName: '<INVALID_INTERFACE>',
+          internalInterfaceName: '<INVALID_INTERFACE>',
+          name: schemaName,
+          namespace: '<INVALID_NAMESPACE>',
+          fullname: '<INVALID_FULLNAME>'
+        };
+      }
+
+      // name each property in this schema
+      setPropertyNames(<Schema><any>schema);
+
+      // fix enum names
+      // skip-for-time-being
+      // if (schema.details.default.enum) {
+      //   schema.details.csharp.enum = {
+      //     ...schema.details.default.enum,
+      //     name: getPascalIdentifier(schema.details.default.enum.name)
+      //   };
+
+      //   // and the value names themselves
+      //   for (const value of values(schema.details.csharp.enum.values)) {
+      //     value.name = getPascalIdentifier(value.name);
+      //   }
+      // }
+    }
+  }
+
+}
+
+async function setOperationNames(state: State, resolver: NewSchemaDefinitionResolver) {
+  // keep a list of operation names that we've assigned.
+  const operationNames = new Set<string>();
+  for (const operationGroup of values(state.model.operationGroups)) {
+    for (const operation of values(operationGroup.operations)) {
+      const details = operation.language.default;
+
+      // come up with a name
+      const oName = getPascalIdentifier(details.name);
+      let i = 1;
+      let operationName = oName;
+      while (operationNames.has(operationName)) {
+        // if we have used that name, try again.
+        operationName = `${oName}${i++}`;
+      }
+      operationNames.add(operationName);
+
+      operation.language.csharp = {
+        ...details, // inherit
+        name: operationGroup.language.default.name + operationName,
+      };
+
+      // parameters are camelCased.
+      for (const parameter of values(operation.parameters)) {
+        const parameterDetails = parameter.language.default;
+
+        let propName = camelCase(fixLeadingNumber(deconstruct(parameterDetails.name)));
+
+        if (propName === 'default') {
+          propName = '@default';
+        }
+
+        parameter.language.csharp = {
+          ...parameterDetails,
+          name: propName
+        };
+      }
+
+      for (const rsp of values(operation.responses)) {
+        // per responseCode
+        const response = <SchemaResponse>rsp;
+        const responseTypeDefinition = response.schema ? resolver.resolveTypeDeclaration(<any>response.schema, true, state) : undefined;
+        // const headerTypeDefinition = response.headerSchema ? resolver.resolveTypeDeclaration(<any>response.headerSchema, true, state.path('schemas', response.headerSchema.details.default.name)) : undefined;
+        let code = (System.Net.HttpStatusCode[response.protocol.http?.statusCodes[0]] ? System.Net.HttpStatusCode[response.protocol.http?.statusCodes[0]].value : response.protocol.http?.statusCodes[0]).replace('global::System.Net.HttpStatusCode', '');
+        let rawValue = code.replace(/\./, '');
+        if (response.protocol.http?.statusCodes[0] === 'default' || rawValue === 'default' || '') {
+          rawValue = 'any response code not handled elsewhere';
+          code = 'default';
+        }
+        response.language.csharp = {
+          ...response.language.default,
+          responseType: responseTypeDefinition ? responseTypeDefinition.declaration : '',
+          headerType: '',
+          name: (length(response.protocol.http?.mimeTypes) <= 1) ?
+            camelCase(fixLeadingNumber(deconstruct(`on ${code}`))) : // the common type (or the only one.)
+            camelCase(fixLeadingNumber(deconstruct(`on ${code} ${response.protocol.http?.mimeTypes[0]}`))),
+          description: (length(response.protocol.http?.mimeTypes) <= 1) ?
+            `a delegate that is called when the remote service returns ${response.protocol.http?.statusCodes[0]} (${rawValue}).` :
+            `a delegate that is called when the remote service returns ${response.protocol.http?.statusCodes[0]} (${rawValue}) with a Content-Type matching ${response.protocol.http?.mimeTypes.join(',')}.`
+
+        };
+      }
+    }
+  }
+}
+
+async function nameStuffRight(state: State): Promise<PwshModel> {
+  const resolver = new NewSchemaDefinitionResolver();
+  const model = state.model;
+
+  // set the namespace for the service
+  const serviceNamespace = await state.getValue('namespace', 'Sample.API');
+  const azure = await state.getValue('azure', false) || await state.getValue('azure-arm', false);
+  const clientName = getPascalIdentifier(model.language.default.name);
+
+  // dolauli see model.details.csharp for c# related staff
+  // set c# client details (name)
+  model.language.csharp = {
+    ...model.language.default, // copy everything by default
+    name: clientName,
+    namespace: serviceNamespace,
+    fullname: `${serviceNamespace}.${clientName}`
+  };
+
+  setSchemaNames(<Dictionary<Array<Schema>>><any>model.schemas, azure, serviceNamespace);
+  await setOperationNames(state, resolver);
+
+  return model;
+}
+
+
+export async function csnamerV2(service: Host) {
+  // dolauli add names for http operations and schemas
+  //return processCodeModel(nameStuffRight, service, 'csnamer');
+  //const session = await startSession<PwshModel>(service, {}, codeModelSchema);
+  //const result = tweakModelV2(session);
+  const state = await new NewModelState<PwshModel>(service).init();
+  await service.WriteFile('code-model-v4-csnamer-v2.yaml', serialize(await nameStuffRight(state)), undefined, 'code-model-v4');
+}
+

--- a/powershell/plugins/cs-namer-v2.ts
+++ b/powershell/plugins/cs-namer-v2.ts
@@ -5,7 +5,6 @@
 
 import { codeModelSchema, SchemaResponse, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
 //import { codemodel, JsonType, ModelState, processCodeModel, VirtualProperty } from '@azure-tools/codemodel-v3';
-import { ModelState } from '@azure-tools/codemodel-v3';
 import { camelCase, deconstruct, excludeXDash, fixLeadingNumber, pascalCase, lowest, maximum, minimum, getPascalIdentifier, serialize } from '@azure-tools/codegen';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import { System } from '@azure-tools/codegen-csharp';

--- a/powershell/plugins/cs-namer.ts
+++ b/powershell/plugins/cs-namer.ts
@@ -48,7 +48,7 @@ function setPropertyNames(schema: Schema) {
 function setSchemaNames(schemas: Dictionary<Schema>, azure: boolean, serviceNamespace: string) {
   const baseNamespace = new Set<string>();
   const subNamespace = new Map<string, Set<string>>();
-
+  // dolauli need to notice this -- schemas in the namespace of the lowest supported api version
   // in Azure Mode, we want to always put schemas into the namespace of the lowest supported apiversion.
   // otherwise, we just want to differientiate with a simple incremental numbering scheme.
 
@@ -222,6 +222,7 @@ async function nameStuffRight(state: State): Promise<codemodel.Model> {
   const azure = await state.getValue('azure', false) || await state.getValue('azure-arm', false);
   const clientName = getPascalIdentifier(model.details.default.name);
 
+  // dolauli see model.details.csharp for c# related staff
   // set c# client details (name)
   model.details.csharp = {
     ...model.details.default, // copy everything by default
@@ -238,6 +239,7 @@ async function nameStuffRight(state: State): Promise<codemodel.Model> {
 
 
 export async function csnamer(service: Host) {
+  // dolauli add names for http operations and schemas
   return processCodeModel(nameStuffRight, service, 'csnamer');
 }
 

--- a/powershell/plugins/llcsharp-v2.ts
+++ b/powershell/plugins/llcsharp-v2.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Host, startSession } from '@azure-tools/autorest-extension-base';
+import { codeModelSchema } from '@azure-tools/codemodel';
+import { applyOverrides, copyResources, deserialize, serialize, } from '@azure-tools/codegen';
+import { join } from 'path';
+import { Model } from '../llcsharp/code-model';
+import { State } from '../llcsharp/generator';
+import { Project, NewProject } from '../llcsharp/project';
+import { PwshModel } from '../utils/PwshModel';
+
+const resources = `${__dirname}/../../resources`;
+
+export async function llcsharpV2(service: Host) {
+  try {
+    const project = await new NewProject(service).init();
+
+    await project.writeFiles(async (fname, content) => service.WriteFile(join(project.apifolder, fname), applyOverrides(content, project.overrides), undefined, 'source-file-csharp'));
+
+    // recursive copy resources
+    await copyResources(join(resources, 'runtime', 'csharp', 'client'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, 'source-file-csharp'), project.overrides);
+    await copyResources(join(resources, 'runtime', 'csharp', 'pipeline'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, 'source-file-csharp'), project.overrides);
+    // Note:
+    // we are using the Carbon.Json library, but we don't *really* want to expose that as public members where we don't have to
+    // and I don't want to make code changes in the source repository, so I can keep merging from upstream as simple as possible.
+    // so, we're converting as much as possible to internal, and exposing only what must be exposed to make the code compile.
+
+    await copyResources(join(resources, 'runtime', 'csharp', 'json'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, 'source-file-csharp'), {
+      ...project.overrides,
+      'public': 'internal',
+      'internal (.*) class JsonNumber': 'public $1 class JsonNumber',
+      'internal (.*) class JsonObject': 'public $1 class JsonObject',
+      'internal (.*) class JsonNode': 'public $1 class JsonNode',
+      'internal (.*) class JsonString': 'public $1 class JsonString',
+      'internal (.*) class XNodeArray': 'public $1 class XNodeArray',
+      'internal (.*) class JsonArray': 'public $1 class JsonArray',
+      'internal(.*) class JsonTokenizer': 'public$1 class JsonTokenizer',
+      'internal(.*) class JsonParser': 'public$1 class JsonParser',
+      'internal(.*) class TokenReader': 'public$1 class TokenReader',
+      'internal(.*) class SourceReader': 'public$1 class SourceReader',
+      'internal(.*) class (.*)Converter': 'public$1 class $2Converter',
+      'internal(.*) interface IJsonSerializable': 'public$1 interface IJsonSerializable',
+      'internal override string ToString': 'public override string ToString',
+      'internal void Add\\(': 'public void Add(',
+      'internal bool ContainsKey\\(': 'public bool ContainsKey(',
+      'internal bool Remove\\(': 'public bool Remove(',
+      'internal bool TryGetValue\\(': 'public bool TryGetValue(',
+      'internal (.*) JsonNode this\\[': 'public $1 JsonNode this[',
+
+      'internal ICollection<JsonNode> Values': 'public ICollection<JsonNode> Values',
+      'internal ICollection<string> Keys': 'public ICollection<string> Keys',
+      'internal bool IsReadOnly': 'public bool IsReadOnly',
+      'internal (.*) int Count': 'public $1 int Count',
+      'internal bool Contains\\(': 'public bool Contains(',
+      'internal(.*) bool Equals': 'public$1 bool Equals',
+      'internal (.*) int GetHashCode': 'public $1 int GetHashCode',
+      'internal void Dispose': 'public void Dispose',
+      'internal (.*) operator': 'public $1 operator',
+      'internal object FromJson\\(': 'public object FromJson(',
+      'internal JsonNode ToJson\\(': 'public JsonNode ToJson(',
+
+    });
+
+    if (project.xmlSerialization) {
+      await copyResources(join(resources, 'runtime', 'csharp', 'xml'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, 'source-file-csharp'), project.overrides);
+    }
+
+    if (project.azure) {
+      await copyResources(join(resources, 'runtime', 'csharp.azure'), async (fname, content) => service.WriteFile(join(project.runtimefolder, fname), content, undefined, 'source-file-csharp'), project.overrides);
+    }
+
+  } catch (E) {
+    console.error(`${__filename} - ${E.stack}/${E.message}`);
+    throw E;
+  }
+}

--- a/powershell/plugins/modifiers.ts
+++ b/powershell/plugins/modifiers.ts
@@ -232,6 +232,7 @@ function isWhereEnumDirective(it: any): it is WhereEnumDirective {
 async function tweakModel(state: State): Promise<codemodel.Model> {
 
   // only look at directives without the `transform` node.
+  // dolauli for directives with transform are implemented in autorest core
   for (const directive of directives.filter(each => !each.transform)) {
     const getPatternToMatch = (selector: string | undefined): RegExp | undefined => {
       return selector ? !hasSpecialChars(selector) ? new RegExp(`^${selector}$`, 'gi') : new RegExp(selector, 'gi') : undefined;
@@ -689,6 +690,7 @@ async function tweakModel(state: State): Promise<codemodel.Model> {
 }
 
 export async function applyModifiers(service: Host) {
+  // dolauli implement directives
   const allDirectives = await service.GetValue('directive');
   directives = values(allDirectives)
     // .select(directive => directive)

--- a/powershell/plugins/onbaordpipeline.md
+++ b/powershell/plugins/onbaordpipeline.md
@@ -1,0 +1,39 @@
+There are three key steps for on-boarding a new RP with AutoRest PowerShell Generator.
+- Onboard request
+- Design review
+- PR review
+
+## Onboard Request
+The first step is to send an onboard request to Azure PowerShell PM Damien(<dcaro@microsoft.com>). And you are expected to provide information as below(maybe more).
+- RP status
+- Roadmap
+- Contact person for customer support
+
+Damien will assist you to work out a speclet for your RP, which is something like combination of use-case spec and function spec.
+
+## Design Review
+Based on the speclet, you may start to generate code. Detailed steps are below.
+
+- Generate code with PowerShell generator
+- Customize code based on the speclet
+- Write examples
+
+When all above steps are completed, you may file a ticket in https://github.com/Azure/azure-powershell-cmdlet-review-pr/issues for design review.
+The issue should contain content below.
+- Link to the speclet
+- Cmdlets syntax and examples (you may copy and paste them from the ./docs folder)
+- A link to the code repo which contains the docs folder
+
+The issue will be assigned to an engineer in Azure PowerShell team for review. If the RP is complex, a review meeting will be needed, otherwise, review may be done through comments in the ticket/emails.  
+
+## Code Review
+When design review is ongoing, you may write the test cases. After design review passes, you may file a PR against the generation branch of azure-powershell for code review. And code list is as following.
+- readme.md
+- custom
+- examples
+- test
+- docs
+
+After code review, congratulaitions, you got the chance to take the release train, which is once every three week.
+
+

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -309,7 +309,7 @@ function createVirtualParameters(operation: CommandOperation) {
 
     if (dropBodyParameter && parameter.details.default.isBodyParameter) {
       // the client will make a hidden body parameter for this, and we're expected to fill it.
-      const vps = parameter.schema.details.default.virtualProperties;
+      const vps = parameter.schema.language.default.virtualProperties;
       if (vps) {
         for (const virtualProperty of [...vps.inherited, ...vps.owned, ...vps.inlined]) {
           // dolauli add virtual parameter for virtual property

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -4,14 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { codeModelSchema, CodeModel, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
-import { Schema, codemodel, JsonType, processCodeModel, VirtualProperty, VirtualParameter, resolveParameterNames, ModelState, getAllProperties, getAllPublicVirtualProperties } from '@azure-tools/codemodel-v3';
+//import { VirtualParameter } from '@azure-tools/codemodel-v3';
 import { getPascalIdentifier, removeSequentialDuplicates, pascalCase, fixLeadingNumber, deconstruct, selectName, EnglishPluralizationService, serialize } from '@azure-tools/codegen';
 import { length, values, } from '@azure-tools/linq';
 import { Host, Session, startSession } from '@azure-tools/autorest-extension-base';
-import { CommandOperation } from '@azure-tools/codemodel-v3/dist/code-model/command-operation';
+//import { CommandOperation } from '@azure-tools/codemodel-v3/dist/code-model/command-operation';
+import { CommandOperation } from '../utils/command-operation';
 import { PwshModel } from '../utils/PwshModel';
 import { NewModelState } from '../utils/model-state';
-
+import { VirtualParameter } from '../utils/command-operation';
 
 function getPluralizationService(): EnglishPluralizationService {
   const result = new EnglishPluralizationService();

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -1,0 +1,399 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { codeModelSchema, CodeModel, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
+import { Schema, codemodel, JsonType, processCodeModel, VirtualProperty, VirtualParameter, resolveParameterNames, ModelState, getAllProperties, getAllPublicVirtualProperties } from '@azure-tools/codemodel-v3';
+import { getPascalIdentifier, removeSequentialDuplicates, pascalCase, fixLeadingNumber, deconstruct, selectName, EnglishPluralizationService, serialize } from '@azure-tools/codegen';
+import { length, values, } from '@azure-tools/linq';
+import { Host, Session, startSession } from '@azure-tools/autorest-extension-base';
+import { CommandOperation } from '@azure-tools/codemodel-v3/dist/code-model/command-operation';
+import { PwshModel } from '../utils/PwshModel';
+import { NewModelState } from '../utils/model-state';
+
+
+function getPluralizationService(): EnglishPluralizationService {
+  const result = new EnglishPluralizationService();
+  result.addWord('Database', 'Databases');
+  result.addWord('database', 'databases');
+  return result;
+}
+
+type State = NewModelState<PwshModel>;
+
+export function singularize(word: string): string {
+  return getPluralizationService().singularize(word);
+}
+
+function getNameOptions(typeName: string, components: Array<string>) {
+  const result = new Set<string>();
+
+  // add a variant for each incrementally inclusive parent naming scheme.
+  for (let i = 0; i < length(components); i++) {
+    const subset = pascalCase([...removeSequentialDuplicates(components.slice(-1 * i, length(components)))]);
+    result.add(subset);
+  }
+
+  // add a second-to-last-ditch option as <typename>.<name>
+  result.add(pascalCase([...removeSequentialDuplicates([...fixLeadingNumber(deconstruct(typeName)), ...deconstruct(components.last)])]));
+  return [...result.values()];
+}
+
+
+// function createVirtualProperties(schema: Schema, stack: Array<string>, threshold: number, conflicts: Array<string>) {
+//   // dolauli
+//   //    owned: all properties(obj & nonobj) in the schema,
+//   //  inherited: Properties from parents,
+//   //    inlined: for obj properties, flatten them to children,
+//   // did we already inline this object
+//   if (schema.details.default.inline === 'yes') {
+//     return true;
+//   }
+
+//   if (schema.details.default.inline === 'no') {
+//     return false;
+//   }
+
+//   // this is bad. This would happen when we have a circular reference in the tree.
+//   // dolauli curious in which case this will happen, got it to use no-inline to skip inline and avoid circular reference
+//   if (schema.details.default.inline === 'inprogress') {
+//     let text = (`Note: during processing of '${schema.details.default.name}' a circular reference has been discovered.`);
+//     text += '\n  In order to proceed, you must add a directive to indicate which model you want to not inline.\n';
+//     text += '\ndirective:';
+//     text += '\n- no-inline:  # choose ONE of these models to disable inlining';
+//     for (const each of stack) {
+//       text += (`\n  - ${each} `);
+//     }
+//     text += '\n';
+//     conflicts.push(text);
+//     /*     `directive:
+//          - no-inline: 
+//            - MyModel
+//            - YourModel
+//            - HerModel
+//         ` */
+
+//     // `, and we're skipping inlining.\n  ${stack.join(' => ')}`);
+//     // mark it as 'not-inlining'
+//     schema.details.default.inline = 'no';
+//     return false;
+//   }
+
+//   // ok, set to in progress now.
+//   schema.details.default.inline = 'inprogress';
+
+//   // virutual property set.
+//   const virtualProperties = schema.details.default.virtualProperties = {
+//     owned: new Array<VirtualProperty>(),
+//     inherited: new Array<VirtualProperty>(),
+//     inlined: new Array<VirtualProperty>(),
+//   };
+
+//   // First we should run thru the properties in parent classes and create inliners for each property they have.
+//   // dolauli handle properties in parents
+//   for (const parentSchema of values(schema.allOf)) {
+//     // make sure that the parent is done.
+//     createVirtualProperties(parentSchema, [...stack, `${schema.details.default.name}`], threshold, conflicts);
+
+//     const parentProperties = parentSchema.details.default.virtualProperties || {
+//       owned: [],
+//       inherited: [],
+//       inlined: [],
+//     };
+
+//     // now we go thru the parent's virutal properties and create our own copies 
+//     for (const virtualProperty of [...parentProperties.inherited, ...parentProperties.inlined, ...parentProperties.owned]) {
+//       // make sure that we have a list of shared owners of this property.
+//       virtualProperty.sharedWith = virtualProperty.sharedWith || [virtualProperty];
+
+//       // we are just copying over theirs to ours.
+//       const inheritedProperty = {
+//         name: virtualProperty.name,
+//         property: virtualProperty.property,
+//         private: virtualProperty.private,
+//         nameComponents: virtualProperty.nameComponents,
+//         nameOptions: virtualProperty.nameOptions,
+//         accessViaProperty: virtualProperty,
+//         accessViaMember: virtualProperty,
+//         accessViaSchema: parentSchema,
+//         originalContainingSchema: virtualProperty.originalContainingSchema,
+//         description: virtualProperty.description,
+//         alias: [],
+//         required: virtualProperty.required || !!values(schema.required).first(each => !!each && !!each.toLowerCase && each.toLowerCase() === virtualProperty.property.details.default.name.toLowerCase()),
+//         sharedWith: virtualProperty.sharedWith,
+//       };
+//       // add it to the list of virtual properties that share this property.
+//       virtualProperty.sharedWith.push(inheritedProperty);
+
+//       // add it to this class.
+//       virtualProperties.inherited.push(inheritedProperty);
+//     }
+//   }
+
+//   // dolauli figure out object properties and non object properties in this class 
+//   const [objectProperties, nonObjectProperties] = values(schema.properties).bifurcate(each =>
+//     !schema.details.default['skip-inline'] && // if this schema is marked skip-inline, none can be inlined, treat them all as straight properties.
+//     !each.schema.details.default['skip-inline'] && // if the property schema is marked skip-inline, then it should not be processed either.
+//     each.schema.type === JsonType.Object &&       // is it an object 
+//     getAllProperties(each.schema).length > 0    // does it have properties (or inherit properties)
+//   );
+
+//   // run thru the properties in this class.
+//   // dolauli handle properties in this class
+//   for (const property of objectProperties) {
+//     const propertyName = property.details.default.name;
+
+//     // for each object member, make sure that it's inlined it's children that it can.
+//     createVirtualProperties(property.schema, [...stack, `${schema.details.default.name}`], threshold, conflicts);
+
+//     // this happens if there is a circular reference.
+//     // this means that this class should not attempt any inlining of that property at all .
+//     // dolauli pay attention to the condition check
+//     const canInline =
+//       // (!property.schema.details.default['skip-inline']) &&
+//       (!property.schema.details.default.byReference) &&
+//       (!property.schema.additionalProperties) &&
+//       property.schema.details.default.inline === 'yes';
+
+//     // the target has properties that we can inline
+//     const virtualChildProperties = property.schema.details.default.virtualProperties || {
+//       owned: [],
+//       inherited: [],
+//       inlined: [],
+//     };
+
+//     const allNotRequired = values(getAllPublicVirtualProperties()).all(each => !each.property.details.default.required);
+
+//     const childCount = length(virtualChildProperties.owned) + length(virtualChildProperties.inherited) + length(virtualChildProperties.inlined);
+//     if (canInline && (property.details.default.required || allNotRequired) && (childCount < threshold || propertyName === 'properties')) {
+
+
+//       // if the child property is low enough (or it's 'properties'), let's create virtual properties for each one.
+//       // create a private property for the inlined ones to use.
+//       const privateProperty = {
+//         name: getPascalIdentifier(propertyName),
+//         propertySchema: schema,
+//         property,
+//         nameComponents: [getPascalIdentifier(propertyName)],
+//         nameOptions: getNameOptions(schema.details.default.name, [propertyName]),
+//         private: true,
+//         description: property.description || '',
+//         originalContainingSchema: schema,
+//         alias: [],
+//         required: property.details.default.required,
+//       };
+//       virtualProperties.owned.push(privateProperty);
+
+//       for (const inlinedProperty of [...virtualChildProperties.inherited, ...virtualChildProperties.owned]) {
+//         // child properties are be inlined without prefixing the name with the property name
+//         // unless there is a collision, in which case, we have to resolve 
+
+//         // (scan back from the far right)
+//         // deeper child properties should be inlined with their parent's name 
+//         // ie, this.[properties].owner.name should be this.ownerName 
+
+//         const proposedName = getPascalIdentifier(`${propertyName === 'properties' || /*objectProperties.length === 1*/ propertyName === 'error' ? '' : pascalCase(fixLeadingNumber(deconstruct(propertyName)).map(each => singularize(each)))} ${inlinedProperty.name}`);
+
+//         const components = [...removeSequentialDuplicates([propertyName, ...inlinedProperty.nameComponents])];
+//         virtualProperties.inlined.push({
+//           name: proposedName,
+//           property: inlinedProperty.property,
+//           private: inlinedProperty.private,
+//           nameComponents: components,
+//           nameOptions: getNameOptions(inlinedProperty.property.schema.details.default.name, components),
+//           accessViaProperty: privateProperty,
+//           accessViaMember: inlinedProperty,
+//           accessViaSchema: schema,
+//           originalContainingSchema: schema,
+//           description: inlinedProperty.description,
+//           alias: [],
+//           required: inlinedProperty.required && privateProperty.required,
+//         });
+//       }
+
+
+//       for (const inlinedProperty of [...virtualChildProperties.inlined]) {
+//         // child properties are be inlined without prefixing the name with the property name
+//         // unless there is a collision, in which case, we have to resolve 
+
+//         // (scan back from the far right)
+//         // deeper child properties should be inlined with their parent's name 
+//         // ie, this.[properties].owner.name should be this.ownerName 
+
+
+//         const proposedName = getPascalIdentifier(inlinedProperty.name);
+//         const components = [...removeSequentialDuplicates([propertyName, ...inlinedProperty.nameComponents])];
+//         virtualProperties.inlined.push({
+//           name: proposedName,
+//           property: inlinedProperty.property,
+//           private: inlinedProperty.private,
+//           nameComponents: components,
+//           nameOptions: getNameOptions(inlinedProperty.property.schema.details.default.name, components),
+//           accessViaProperty: privateProperty,
+//           accessViaMember: inlinedProperty,
+//           accessViaSchema: schema,
+//           originalContainingSchema: schema,
+//           description: inlinedProperty.description,
+//           alias: [],
+//           required: inlinedProperty.required && privateProperty.required
+//         });
+//       }
+//     } else {
+//       // otherwise, we're not below the threshold, and we should treat this as a non-inlined property
+//       nonObjectProperties.push(property);
+//     }
+//   }
+
+//   for (const property of nonObjectProperties) {
+//     const name = getPascalIdentifier(<string>property.details.default.name);
+//     // this is not something that has properties,
+//     // so we don't need to do any inlining
+//     // however, we can add it to our list of virtual properties
+//     // so that our consumers can get it.
+//     virtualProperties.owned.push({
+//       name,
+//       property,
+//       nameComponents: [name],
+//       nameOptions: [name],
+//       description: property.description || '',
+//       originalContainingSchema: schema,
+//       alias: [],
+//       required: property.details.default.required
+//     });
+//   }
+
+//   // resolve name collisions.
+//   const allProps = [...virtualProperties.owned, ...virtualProperties.inherited, ...virtualProperties.inlined];
+//   const inlined = new Map<string, number>();
+
+//   for (const each of allProps) {
+//     // track number of instances of a given name.
+//     inlined.set(each.name, (inlined.get(each.name) || 0) + 1);
+//   }
+
+//   const usedNames = new Set(inlined.keys());
+//   for (const each of virtualProperties.inlined.sort((a, b) => length(a.nameOptions) - length(b.nameOptions))) {
+//     const ct = inlined.get(each.name);
+//     if (ct && ct > 1) {
+//       // console.error(`Fixing collision on name ${each.name} #${ct} `);
+//       each.name = selectName(each.nameOptions, usedNames);
+//     }
+//   }
+//   schema.details.default.inline = 'yes';
+//   return true;
+// }
+
+function createVirtualParameters(operation: CommandOperation) {
+  // dolauli expand body parameter
+  // for virtual parameters, there are two keys, operation and body
+  const virtualParameters = {
+    operation: new Array<VirtualParameter>(),
+    body: new Array<VirtualParameter>()
+  };
+
+  /// const dropBodyParameter = !!operation.details.default.dropBodyParameter;
+  const dropBodyParameter = false;
+  // loop thru the parameters of the command operation, and if there is a body parameter, expand it if necessary.
+  for (const parameter of values(operation.parameters)) {
+    if (parameter.details.default.constantValue) {
+      // this parameter has a constant value -- SKIP IT
+      continue;
+    }
+    // dolauli fromhost and apiversion are not exposed, this if block looks useless
+    if (parameter.details.default.fromHost || parameter.details.default.apiversion) {
+      // handled in the generator right now. Not exposed to the user directly.
+      continue;
+    }
+
+    if (dropBodyParameter && parameter.details.default.isBodyParameter) {
+      // the client will make a hidden body parameter for this, and we're expected to fill it.
+      const vps = parameter.schema.details.default.virtualProperties;
+      if (vps) {
+        for (const virtualProperty of [...vps.inherited, ...vps.owned, ...vps.inlined]) {
+          // dolauli add virtual parameter for virtual property
+          if (virtualProperty.private || virtualProperty.property.details.default.readOnly || virtualProperty.property.details.default.constantValue !== undefined || virtualProperty.property.details.default.HeaderProperty === 'Header') {
+            // private or readonly properties aren't needed as parameters. 
+            continue;
+          }
+          virtualParameters.body.push({
+            name: virtualProperty.name,
+            description: virtualProperty.property.details.default.description,
+            nameOptions: virtualProperty.nameOptions,
+            required: virtualProperty.required,
+            schema: virtualProperty.property.schema,
+            origin: virtualProperty,
+            alias: []
+          });
+        }
+      }
+    } else {
+      // dolauli if not drop body or not body parameter add it to operation 
+      virtualParameters.operation.push({
+        name: parameter.details.default.name,
+        nameOptions: [parameter.details.default.name],
+        description: parameter.details.default.description,
+        required: parameter.details.default.isBodyParameter ? true : parameter.required,
+        schema: parameter.schema,
+        origin: parameter,
+        alias: []
+      });
+    }
+  }
+
+  //resolveParameterNames([], virtualParameters);
+
+  // dolauli see operation.details.default.virtualParameters
+  operation.details.default.virtualParameters = virtualParameters;
+}
+
+async function createVirtuals(state: State): Promise<PwshModel> {
+  /* 
+    A model class should provide inlined properties for anything in a property called properties
+    
+    Classes that have $THRESHOLD number of properties should be inlined.
+ 
+    Individual models can change the $THRESHOLD for generate
+  */
+  // dolauli this plugin is used to expand the property in an object.
+  // dolauli inline-threshold could be set in readme.md
+  // skip-for-time-being
+  // const threshold = await state.getValue('inlining-threshold', 24);
+  // const conflicts = new Array<string>();
+
+  // for (const schema of values(state.model.schemas)) {
+  //   if (schema.type === JsonType.Object) {
+  //     // did we already inline this object
+  //     // dolauli skip if inlined
+  //     if (schema.details.default.inlined) {
+  //       continue;
+  //     }
+  //     // we have an object, let's process it.
+
+  //     createVirtualProperties(schema, new Array<string>(), threshold, conflicts);
+  //   }
+  // }
+  // if (length(conflicts) > 0) {
+  //   // dolauli need to figure out how inline-properties is used in readme.md
+  //   state.error('You have one or more circular references in your model, you must add configuration entries to specify which models won\'t be inlined.', ['inline-properties']);
+  //   for (const each of conflicts) {
+  //     state.error(each, ['circular reference']);
+  //   }
+  //   throw new Error('Circular references exists, must mark models as `no-inline`');
+  // }
+  // dolauli update operations under commands
+  for (const operation of values(state.model.commands.operations)) {
+    createVirtualParameters(operation);
+  }
+
+  return state.model;
+}
+
+
+export async function createInlinedPropertiesPlugin(service: Host) {
+  //const session = await startSession<PwshModel>(service, {}, codeModelSchema);
+  //const result = tweakModelV2(session);
+  const state = await new NewModelState<PwshModel>(service).init();
+  await service.WriteFile('code-model-v4-create-virtual-properties-v2.yaml', serialize(await createVirtuals(state)), undefined, 'code-model-v4');
+  //return processCodeModel(createVirtuals, service, 'create-virtual-properties-v2');
+}

--- a/powershell/plugins/plugin-tweak-model-azure.ts
+++ b/powershell/plugins/plugin-tweak-model-azure.ts
@@ -1,0 +1,175 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { codemodel, JsonType, processCodeModel, ModelState, getAllProperties, HttpMethod, schema } from '@azure-tools/codemodel-v3';
+import { keys, length, values } from '@azure-tools/linq';
+
+import { Channel, Host } from '@azure-tools/autorest-extension-base';
+type State = ModelState<codemodel.Model>;
+
+const xmsPageable = 'x-ms-pageable';
+
+async function tweakModel(state: State): Promise<codemodel.Model> {
+  const model = state.model;
+
+  // service.Message({ Channel: Channel.Debug, Text: "THIS IS THE AZURE TWEAKER" });
+
+  // TODO:
+  // look at models, and extract out any case that has an IRESOURCE, IPROXYRESOURCE, etc.
+  // and use the common versions of those models.
+
+  // Is the result marked x-ms-pagable?
+  // identify the next link (null means just get the results as an array)
+  // if nextLinkName is null, then it won't actually page, but we'd like to unroll the contents anyway.
+  for (const operation of values(model.http.operations)) {
+    if (operation.extensions && operation.extensions[xmsPageable]) {
+      // it's marked pagable.
+      operation.details.default.pageable = {
+        responseType: 'pageable',
+        nextLinkName: operation.extensions[xmsPageable].nextLinkName || undefined,
+        itemName: operation.extensions[xmsPageable].itemName || 'value',
+        operationName: operation.extensions[xmsPageable].operationName || `${operation.operationId}Next`,
+      };
+      continue;
+    }
+
+    // let's just check to see if it looks like it's supposed to be a collection
+    for (const responses of values(operation.responses)) {
+      for (const response of values(responses)) {
+        // does the response have a schema?
+        if (response.schema) {
+          const schema = response.schema;
+
+          // is this just an array response?
+          if (schema.type === JsonType.Array) {
+            operation.details.default.pageable = {
+              responseType: 'array',
+            };
+            continue;
+          }
+
+          // if it returns an object, let's see what's inside...
+          if (schema.type === JsonType.Object) {
+
+            // does it have  a single member that is an array (ie, value :  [...])
+            if (length(schema.properties) === 1 && length(schema.allOf) === 0) {
+              const propertyName = keys(schema.properties).first();
+              if (propertyName) {
+                const property = schema.properties[propertyName];
+                if (property.schema.type === JsonType.Array) {
+                  // nested array!
+                  operation.details.default.pageable = {
+                    responseType: 'nested-array',
+                    itemName: propertyName,
+                  };
+                }
+                continue;
+              }
+            }
+
+            // does it kinda look like a x-ms-pagable (value/nextlink?)
+            if (length(schema.properties) === 2 && length(schema.allOf) === 0) {
+              if (schema.properties.nextLink) {
+                const propertyName = keys(schema.properties).where(each => each !== 'nextLink').first();
+                if (propertyName) {
+                  const property = schema.properties[propertyName];
+                  if (property.schema.type === JsonType.Array) {
+                    // nested array!
+                    operation.details.default.pageable = {
+                      responseType: 'nested-array',
+                      itemName: propertyName,
+                      nextLinkName: 'nextLink'
+                    };
+                  }
+                  continue;
+                }
+              }
+
+            }
+
+          }
+        }
+
+      }
+    }
+  }
+
+  // make sure that all operations with lro have an options block.
+  for (const operation of values(model.http.operations)) {
+    if (operation.extensions && operation.extensions['x-ms-long-running-operation']) {
+      operation.details.default.asjob = true;
+
+      operation.details.default.lro = operation.extensions['x-ms-long-running-operation-options'] || {
+        'final-state-via': 'default'
+      };
+
+      // LRO 201 and 202 responses are handled internally, so remove any 201/202 responses in the operation
+      delete operation.responses['201'];
+      delete operation.responses['202'];
+    }
+  }
+
+  // Api Version parameter handling for Azure.
+  // if there is only a single api-version for the operation, let's just make it a constant
+  // otherwise, we need to make it selectable, but default to the 'latest' version there is.
+  for (const operation of values(model.http.operations)) {
+    const apiVersions = operation.pathExtensions && operation.pathExtensions['x-ms-metadata'] ? operation.pathExtensions['x-ms-metadata'].apiVersions : undefined;
+    for (const parameter of values(operation.parameters)) {
+
+      if (parameter.name === 'api-version') {
+        // only set it if it hasn't been set yet.
+        // if (parameter.details.default.constantValue) {
+        //continue;
+        //}
+
+        if (apiVersions) {
+          // set the constant value to the first one
+          if (length(apiVersions) === 1) {
+            parameter.details.default.constantValue = apiVersions[0];
+            continue;
+          }
+
+          // otherwise, the parameter can't have a constant value
+          parameter.details.default.constantValue = undefined;
+
+          // mark it so that we can add profile support in the method generation
+          parameter.details.default.apiversion = true;
+        }
+      }
+    }
+  }
+
+  // when make-sub-resources-byreference is specified, mark models with a writable id as byref.
+  if (await state.getValue('azure', false) && await state.getValue('make-sub-resources-byreference', false)) {
+
+    for (const schema of values(model.schemas)) {
+      // find schemas that have an 'id' and are not readonly
+      if (values(getAllProperties(schema)).any(prop => prop.serializedName === 'id' && !prop.details.default.readOnly)) {
+
+        // look thru the operations, and the PUT methods 
+        for (const op of values(model.http.operations).where(o => o.method === HttpMethod.Put)) {
+
+          // see if any of the responses have the same schema as we are looking for 
+          if (values(op.responses).any(rsps => values(rsps).any(resp => !!resp.schema && resp.schema.details.default.uid === schema.details.default.uid))) {
+
+            // tell it not to inline that 
+            schema.details.default.byReference = true;
+          }
+
+        }
+      }
+    }
+  }
+
+  return model;
+}
+
+// Azure version -
+// Additional tweaks the code model to adjust things so that the code will generate better.
+
+export async function tweakModelAzurePlugin(service: Host) {
+  return processCodeModel(tweakModel, service, 'tweakcodemodelazure-v2');
+}

--- a/powershell/plugins/plugin-tweak-model.ts
+++ b/powershell/plugins/plugin-tweak-model.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { codeModelSchema, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
-import { ModelState } from '@azure-tools/codemodel-v3';
+//import { ModelState } from '@azure-tools/codemodel-v3';
 //import { KnownMediaType, knownMediaType, ParameterLocation, getPolymorphicBases, isSchemaObject, JsonType, Property, Schema, processCodeModel, StringFormat, codemodel, ModelState } from '@azure-tools/codemodel-v3';
 import { pascalCase, deconstruct, fixLeadingNumber, serialize } from '@azure-tools/codegen';
 import { items, keys, values, Dictionary, length } from '@azure-tools/linq';

--- a/powershell/plugins/plugin-tweak-model.ts
+++ b/powershell/plugins/plugin-tweak-model.ts
@@ -1,0 +1,356 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { codeModelSchema, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
+import { ModelState } from '@azure-tools/codemodel-v3';
+//import { KnownMediaType, knownMediaType, ParameterLocation, getPolymorphicBases, isSchemaObject, JsonType, Property, Schema, processCodeModel, StringFormat, codemodel, ModelState } from '@azure-tools/codemodel-v3';
+import { pascalCase, deconstruct, fixLeadingNumber, serialize } from '@azure-tools/codegen';
+import { items, keys, values, Dictionary, length } from '@azure-tools/linq';
+import { PwshModel } from '../utils/PwshModel';
+import { NewModelState } from '../utils/model-state';
+
+import { Channel, Host, Session, startSession } from '@azure-tools/autorest-extension-base';
+import { defaultCipherList } from 'constants';
+
+export const HeaderProperty = 'HeaderProperty';
+export enum HeaderPropertyType {
+  Header = 'Header',
+  HeaderAndBody = 'HeaderAndBody'
+}
+type State = NewModelState<PwshModel>;
+
+
+// For now, we are not dynamically changing the service-name. Instead, we would figure out a method to change it during the creation of service readme's.
+export function titleToAzureServiceName(title: string): string {
+  const titleCamelCase = pascalCase(deconstruct(title)).trim();
+  const serviceName = titleCamelCase
+    // Remove: !StartsWith(Management)AndContains(Management), Client, Azure, Microsoft, APIs, API, REST
+    .replace(/(?!^Management)(?=.*)Management|Client|Azure|Microsoft|APIs|API|REST/g, '')
+    // Remove: EndsWith(ServiceResourceProvider), EndsWith(ResourceProvider), EndsWith(DataPlane), EndsWith(Data)
+    .replace(/ServiceResourceProvider$|ResourceProvider$|DataPlane$|Data$/g, '');
+  return serviceName || titleCamelCase;
+}
+
+
+// function dropDuplicatePropertiesInChildSchemas(schema: Schema, state: State, map: Map<string, Property> = new Map()) {
+//   let success = true;
+//   for (const parent of values(schema.allOf)) {
+//     handle parents first
+//     if (!dropDuplicatePropertiesInChildSchemas(parent, state, map)) {
+//       return false;
+//     }
+//   }
+//   for (const { key: id, value: property } of items(schema.properties)) {
+//     see if it's in the parent.
+//     const pProp = map.get(property.serializedName);
+//     if (pProp) {
+//       if the parent prop is the same type as the child prop
+//       we're going to drop the child property.
+//       if (pProp.schema.type === property.schema.type) {
+//         if it's an object type, it has to be the exact same schema type too
+//         if (pProp.schema.type != JsonType.Object || pProp.schema === property.schema) {
+//           state.verbose(`Property '${property.serializedName}' in '${schema.details.default.name}' has a property the same as the parent, and is dropping the duplicate.`, {});
+//           delete schema.properties[id];
+//         } else {
+//           const conflict = `Property '${property.serializedName}' in '${schema.details.default.name}' has a conflict with a parent schema (allOf ${schema.allOf.joinWith(each => each.details.default.name)}.`;
+//           state.error(conflict, [], {});
+//           success = false;
+//         }
+//       }
+//     }
+//     else {
+//       map.set(property.serializedName, property);
+//     }
+//   }
+//   return success;
+// }
+
+async function tweakModelV2(state: State): Promise<PwshModel> {
+  const title = pascalCase(fixLeadingNumber(deconstruct(await state.getValue('title', state.model.info.title))));
+  state.setValue('title', title);
+
+  const serviceName = await state.getValue('service-name', titleToAzureServiceName(title));
+  state.setValue('service-name', serviceName);
+
+  const model = state.model;
+
+  const universalId = new ObjectSchema(`${serviceName}Identity`, 'Resource Identity');
+  universalId.apiVersions = universalId.apiVersions || [];
+  state.model.schemas.objects = state.model.schemas.objects || [];
+  state.model.schemas.objects.push(universalId);
+
+  model.commands = <any>{
+    operations: new Dictionary<any>(),
+    parameters: new Dictionary<any>(),
+  };
+
+  return model;
+}
+// async function tweakModel(state: State): Promise<codemodel.Model> {
+//   const title = pascalCase(fixLeadingNumber(deconstruct(await state.getValue('title', state.model.info.title))));
+//   state.setValue('title', title);
+
+//   const serviceName = await state.getValue('service-name', titleToAzureServiceName(title));
+//   state.setValue('service-name', serviceName);
+
+//   const model = state.model;
+//   model.schemas = model.schemas || [];
+
+//   const set = new Set<Schema>();
+//   const removes = new Set<string>();
+
+//   for (const key of keys(model.schemas)) {
+//     const value = model.schemas[key];
+//     if (set.has(value)) {
+//       // this schema is already in the collection. let's drop it when we're done
+//       removes.add(key);
+//     } else {
+//       set.add(value);
+//     }
+//   }
+
+//   // we're going to create a schema that represents the distinct sum 
+//   // of all operation PATH parameters
+//   const universalId = new Schema(`${serviceName}Identity`, {
+//     type: JsonType.Object, description: 'Resource Identity', details: {
+//       default: {
+//         uid: 'universal-parameter-type'
+//       }
+//     }
+//   });
+//   model.schemas['universal-parameter-type'] = universalId;
+
+//   for (const operation of values(model.http.operations)) {
+//     for (const param of values(operation.parameters).where(each => each.in === ParameterLocation.Path)) {
+//       const name = param.details.default.name;
+//       if (!universalId.properties[name]) {
+//         universalId.properties[name] = new Property(name, {
+//           schema: param.schema, description: param.description, serializedName: name, details: {
+//             default: {
+//               description: param.description,
+//               name: name,
+//               required: false,
+//               readOnly: false,
+//               uid: `universal-parameter:${name}`
+//             }
+//           }
+//         });
+//       }
+//     }
+//   }
+
+//   if (await state.getValue('azure', false)) {
+//     universalId.properties['id'] = new Property('id', {
+//       schema: new Schema('_identity_type_', { type: JsonType.String, description: 'Resource identity path' }),
+//       description: 'Resource identity path', serializedName: 'id', details: {
+//         default: {
+//           description: 'Resource identity path',
+//           name: 'id',
+//           required: false,
+//           readOnly: false,
+//           uid: 'universal-parameter:resource identity'
+//         }
+//       }
+//     });
+//   }
+
+//   // remove schemas that are referenced elsewhere previously.
+//   for (const each of removes.values()) {
+//     delete model.schemas[each];
+//   }
+
+//   // if an operation has a response that has a schema with string/binary we should make the response  application/octet-stream
+//   for (const operation of values(model.http.operations)) {
+//     for (const responses of values(operation.responses)) {
+//       for (const response of responses) {
+//         if (response.schema) {
+//           if (response.schema.type === JsonType.String && response.schema.format === StringFormat.Binary) {
+//             // WHY WAS THIS HERE?!
+//             // response.mimeTypes = [KnownMediaType.Stream];
+//           }
+//         }
+//       }
+//     }
+//   }
+
+//   // schemas that have parents and implement properties that are in the parent schemas
+//   // will have the property dropped in the child schema
+//   for (const schema of values(model.schemas)) {
+//     if (length(schema.allOf) > 0) {
+//       if (!dropDuplicatePropertiesInChildSchemas(schema, state)) {
+//         throw new Error('Schemas are in conflict.');
+//       }
+//     }
+//   }
+
+
+//   if (await state.getValue('use-storage-pipeline', false)) {
+//     // we're going to create new models for the reponse headers ?
+
+//   } else {
+
+//     // if an operation has a body parameter with string/binary, we should make the request application/octet-stream
+
+//     // === Header Schemas ===
+//     // go thru the operations, find responses that have header values, and add a property to the schemas that are returned with those values
+//     for (const operation of values(model.http.operations)) {
+//       for (const responses of values(operation.responses)) {
+//         for (const response of responses) {
+//           // for a given response, find the possible models that can be returned from the service
+//           for (const header of values(response.headers)) {
+
+//             if (!response.schema) {
+//               // no response schema? can we fake one?
+//               // service.Message({ Channel: Channel.Debug, Text: `${header.key} is in ${operation.details.default.name} but there is no response model` });
+//               continue;
+//             }
+
+//             // if the method response has a schema and it's an object, we're going to add our properties to the schema object.
+//             // yes, this means that the reponse model may have properties that are undefined if the server doesn't send back the header
+//             // and other operations might add other headers that are not the same.
+
+//             // if the method's response is a primitive value (string, boolean, null, number) or an array, we can't modify that type obviously
+//             // in which case, we're going to add a header
+
+//             // work with schemas that have objects only.
+
+//             if (isSchemaObject(response.schema)) {
+//               response.schema.details.default.hasHeaders = true;
+//               const property = response.schema.properties[header.key];
+//               if (!property) {
+//                 state.message({ Channel: Channel.Debug, Text: `Adding header property '${header.key}' to model ${response.schema.details.default.name}` });
+
+//                 // create a property for the header value
+//                 const newProperty = new Property(header.key, { schema: header.schema, description: header.description });
+//                 newProperty.details.default.name = header.key;
+//                 newProperty.details.default.required = false;
+
+//                 // mark it that it's a header-only property
+//                 newProperty.details.default[HeaderProperty] = HeaderPropertyType.Header;
+
+//                 // add it to this model.
+//                 response.schema.properties[header.key] = newProperty;
+//               } else {
+//                 // there is a property with this name already.
+//                 // was this previously declared as a header only property?
+//                 if (!property.details.default[HeaderProperty]) {
+
+//                   state.message({ Channel: Channel.Debug, Text: `Property ${header.key} in model ${response.schema.details.default.name} can also come from the header.` });
+//                   // no.. There is duplication between header and body property. Probably because of etags.
+//                   // tell it to be a header-and-body property.
+//                   property.details.default[HeaderProperty] = HeaderPropertyType.HeaderAndBody;
+//                   property.details.default.name = header.key;
+//                 }
+//               }
+//             }
+//           }
+//         }
+//       }
+//     }
+//   }
+
+//   // remove well-known header parameters from operations and add mark the operation has supporting that feature
+
+//   for (const operation of values(model.http.operations)) {
+//     // if we have an operation with a body, and content-type is a multipart/formdata
+//     // then we should go thru the parameters of the body and look for a string/binary parameters
+//     // and remember to add another parameter for the filename of the string/binary
+//     if (operation.requestBody && knownMediaType(operation.requestBody.contentType) === KnownMediaType.Multipart) {
+//       for (const prop of values(operation.requestBody.schema.properties)) {
+//         if (prop.schema.type === JsonType.String && prop.schema.format === 'binary') {
+//           prop.details.default.isNamedStream = true;
+//         }
+//       }
+//     }
+
+//     // move well-known hearder parameters into details, and we can process them in the generator how we please.
+//     // operation.details.default.headerparameters = values(operation.parameters).where(p => p.in === ParameterLocation.Header && ['If-Match', 'If-None-Match'].includes(p.name)).toArray();
+
+//     // remove if-match and if-none-match parameters from the operation itself.
+//     // operation.parameters = values(operation.parameters).where(p => !(p.in === ParameterLocation.Header && ['If-Match', 'If-None-Match'].includes(p.name))).toArray();
+
+//   }
+
+//   // identify models that are polymorphic in nature
+//   for (const schema of values(model.schemas)) {
+//     // if this actual type is polymorphic, make sure we know that.
+//     if (schema.discriminator) {
+//       schema.details.default.isPolymorphic = true;
+//     }
+
+
+//     const parents = getPolymorphicBases(schema);
+//     if (length(parents) > 0) {
+//       // if our parent is polymorphic, then we must have a discriminator value
+//       schema.details.default.discriminatorValue = schema.extensions['x-ms-discriminator-value'] || schema.details.default.name;
+
+//       // and make sure that all our polymorphic parents have a reference to this type.
+//       for (const parent of getPolymorphicBases(schema)) {
+
+//         parent.details.default.polymorphicChildren = parent.details.default.polymorphicChildren || new Array<Schema>();
+//         parent.details.default.polymorphicChildren.push(schema);
+//       }
+//     }
+//   }
+
+//   // identify parameters that are constants
+//   for (const operation of values(model.http.operations)) {
+//     for (const parameter of values(operation.parameters)) {
+//       if (parameter.required && length(parameter.schema.enum) === 1) {
+//         // parameters with an enum single value are constants
+//         parameter.details.default.constantValue = parameter.schema.enum[0];
+//       }
+//     }
+//   }
+
+//   const enumsToSkip = new Set<string>();
+//   // identify properties that are constants
+//   for (const schema of values(model.schemas)) {
+//     for (const property of values(schema.properties)) {
+//       if (property.details.default.required && length(property.schema.enum) === 1) {
+//         // properties with an enum single value are constants
+//         // add the constant value
+//         property.details.default.constantValue = property.schema.enum[0];
+
+//         // mark as skip the generation of this model
+//         enumsToSkip.add(property.schema.details.default.uid);
+
+//         // make it a string and keep its name
+//         property.schema = new Schema(property.schema.details.default.name, { type: property.schema.type });
+//       } else {
+//         enumsToSkip.delete(property.schema.details.default.uid);
+//       }
+//     }
+//   }
+
+//   // mark enums that shouldn't be generated
+//   for (const schema of values(model.schemas)) {
+//     if (enumsToSkip.has(schema.details.default.uid)) {
+//       schema.details.default.skip = true;
+//     }
+//   }
+
+//   for (const operation of values(model.http.operations)) {
+//     for (const { key: responseCode, value: responses } of items(operation.responses)) {
+//       for (const response of values(responses)) {
+//         if (responseCode === 'default' || response.extensions['x-ms-error-response'] === true) {
+//           response.details.default.isErrorResponse = true;
+//         }
+//       }
+//     }
+//   }
+
+//   return model;
+// }
+
+// Universal version -
+// tweaks the code model to adjust things so that the code will generate better.
+
+export async function tweakModelPlugin(service: Host) {
+  //const session = await startSession<PwshModel>(service, {}, codeModelSchema);
+  const state = await new NewModelState<PwshModel>(service).init();
+  //const result = tweakModelV2(session);
+  await service.WriteFile('code-model-v4-tweakcodemodel-v2.yaml', serialize(await tweakModelV2(state)), undefined, 'code-model-v4');
+  //return processCodeModel(tweakModelV2, service, 'tweakcodemodel-v2');
+}

--- a/powershell/plugins/powershell-v2.ts
+++ b/powershell/plugins/powershell-v2.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { codemodel } from '@azure-tools/codemodel-v3';
+//import { codemodel } from '@azure-tools/codemodel-v3';
 import { deserialize, applyOverrides, copyResources, copyBinaryResources, safeEval } from '@azure-tools/codegen';
 import { Host } from '@azure-tools/autorest-extension-base';
 import { join } from 'path';
@@ -23,7 +23,7 @@ const sourceFileCSharp = 'source-file-csharp';
 const resources = `${__dirname}/../../resources`;
 
 
-async function copyRequiredFiles(project: Project | NewProject) {
+async function copyRequiredFiles(project: NewProject) {
   const transformOutput = async (input: string) => { return await project.state.resolveVariables(input); };
 
   // Project assets

--- a/powershell/plugins/powershell-v2.ts
+++ b/powershell/plugins/powershell-v2.ts
@@ -7,7 +7,7 @@ import { codemodel } from '@azure-tools/codemodel-v3';
 import { deserialize, applyOverrides, copyResources, copyBinaryResources, safeEval } from '@azure-tools/codegen';
 import { Host } from '@azure-tools/autorest-extension-base';
 import { join } from 'path';
-import { Project } from '../internal/project';
+import { Project, NewProject } from '../internal/project';
 import { State } from '../internal/state';
 import { generatePsm1 } from '../generators/psm1';
 import { generateCsproj } from '../generators/csproj';
@@ -18,7 +18,6 @@ import { generateGitIgnore } from '../generators/gitignore';
 import { generateGitAttributes } from '../generators/gitattributes';
 import { generateReadme } from '../generators/readme';
 import { generateScriptCmdlets } from '../generators/script-cmdlet';
-import { NewProject } from '../internal/project';
 
 const sourceFileCSharp = 'source-file-csharp';
 const resources = `${__dirname}/../../resources`;
@@ -43,11 +42,11 @@ async function copyRequiredFiles(project: Project | NewProject) {
 }
 
 
-export async function powershell(service: Host) {
+export async function powershellV2(service: Host) {
   const debug = await service.GetValue('debug') || false;
 
   try {
-    const project = await new Project(service).init();
+    const project = await new NewProject(service).init();
 
     await project.writeFiles(async (filename, content) => project.state.writeFile(filename, applyOverrides(content, project.overrides), undefined, sourceFileCSharp));
 

--- a/powershell/plugins/ps-namer-v2.ts
+++ b/powershell/plugins/ps-namer-v2.ts
@@ -55,7 +55,7 @@ async function tweakModel(state: State): Promise<PwshModel> {
 
   // make sure recursively that every details field has csharp
   for (const { index, instance } of linq.visitor(state.model)) {
-    if (index === 'language' && instance.default && !instance.csharp) {
+    if (index === 'details' && instance.default && !instance.csharp) {
       instance.csharp = linq.clone(instance.default, false, undefined, undefined, ['schema', 'origin']);
     }
   }

--- a/powershell/plugins/ps-namer-v2.ts
+++ b/powershell/plugins/ps-namer-v2.ts
@@ -5,13 +5,14 @@
 
 import { codeModelSchema, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
 import { Host, Channel, Session, startSession } from '@azure-tools/autorest-extension-base';
-import { codemodel, processCodeModel, allVirtualParameters, allVirtualProperties, resolveParameterNames, resolvePropertyNames, ModelState, isMediaTypeMultipartFormData, VirtualParameter } from '@azure-tools/codemodel-v3';
+//import { allVirtualParameters, allVirtualProperties, resolveParameterNames, resolvePropertyNames } from '@azure-tools/codemodel-v3';
 import { deconstruct, removeProhibitedPrefix, removeSequentialDuplicates, pascalCase, serialize } from '@azure-tools/codegen';
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
 import * as linq from '@azure-tools/linq';
 import { singularize } from '../internal/name-inferrer';
 import { PwshModel } from '../utils/PwshModel';
 import { NewModelState } from '../utils/model-state';
+import { allVirtualParameters, allVirtualProperties, resolveParameterNames, resolvePropertyNames } from '../utils/resolve-conflicts';
 
 type State = NewModelState<PwshModel>;
 

--- a/powershell/utils/PwshModel.ts
+++ b/powershell/utils/PwshModel.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { codeModelSchema, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
+import { CommandComponents } from '@azure-tools/codemodel-v3/dist/code-model/command-operation';
+import { DeepPartial } from '@azure-tools/codegen';
+
+export class PwshModel extends CodeModel {
+  public commands = new CommandComponents();
+  constructor(title: string, sourceTracking = false, initializer?: DeepPartial<PwshModel>) {
+    super(title, sourceTracking);
+
+    this.apply(initializer);
+  }
+}

--- a/powershell/utils/PwshModel.ts
+++ b/powershell/utils/PwshModel.ts
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { codeModelSchema, CodeModel, Schema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
-import { CommandComponents } from '@azure-tools/codemodel-v3/dist/code-model/command-operation';
+//import { CommandComponents } from '@azure-tools/codemodel-v3/dist/code-model/command-operation';
 import { DeepPartial } from '@azure-tools/codegen';
+import { CommandComponents } from '../utils/command-operation';
 
 export class PwshModel extends CodeModel {
   public commands = new CommandComponents();

--- a/powershell/utils/command-operation.ts
+++ b/powershell/utils/command-operation.ts
@@ -1,0 +1,79 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Components, IParameter, LanguageDetails } from './components';
+import { Extensions } from './extensions';
+import { HttpOperation } from './http-operation';
+import { ProgramaticOperationDetails, ProgrammaticOperation } from './programatic-operation';
+import { Schema, VirtualProperty } from './schema';
+import { DeepPartial } from '@azure-tools/codegen';
+
+import { uid } from './uid';
+import { Dictionary } from '@azure-tools/linq';
+
+export interface VirtualParameters {
+  body: Array<VirtualParameter>;
+  operation: Array<VirtualParameter>;
+}
+
+export interface CommandOperationDetails extends ProgramaticOperationDetails {
+  virtualParameters?: VirtualParameters;
+}
+
+export interface CompleterInfo {
+  script: string;
+  name: string;
+  description: string;
+}
+
+export interface CommandOperation extends ProgrammaticOperation {
+  alias: Array<string>;
+  verb: string;
+  noun: string;
+  variant: string;
+  category: string;
+  asjob: boolean;
+  callGraph: Array<HttpOperation>;
+}
+
+export interface VirtualParameter {
+  name: string;
+  description: string;
+  required: boolean;
+  schema: Schema;
+  nameOptions: Array<string>;
+  origin: VirtualProperty | IParameter;
+  alias: Array<string>;
+  completerInfo?: CompleterInfo;
+}
+
+export class CommandOperation extends Extensions implements CommandOperation {
+  public extensions = new Dictionary<any>();
+  public details: LanguageDetails<CommandOperationDetails>;
+
+  public responses = new Dictionary<Dictionary<Schema>>();
+
+  constructor(name: string, initializer?: DeepPartial<CommandOperation>) {
+    super();
+    this.details = {
+      default: {
+        uid: `command-operation:${uid()}`,
+        description: initializer?.description || '',
+        name,
+      }
+    };
+    this.deprecated = false;
+    this.pure = true;
+
+    this.apply(initializer);
+  }
+}
+
+export interface CommandComponents extends Components<CommandOperation, IParameter> {
+
+}
+
+export class CommandComponents extends Components<CommandOperation, IParameter> {
+}

--- a/powershell/utils/command-operation.ts
+++ b/powershell/utils/command-operation.ts
@@ -5,10 +5,11 @@
 
 import { Components, IParameter, LanguageDetails } from './components';
 import { Extensions } from './extensions';
-import { HttpOperation } from './http-operation';
 import { ProgramaticOperationDetails, ProgrammaticOperation } from './programatic-operation';
-import { Schema, VirtualProperty } from './schema';
+import { VirtualProperty } from './schema';
+import { Schema } from '@azure-tools/codemodel';
 import { DeepPartial } from '@azure-tools/codegen';
+import { Operation } from '@azure-tools/codemodel';
 
 import { uid } from './uid';
 import { Dictionary } from '@azure-tools/linq';
@@ -35,7 +36,7 @@ export interface CommandOperation extends ProgrammaticOperation {
   variant: string;
   category: string;
   asjob: boolean;
-  callGraph: Array<HttpOperation>;
+  callGraph: Array<Operation>;
 }
 
 export interface VirtualParameter {

--- a/powershell/utils/components.ts
+++ b/powershell/utils/components.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import { DeepPartial } from '@azure-tools/codegen';
 import { Dictionary } from '@azure-tools/linq';
-import { Schema as NewSchema } from '@azure-tools/codemodel';
+import { Schema } from '@azure-tools/codemodel';
 import { Extensions } from './extensions';
-import { Schema } from './schema';
+//import { Schema } from './schema';
 import { uid } from './uid';
 
 export interface IOperationBase {
@@ -42,11 +42,7 @@ export class IParameter extends Extensions {
   }
 }
 
-export class IParameterPwsh extends IParameter {
-  constructor(public name: string, public schema: Schema, public newSchema: NewSchema, initializer?: DeepPartial<IParameter>) {
-    super(name, schema);
-  }
-}
+
 export interface IOperation<TParameterType extends IParameter> extends IOperationBase {
   operationId: string;
   description: string;

--- a/powershell/utils/components.ts
+++ b/powershell/utils/components.ts
@@ -4,30 +4,215 @@
  *--------------------------------------------------------------------------------------------*/
 import { DeepPartial } from '@azure-tools/codegen';
 import { Dictionary } from '@azure-tools/linq';
-import { components, Schema } from '@azure-tools/codemodel-v3';
 import { Schema as NewSchema } from '@azure-tools/codemodel';
+import { Extensions } from './extensions';
+import { Schema } from './schema';
+import { uid } from './uid';
 
+export interface IOperationBase {
 
-export class IParameterPwsh extends components.IParameter {
-  constructor(public name: string, public schema: Schema, public newSchema: NewSchema, initializer?: DeepPartial<components.IParameter>) {
+}
+
+export interface IParameter extends Extensions {
+  name: string;
+  schema: Schema;
+  description: string;
+
+  allowEmptyValue: boolean;
+  deprecated: boolean;
+  required: boolean;
+  details: LanguageDetails<ParameterDetails>;
+}
+
+export class IParameter extends Extensions {
+  constructor(public name: string, public schema: Schema, initializer?: DeepPartial<IParameter>) {
+    super();
+    this.description = '';
+    this.deprecated = false;
+    this.required = false;
+    this.details = {
+      default: {
+        uid: `parameter:${uid()}`,
+        description: this.description,
+        name,
+      }
+    };
+    this.allowEmptyValue = false;
+    this.apply(initializer);
+  }
+}
+
+export class IParameterPwsh extends IParameter {
+  constructor(public name: string, public schema: Schema, public newSchema: NewSchema, initializer?: DeepPartial<IParameter>) {
     super(name, schema);
   }
 }
-// export class IParameter extends Extensions {
-//   constructor(public name: string, public schema: Schema, initializer?: DeepPartial<IParameter>) {
-//     super();
-//     this.description = '';
-//     this.deprecated = false;
-//     this.required = false;
-//     this.details = {
-//       default: {
-//         uid: `parameter:${uid()}`,
-//         description: this.description,
-//         name,
-//       }
-//     };
-//     this.allowEmptyValue = false;
-//     this.apply(initializer);
-//   }
-// }
+export interface IOperation<TParameterType extends IParameter> extends IOperationBase {
+  operationId: string;
+  description: string;
+
+  summary?: string;
+  deprecated: boolean;
+
+  parameters: Array<TParameterType>;
+}
+
+export interface Components<TOperation extends IOperation<TParameter>, TParameter extends IParameter> extends Extensions {
+  operations: Dictionary<TOperation>;
+  parameters: Dictionary<TParameter>;
+}
+
+export class Components<TOperation extends IOperation<TParameter>, TParameter extends IParameter> extends Extensions implements Components<TOperation, TParameter> {
+  /**
+   * Dictionary of Operations in this model.
+   *
+   * This is intended to invert the original PathItems in the OAI model, and focus on operations, not endpoints.
+   */
+  public operations = new Dictionary<TOperation>();
+
+  constructor(initializer?: DeepPartial<Components<TOperation, TParameter>>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export interface ParameterDetails extends ImplementationDetails {
+
+}
+
+export interface ResponseDetails extends ImplementationDetails {
+  isErrorResponse: boolean;
+}
+
+/** LanguageDetails contains a map of languages to details for a given node in the code-model  */
+export interface LanguageDetails<T extends ImplementationDetails> extends Dictionary<T> {
+  default: T;
+
+}
+
+export interface ImplementationDetails extends Dictionary<any> {
+  /** a unique id for correlation between cloned objects */
+  uid: string;
+
+  /** name used in actual implementation */
+  name: string;
+
+  /** description text */
+  description: string;
+
+  /** message used to go along with deprecation */
+  deprecationMessage?: string;
+}
+
+export enum ImplementationLocation {
+  Method = 'Method',
+  Client = 'Client',
+}
+
+export class Example extends Extensions implements Example {
+  extensions = new Dictionary<any>();
+
+  constructor(initializer?: DeepPartial<Example>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class ExternalDocumentation extends Extensions implements ExternalDocumentation {
+  extensions = new Dictionary<any>();
+
+  constructor(public url: string, initializer?: DeepPartial<ExternalDocumentation>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class Link extends Extensions implements Link {
+  extensions = new Dictionary<any>();
+  parameters = new Dictionary<string>();
+
+  constructor(initializer?: DeepPartial<Link>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class Server extends Extensions implements Server {
+  extensions = new Dictionary<any>();
+  variables = new Dictionary<ServerVariable>();
+
+  constructor(public url: string, initializer?: DeepPartial<Server>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class ServerVariable extends Extensions implements ServerVariable {
+  extensions = new Dictionary<any>();
+  enum = new Array<string>();
+
+  constructor(defaultValue: string, initializer?: DeepPartial<ServerVariable>) {
+    super();
+    this.default = defaultValue;
+    this.apply(initializer);
+  }
+}
+
+export class Tag extends Extensions implements Tag {
+  extensions = new Dictionary<any>();
+
+  constructor(public name: string, initializer?: DeepPartial<Tag>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+/**
+ * @description common ways of serializing simple parameters
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#style-values
+ */
+
+export interface SecurityRequirement extends Dictionary<string> {
+}
+
+export interface Example extends Extensions {
+  summary?: string;
+  description?: string;
+  value?: any;
+  externalValue?: string; // uriref
+}
+
+export interface ExternalDocumentation extends Extensions {
+  description?: string;
+  url: string; // uriref
+}
+
+export interface Link extends Extensions {
+  operationRef?: string; // uriref
+  operationId?: string;
+  parameters: Dictionary<string>;
+  requestBody?: any;
+  description?: string;
+  server?: Server;
+}
+
+export interface Server extends Extensions {
+
+  url: string;
+  description?: string;
+  variables: Dictionary<ServerVariable>;
+}
+
+export interface ServerVariable extends Extensions {
+  enum: Array<string>;
+  default: string;
+  description?: string;
+}
+
+export interface Tag extends Extensions {
+
+  name: string;
+  description?: string;
+  externalDocs?: ExternalDocumentation;
+}
 

--- a/powershell/utils/components.ts
+++ b/powershell/utils/components.ts
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { DeepPartial } from '@azure-tools/codegen';
+import { Dictionary } from '@azure-tools/linq';
+import { components, Schema } from '@azure-tools/codemodel-v3';
+import { Schema as NewSchema } from '@azure-tools/codemodel';
+
+
+export class IParameterPwsh extends components.IParameter {
+  constructor(public name: string, public schema: Schema, public newSchema: NewSchema, initializer?: DeepPartial<components.IParameter>) {
+    super(name, schema);
+  }
+}
+// export class IParameter extends Extensions {
+//   constructor(public name: string, public schema: Schema, initializer?: DeepPartial<IParameter>) {
+//     super();
+//     this.description = '';
+//     this.deprecated = false;
+//     this.required = false;
+//     this.details = {
+//       default: {
+//         uid: `parameter:${uid()}`,
+//         description: this.description,
+//         name,
+//       }
+//     };
+//     this.allowEmptyValue = false;
+//     this.apply(initializer);
+//   }
+// }
+

--- a/powershell/utils/extensions.ts
+++ b/powershell/utils/extensions.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Initializer, DeepPartial } from '@azure-tools/codegen';
+import { Dictionary } from '@azure-tools/linq';
+
+export class Extensions extends Initializer implements Extensions {
+  extensions = new Dictionary<any>();
+
+  constructor() {
+    super();
+  }
+}
+
+export interface Extensions {
+  /** additional metadata extensions */
+  extensions: Dictionary<any>;
+}

--- a/powershell/utils/http-operation.ts
+++ b/powershell/utils/http-operation.ts
@@ -1,0 +1,300 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Components, Example, ExternalDocumentation, ImplementationDetails, ImplementationLocation, IOperation, IOperationBase, IParameter, LanguageDetails, Link, ParameterDetails, ResponseDetails, SecurityRequirement, Server } from './components';
+import { Extensions } from './extensions';
+import { Schema } from './schema';
+import { SecurityScheme } from './security-scheme';
+import { DeepPartial } from '@azure-tools/codegen';
+import { Dictionary } from '@azure-tools/linq';
+import { uid } from './uid';
+
+export interface HttpOperationDetails extends ImplementationDetails {
+}
+
+/** 
+ * An encoding attribute is introduced to give you control over the serialization of parts of multipart request bodies. 
+ * This attribute is only applicable to multipart and application/x-www-form-urlencoded request bodies. 
+*/
+export class Encoding extends Extensions implements Encoding {
+  public headers = new Array<Header>();
+
+  constructor(public key: string, initializer?: DeepPartial<Encoding>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class Header extends Extensions implements Header {
+
+  public content = new Array<MediaType>();
+
+  constructor(initializer?: DeepPartial<Header>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class MediaType extends Extensions implements MediaType {
+  public encoding = new Array<Encoding>();
+  public accepts = new Array<string>();
+
+  constructor(public key: string, initializer?: DeepPartial<MediaType>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class RequestBody extends Extensions implements RequestBody {
+
+  constructor(initializer?: DeepPartial<RequestBody>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class Response extends Extensions implements Response {
+
+  public content = new Dictionary<MediaType>();
+  public links = new Dictionary<Link>();
+  public headers = new Array<Header>();
+
+  constructor(public description: string, initializer?: DeepPartial<Response>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export enum ParameterLocation {
+  Uri = 'uri',
+  Query = 'query',
+  Header = 'header',
+  Cookie = 'cookie',
+  Path = 'path',
+}
+
+export enum EncodingStyle {
+  Matrix = 'matrix',
+  Label = 'label',
+  Simple = 'simple',
+  Form = 'form',
+  SpaceDelimited = 'spaceDelimited',
+  PipeDelimited = 'pipeDelimited',
+  DeepObject = 'deepObject'
+}
+
+export type QueryEncodingStyle =
+  EncodingStyle.Form
+  | EncodingStyle.SpaceDelimited
+  | EncodingStyle.PipeDelimited
+  | EncodingStyle.DeepObject;
+export type PathEncodingStyle = EncodingStyle.Matrix | EncodingStyle.Label | EncodingStyle.Simple;
+
+export interface Encoding extends Extensions {
+  key: string;
+  contentType?: string;
+  headers: Array<Header>;
+  style?: QueryEncodingStyle;
+  explode?: boolean;
+  allowReserved?: boolean;
+}
+
+export interface Header extends Extensions {
+  key: string;
+  schema: Schema;
+  explode?: boolean;
+  examples: Dictionary<Example>;
+
+  description?: string;
+  required: boolean;
+  deprecated: boolean;
+  allowEmptyValue: boolean;
+  allowReserved: boolean;
+}
+
+export interface MediaType extends Extensions {
+  key: string;
+  accepts: Array<string>; // equivalent media types for this media type (ie, text/json, application/json)
+  examples: Array<Example>;
+  encoding: Array<Encoding>;
+  schema?: Schema;
+}
+
+export interface RequestBody extends Extensions {
+  description?: string;
+  contentType: string;
+  schema: Schema;
+  required: boolean;
+}
+
+export interface Response extends Extensions {
+  description: string;
+  headers: Array<Header>;
+  content: Dictionary<MediaType>;
+  links: Dictionary<Link>;
+}
+
+export interface HttpParameterDetails extends ParameterDetails {
+  location: ImplementationLocation;
+}
+
+export enum HttpMethod {
+  Get = 'get',
+  Put = 'put',
+  Post = 'post',
+  Delete = 'delete',
+  Options = 'options',
+  Head = 'head',
+  Patch = 'patch',
+  Trace = 'trace'
+}
+
+export interface NewResponse {
+  details: LanguageDetails<ResponseDetails>;
+  responseCode: string;
+  description: string;
+  headers: Array<Header>;
+  headerSchema?: Schema;
+  mimeTypes: Array<string>; // accepted equivalent media types for this media type (ie, text/json, application/json)
+  schema?: Schema;
+}
+
+export class NewResponse extends Extensions implements NewResponse {
+  public details: LanguageDetails<ResponseDetails>;
+
+  constructor(public responseCode: string, public description: string, public mimeTypes: Array<string>, objectInitializer?: DeepPartial<NewResponse>) {
+    super();
+    this.details = {
+      default: {
+        uid: `response:${uid()}`,
+        isErrorResponse: false,
+        description: description || objectInitializer?.description || '',
+        name: `${responseCode} ${mimeTypes.join(' ')}`,
+      }
+    };
+    this.headers = new Array<Header>();
+    this.apply(objectInitializer);
+  }
+}
+
+export class HttpOperation extends Extensions implements HttpOperation {
+  public details: LanguageDetails<HttpOperationDetails>;
+  public tags = new Array<string>();
+  public parameters = new Array<HttpOperationParameter>();
+  public responses = new Dictionary<Array<NewResponse>>();
+  public callbacks = new Dictionary<Callback>();
+  public security = new Array<SecurityRequirement>();
+  public servers = new Array<Server>();
+  public deprecated = false;
+
+  constructor(operationId: string, public baseUrl: string, public path: string, public method: HttpMethod, initializer?: DeepPartial<HttpOperation>) {
+    super();
+    this.details = {
+      default: {
+        uid: `http-operation:${uid()}`,
+        description: initializer?.description || '',
+        name: operationId,
+      }
+    };
+
+    this.apply(initializer);
+  }
+}
+
+export interface HttpOperation extends IOperation<HttpOperationParameter>, Extensions {
+  details: LanguageDetails<HttpOperationDetails>;
+
+  tags: Array<string>;
+  summary?: string;
+
+  externalDocs?: ExternalDocumentation;
+
+  parameters: Array<HttpOperationParameter>;
+  requestBody?: RequestBody;
+  responses: Dictionary<Array<NewResponse>>;
+
+  callbacks: Dictionary<Callback>;
+  deprecated: boolean;
+  security: Array<SecurityRequirement>;
+  servers: Array<Server>;
+
+  path: string;
+  baseUrl: string;
+  method: HttpMethod;
+  pathDescription?: string;
+  pathSummary?: string;
+  pathExtensions?: Dictionary<any>;
+}
+
+export interface HttpOperationParameter extends IParameter {
+
+  in: ParameterLocation;
+  explode?: boolean;
+
+  encoding?: Array<Encoding>;
+  mediaType?: string;
+  style: EncodingStyle;
+  examples?: Dictionary<any>;
+  allowReserved?: boolean;
+}
+
+export class HttpOperationParameter extends Extensions implements HttpOperationParameter {
+
+  public details: LanguageDetails<HttpParameterDetails>;
+  public deprecated = false;
+  public required = false;
+  public allowEmptyValue = false;
+
+  constructor(public name: string, inWhere: ParameterLocation, implementation: ImplementationLocation, initializer?: DeepPartial<HttpOperationParameter>) {
+    super();
+    this.in = inWhere;
+    this.details = {
+      default: {
+        uid: `http-parameter:${uid()}`,
+        description: initializer?.description || '',
+        location: implementation,
+        name,
+      }
+    };
+    this.required = inWhere === ParameterLocation.Path;
+    this.apply(initializer);
+  }
+}
+
+export function isHttpOperation(operation: IOperationBase): operation is HttpOperation {
+  if ((<any>operation).path) {
+    return true;
+  }
+  return false;
+}
+
+export class Callback implements Callback {
+  constructor() {
+    // unimplemented.
+  }
+}
+
+export interface Callback extends Dictionary<HttpOperation> {
+}
+
+export interface HttpComponents extends Components<HttpOperation, HttpOperationParameter> {
+
+  examples: Dictionary<Example>;
+  securitySchemes: Dictionary<SecurityScheme>;
+  links: Dictionary<Link>;
+  callbacks: Dictionary<Callback>;
+}
+
+export class HttpComponents extends Components<HttpOperation, HttpOperationParameter> implements HttpComponents {
+  public examples = new Dictionary<Example>();
+  public securitySchemes = new Dictionary<SecurityScheme>();
+  public links = new Dictionary<Link>();
+  public callbacks = new Dictionary<Callback>();
+
+  constructor(initializer?: DeepPartial<HttpComponents>) {
+    super();
+    this.apply(initializer);
+  }
+}

--- a/powershell/utils/http-operation.ts
+++ b/powershell/utils/http-operation.ts
@@ -1,71 +1,71 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
+// /*---------------------------------------------------------------------------------------------
+//  *  Copyright (c) Microsoft Corporation. All rights reserved.
+//  *  Licensed under the MIT License. See License.txt in the project root for license information.
+//  *--------------------------------------------------------------------------------------------*/
 
-import { Components, Example, ExternalDocumentation, ImplementationDetails, ImplementationLocation, IOperation, IOperationBase, IParameter, LanguageDetails, Link, ParameterDetails, ResponseDetails, SecurityRequirement, Server } from './components';
-import { Extensions } from './extensions';
-import { Schema } from './schema';
-import { SecurityScheme } from './security-scheme';
-import { DeepPartial } from '@azure-tools/codegen';
-import { Dictionary } from '@azure-tools/linq';
-import { uid } from './uid';
+// import { Components, Example, ExternalDocumentation, ImplementationDetails, ImplementationLocation, IOperation, IOperationBase, IParameter, LanguageDetails, Link, ParameterDetails, ResponseDetails, SecurityRequirement, Server } from './components';
+// import { Extensions } from './extensions';
+// import { Schema } from './schema';
+// import { SecurityScheme } from './security-scheme';
+// import { DeepPartial } from '@azure-tools/codegen';
+// import { Dictionary } from '@azure-tools/linq';
+// import { uid } from './uid';
 
-export interface HttpOperationDetails extends ImplementationDetails {
-}
+// export interface HttpOperationDetails extends ImplementationDetails {
+// }
 
-/** 
- * An encoding attribute is introduced to give you control over the serialization of parts of multipart request bodies. 
- * This attribute is only applicable to multipart and application/x-www-form-urlencoded request bodies. 
-*/
-export class Encoding extends Extensions implements Encoding {
-  public headers = new Array<Header>();
+// /** 
+//  * An encoding attribute is introduced to give you control over the serialization of parts of multipart request bodies. 
+//  * This attribute is only applicable to multipart and application/x-www-form-urlencoded request bodies. 
+// */
+// export class Encoding extends Extensions implements Encoding {
+//   public headers = new Array<Header>();
 
-  constructor(public key: string, initializer?: DeepPartial<Encoding>) {
-    super();
-    this.apply(initializer);
-  }
-}
+//   constructor(public key: string, initializer?: DeepPartial<Encoding>) {
+//     super();
+//     this.apply(initializer);
+//   }
+// }
 
-export class Header extends Extensions implements Header {
+// export class Header extends Extensions implements Header {
 
-  public content = new Array<MediaType>();
+//   public content = new Array<MediaType>();
 
-  constructor(initializer?: DeepPartial<Header>) {
-    super();
-    this.apply(initializer);
-  }
-}
+//   constructor(initializer?: DeepPartial<Header>) {
+//     super();
+//     this.apply(initializer);
+//   }
+// }
 
-export class MediaType extends Extensions implements MediaType {
-  public encoding = new Array<Encoding>();
-  public accepts = new Array<string>();
+// export class MediaType extends Extensions implements MediaType {
+//   public encoding = new Array<Encoding>();
+//   public accepts = new Array<string>();
 
-  constructor(public key: string, initializer?: DeepPartial<MediaType>) {
-    super();
-    this.apply(initializer);
-  }
-}
+//   constructor(public key: string, initializer?: DeepPartial<MediaType>) {
+//     super();
+//     this.apply(initializer);
+//   }
+// }
 
-export class RequestBody extends Extensions implements RequestBody {
+// export class RequestBody extends Extensions implements RequestBody {
 
-  constructor(initializer?: DeepPartial<RequestBody>) {
-    super();
-    this.apply(initializer);
-  }
-}
+//   constructor(initializer?: DeepPartial<RequestBody>) {
+//     super();
+//     this.apply(initializer);
+//   }
+// }
 
-export class Response extends Extensions implements Response {
+// export class Response extends Extensions implements Response {
 
-  public content = new Dictionary<MediaType>();
-  public links = new Dictionary<Link>();
-  public headers = new Array<Header>();
+//   public content = new Dictionary<MediaType>();
+//   public links = new Dictionary<Link>();
+//   public headers = new Array<Header>();
 
-  constructor(public description: string, initializer?: DeepPartial<Response>) {
-    super();
-    this.apply(initializer);
-  }
-}
+//   constructor(public description: string, initializer?: DeepPartial<Response>) {
+//     super();
+//     this.apply(initializer);
+//   }
+// }
 
 export enum ParameterLocation {
   Uri = 'uri',
@@ -75,226 +75,226 @@ export enum ParameterLocation {
   Path = 'path',
 }
 
-export enum EncodingStyle {
-  Matrix = 'matrix',
-  Label = 'label',
-  Simple = 'simple',
-  Form = 'form',
-  SpaceDelimited = 'spaceDelimited',
-  PipeDelimited = 'pipeDelimited',
-  DeepObject = 'deepObject'
-}
+// export enum EncodingStyle {
+//   Matrix = 'matrix',
+//   Label = 'label',
+//   Simple = 'simple',
+//   Form = 'form',
+//   SpaceDelimited = 'spaceDelimited',
+//   PipeDelimited = 'pipeDelimited',
+//   DeepObject = 'deepObject'
+// }
 
-export type QueryEncodingStyle =
-  EncodingStyle.Form
-  | EncodingStyle.SpaceDelimited
-  | EncodingStyle.PipeDelimited
-  | EncodingStyle.DeepObject;
-export type PathEncodingStyle = EncodingStyle.Matrix | EncodingStyle.Label | EncodingStyle.Simple;
+// export type QueryEncodingStyle =
+//   EncodingStyle.Form
+//   | EncodingStyle.SpaceDelimited
+//   | EncodingStyle.PipeDelimited
+//   | EncodingStyle.DeepObject;
+// export type PathEncodingStyle = EncodingStyle.Matrix | EncodingStyle.Label | EncodingStyle.Simple;
 
-export interface Encoding extends Extensions {
-  key: string;
-  contentType?: string;
-  headers: Array<Header>;
-  style?: QueryEncodingStyle;
-  explode?: boolean;
-  allowReserved?: boolean;
-}
+// export interface Encoding extends Extensions {
+//   key: string;
+//   contentType?: string;
+//   headers: Array<Header>;
+//   style?: QueryEncodingStyle;
+//   explode?: boolean;
+//   allowReserved?: boolean;
+// }
 
-export interface Header extends Extensions {
-  key: string;
-  schema: Schema;
-  explode?: boolean;
-  examples: Dictionary<Example>;
+// export interface Header extends Extensions {
+//   key: string;
+//   schema: Schema;
+//   explode?: boolean;
+//   examples: Dictionary<Example>;
 
-  description?: string;
-  required: boolean;
-  deprecated: boolean;
-  allowEmptyValue: boolean;
-  allowReserved: boolean;
-}
+//   description?: string;
+//   required: boolean;
+//   deprecated: boolean;
+//   allowEmptyValue: boolean;
+//   allowReserved: boolean;
+// }
 
-export interface MediaType extends Extensions {
-  key: string;
-  accepts: Array<string>; // equivalent media types for this media type (ie, text/json, application/json)
-  examples: Array<Example>;
-  encoding: Array<Encoding>;
-  schema?: Schema;
-}
+// export interface MediaType extends Extensions {
+//   key: string;
+//   accepts: Array<string>; // equivalent media types for this media type (ie, text/json, application/json)
+//   examples: Array<Example>;
+//   encoding: Array<Encoding>;
+//   schema?: Schema;
+// }
 
-export interface RequestBody extends Extensions {
-  description?: string;
-  contentType: string;
-  schema: Schema;
-  required: boolean;
-}
+// export interface RequestBody extends Extensions {
+//   description?: string;
+//   contentType: string;
+//   schema: Schema;
+//   required: boolean;
+// }
 
-export interface Response extends Extensions {
-  description: string;
-  headers: Array<Header>;
-  content: Dictionary<MediaType>;
-  links: Dictionary<Link>;
-}
+// export interface Response extends Extensions {
+//   description: string;
+//   headers: Array<Header>;
+//   content: Dictionary<MediaType>;
+//   links: Dictionary<Link>;
+// }
 
-export interface HttpParameterDetails extends ParameterDetails {
-  location: ImplementationLocation;
-}
+// export interface HttpParameterDetails extends ParameterDetails {
+//   location: ImplementationLocation;
+// }
 
-export enum HttpMethod {
-  Get = 'get',
-  Put = 'put',
-  Post = 'post',
-  Delete = 'delete',
-  Options = 'options',
-  Head = 'head',
-  Patch = 'patch',
-  Trace = 'trace'
-}
+// export enum HttpMethod {
+//   Get = 'get',
+//   Put = 'put',
+//   Post = 'post',
+//   Delete = 'delete',
+//   Options = 'options',
+//   Head = 'head',
+//   Patch = 'patch',
+//   Trace = 'trace'
+// }
 
-export interface NewResponse {
-  details: LanguageDetails<ResponseDetails>;
-  responseCode: string;
-  description: string;
-  headers: Array<Header>;
-  headerSchema?: Schema;
-  mimeTypes: Array<string>; // accepted equivalent media types for this media type (ie, text/json, application/json)
-  schema?: Schema;
-}
+// export interface NewResponse {
+//   details: LanguageDetails<ResponseDetails>;
+//   responseCode: string;
+//   description: string;
+//   headers: Array<Header>;
+//   headerSchema?: Schema;
+//   mimeTypes: Array<string>; // accepted equivalent media types for this media type (ie, text/json, application/json)
+//   schema?: Schema;
+// }
 
-export class NewResponse extends Extensions implements NewResponse {
-  public details: LanguageDetails<ResponseDetails>;
+// export class NewResponse extends Extensions implements NewResponse {
+//   public details: LanguageDetails<ResponseDetails>;
 
-  constructor(public responseCode: string, public description: string, public mimeTypes: Array<string>, objectInitializer?: DeepPartial<NewResponse>) {
-    super();
-    this.details = {
-      default: {
-        uid: `response:${uid()}`,
-        isErrorResponse: false,
-        description: description || objectInitializer?.description || '',
-        name: `${responseCode} ${mimeTypes.join(' ')}`,
-      }
-    };
-    this.headers = new Array<Header>();
-    this.apply(objectInitializer);
-  }
-}
+//   constructor(public responseCode: string, public description: string, public mimeTypes: Array<string>, objectInitializer?: DeepPartial<NewResponse>) {
+//     super();
+//     this.details = {
+//       default: {
+//         uid: `response:${uid()}`,
+//         isErrorResponse: false,
+//         description: description || objectInitializer?.description || '',
+//         name: `${responseCode} ${mimeTypes.join(' ')}`,
+//       }
+//     };
+//     this.headers = new Array<Header>();
+//     this.apply(objectInitializer);
+//   }
+// }
 
-export class HttpOperation extends Extensions implements HttpOperation {
-  public details: LanguageDetails<HttpOperationDetails>;
-  public tags = new Array<string>();
-  public parameters = new Array<HttpOperationParameter>();
-  public responses = new Dictionary<Array<NewResponse>>();
-  public callbacks = new Dictionary<Callback>();
-  public security = new Array<SecurityRequirement>();
-  public servers = new Array<Server>();
-  public deprecated = false;
+// export class HttpOperation extends Extensions implements HttpOperation {
+//   public details: LanguageDetails<HttpOperationDetails>;
+//   public tags = new Array<string>();
+//   public parameters = new Array<HttpOperationParameter>();
+//   public responses = new Dictionary<Array<NewResponse>>();
+//   public callbacks = new Dictionary<Callback>();
+//   public security = new Array<SecurityRequirement>();
+//   public servers = new Array<Server>();
+//   public deprecated = false;
 
-  constructor(operationId: string, public baseUrl: string, public path: string, public method: HttpMethod, initializer?: DeepPartial<HttpOperation>) {
-    super();
-    this.details = {
-      default: {
-        uid: `http-operation:${uid()}`,
-        description: initializer?.description || '',
-        name: operationId,
-      }
-    };
+//   constructor(operationId: string, public baseUrl: string, public path: string, public method: HttpMethod, initializer?: DeepPartial<HttpOperation>) {
+//     super();
+//     this.details = {
+//       default: {
+//         uid: `http-operation:${uid()}`,
+//         description: initializer?.description || '',
+//         name: operationId,
+//       }
+//     };
 
-    this.apply(initializer);
-  }
-}
+//     this.apply(initializer);
+//   }
+// }
 
-export interface HttpOperation extends IOperation<HttpOperationParameter>, Extensions {
-  details: LanguageDetails<HttpOperationDetails>;
+// export interface HttpOperation extends IOperation<HttpOperationParameter>, Extensions {
+//   details: LanguageDetails<HttpOperationDetails>;
 
-  tags: Array<string>;
-  summary?: string;
+//   tags: Array<string>;
+//   summary?: string;
 
-  externalDocs?: ExternalDocumentation;
+//   externalDocs?: ExternalDocumentation;
 
-  parameters: Array<HttpOperationParameter>;
-  requestBody?: RequestBody;
-  responses: Dictionary<Array<NewResponse>>;
+//   parameters: Array<HttpOperationParameter>;
+//   requestBody?: RequestBody;
+//   responses: Dictionary<Array<NewResponse>>;
 
-  callbacks: Dictionary<Callback>;
-  deprecated: boolean;
-  security: Array<SecurityRequirement>;
-  servers: Array<Server>;
+//   callbacks: Dictionary<Callback>;
+//   deprecated: boolean;
+//   security: Array<SecurityRequirement>;
+//   servers: Array<Server>;
 
-  path: string;
-  baseUrl: string;
-  method: HttpMethod;
-  pathDescription?: string;
-  pathSummary?: string;
-  pathExtensions?: Dictionary<any>;
-}
+//   path: string;
+//   baseUrl: string;
+//   method: HttpMethod;
+//   pathDescription?: string;
+//   pathSummary?: string;
+//   pathExtensions?: Dictionary<any>;
+// }
 
-export interface HttpOperationParameter extends IParameter {
+// export interface HttpOperationParameter extends IParameter {
 
-  in: ParameterLocation;
-  explode?: boolean;
+//   in: ParameterLocation;
+//   explode?: boolean;
 
-  encoding?: Array<Encoding>;
-  mediaType?: string;
-  style: EncodingStyle;
-  examples?: Dictionary<any>;
-  allowReserved?: boolean;
-}
+//   encoding?: Array<Encoding>;
+//   mediaType?: string;
+//   style: EncodingStyle;
+//   examples?: Dictionary<any>;
+//   allowReserved?: boolean;
+// }
 
-export class HttpOperationParameter extends Extensions implements HttpOperationParameter {
+// export class HttpOperationParameter extends Extensions implements HttpOperationParameter {
 
-  public details: LanguageDetails<HttpParameterDetails>;
-  public deprecated = false;
-  public required = false;
-  public allowEmptyValue = false;
+//   public details: LanguageDetails<HttpParameterDetails>;
+//   public deprecated = false;
+//   public required = false;
+//   public allowEmptyValue = false;
 
-  constructor(public name: string, inWhere: ParameterLocation, implementation: ImplementationLocation, initializer?: DeepPartial<HttpOperationParameter>) {
-    super();
-    this.in = inWhere;
-    this.details = {
-      default: {
-        uid: `http-parameter:${uid()}`,
-        description: initializer?.description || '',
-        location: implementation,
-        name,
-      }
-    };
-    this.required = inWhere === ParameterLocation.Path;
-    this.apply(initializer);
-  }
-}
+//   constructor(public name: string, inWhere: ParameterLocation, implementation: ImplementationLocation, initializer?: DeepPartial<HttpOperationParameter>) {
+//     super();
+//     this.in = inWhere;
+//     this.details = {
+//       default: {
+//         uid: `http-parameter:${uid()}`,
+//         description: initializer?.description || '',
+//         location: implementation,
+//         name,
+//       }
+//     };
+//     this.required = inWhere === ParameterLocation.Path;
+//     this.apply(initializer);
+//   }
+// }
 
-export function isHttpOperation(operation: IOperationBase): operation is HttpOperation {
-  if ((<any>operation).path) {
-    return true;
-  }
-  return false;
-}
+// export function isHttpOperation(operation: IOperationBase): operation is HttpOperation {
+//   if ((<any>operation).path) {
+//     return true;
+//   }
+//   return false;
+// }
 
-export class Callback implements Callback {
-  constructor() {
-    // unimplemented.
-  }
-}
+// export class Callback implements Callback {
+//   constructor() {
+//     // unimplemented.
+//   }
+// }
 
-export interface Callback extends Dictionary<HttpOperation> {
-}
+// export interface Callback extends Dictionary<HttpOperation> {
+// }
 
-export interface HttpComponents extends Components<HttpOperation, HttpOperationParameter> {
+// export interface HttpComponents extends Components<HttpOperation, HttpOperationParameter> {
 
-  examples: Dictionary<Example>;
-  securitySchemes: Dictionary<SecurityScheme>;
-  links: Dictionary<Link>;
-  callbacks: Dictionary<Callback>;
-}
+//   examples: Dictionary<Example>;
+//   securitySchemes: Dictionary<SecurityScheme>;
+//   links: Dictionary<Link>;
+//   callbacks: Dictionary<Callback>;
+// }
 
-export class HttpComponents extends Components<HttpOperation, HttpOperationParameter> implements HttpComponents {
-  public examples = new Dictionary<Example>();
-  public securitySchemes = new Dictionary<SecurityScheme>();
-  public links = new Dictionary<Link>();
-  public callbacks = new Dictionary<Callback>();
+// export class HttpComponents extends Components<HttpOperation, HttpOperationParameter> implements HttpComponents {
+//   public examples = new Dictionary<Example>();
+//   public securitySchemes = new Dictionary<SecurityScheme>();
+//   public links = new Dictionary<Link>();
+//   public callbacks = new Dictionary<Callback>();
 
-  constructor(initializer?: DeepPartial<HttpComponents>) {
-    super();
-    this.apply(initializer);
-  }
-}
+//   constructor(initializer?: DeepPartial<HttpComponents>) {
+//     super();
+//     this.apply(initializer);
+//   }
+// }

--- a/powershell/utils/info.ts
+++ b/powershell/utils/info.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Extensions } from './extensions';
+import { Dictionary } from '@azure-tools/linq';
+import { DeepPartial } from '@azure-tools/codegen';
+
+export class Contact extends Extensions implements Contact {
+  extensions = new Dictionary<any>();
+
+  constructor(initializer?: DeepPartial<Contact>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class Info extends Extensions implements Info {
+  extensions = new Dictionary<any>();
+
+  constructor(public title: string, public version: string, initializer?: DeepPartial<Info>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class License extends Extensions implements License {
+  extensions = new Dictionary<any>();
+
+  constructor(public name: string, initializer?: DeepPartial<License>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export interface Contact extends Extensions {
+  name?: string;
+  url?: string; // uriref
+  email?: string; // email
+}
+
+export interface Info extends Extensions {
+  title: string;
+  description?: string;
+  termsOfService?: string; // uriref
+  contact?: Contact;
+  license?: License;
+  version: string;
+}
+
+export interface License extends Extensions {
+  name: string;
+  url?: string; // uriref
+}

--- a/powershell/utils/model-state.ts
+++ b/powershell/utils/model-state.ts
@@ -1,0 +1,239 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Channel, Host, JsonPath, Mapping, RawSourceMap, Message } from '@azure-tools/autorest-extension-base';
+import { safeEval, deserialize, Initializer, DeepPartial } from '@azure-tools/codegen';
+import { Dictionary } from '@azure-tools/linq';
+
+export class NewModelState<T extends Dictionary<any>> extends Initializer {
+  public model!: T;
+  protected documentName!: string;
+  protected currentPath: JsonPath = new Array<string>();
+  private context!: any;
+  private _debug = false;
+  private _verbose = false;
+
+  public constructor(protected service: Host, objectInitializer?: DeepPartial<NewModelState<T>>) {
+    super();
+    this.apply(objectInitializer);
+  }
+
+  async init(project?: any) {
+    const m = await NewModelState.getModel<T>(this.service);
+    this.model = m.model;
+    this.documentName = m.filename;
+    this.initContext(project);
+    this._debug = await this.getValue('debug', false);
+    this._verbose = await this.getValue('verbose', false);
+    return this;
+  }
+
+  async initContext(project: any) {
+    this.context = this.context || {
+      $config: await this.service.GetValue(''),
+      $project: project,
+      $lib: {
+        path: require('path')
+      }
+    };
+    return this;
+  }
+
+  async readFile(filename: string): Promise<string> {
+    return this.service.ReadFile(filename);
+  }
+
+
+  async getValue<V>(key: string, defaultValue?: V): Promise<V> {
+    // check if it's in the model first
+    let value = this.model && this.model.language && this.model.language.default ? (<any>this.model.language.default)[key] : undefined;
+
+    // fall back to the configuration
+    if (value == null || value === undefined) {
+      value = await this.service.GetValue(key);
+    }
+
+    // try as a safe eval execution.
+    if (value === null || value === undefined) {
+      try {
+        value = safeEval(key, this.context);
+      }
+      catch {
+        value = null;
+      }
+    }
+
+    if (defaultValue === undefined && value === null) {
+      throw new Error(`No value for configuration key '${key}' was provided`);
+    }
+
+    if (typeof value === 'string') {
+      value = await this.resolveVariables(value);
+    }
+
+    // ensure that any content variables are resolved at the end.
+    return <V>(value !== null ? value : defaultValue);
+  }
+
+  async setValue<V>(key: string, value: V) {
+    (<any>this.model.language.default)[key] = value;
+  }
+
+  async listInputs(artifactType?: string | undefined): Promise<Array<string>> {
+    return this.service.ListInputs(artifactType);
+  }
+
+  async protectFiles(path: string): Promise<void> {
+    return this.service.ProtectFiles(path);
+  }
+  writeFile(filename: string, content: string, sourceMap?: Array<Mapping> | RawSourceMap | undefined, artifactType?: string | undefined): void {
+    return this.service.WriteFile(filename, content, sourceMap, artifactType);
+  }
+
+  message(message: Message): void {
+    if (message.Channel === Channel.Debug && this._debug === false) {
+      return;
+    }
+    if (message.Channel === Channel.Verbose && this._verbose === false) {
+      return;
+    }
+    return this.service.Message(message);
+  }
+
+  updateConfigurationFile(filename: string, content: string): void {
+    return this.service.UpdateConfigurationFile(filename, content);
+  }
+  async getConfigurationFile(filename: string): Promise<string> {
+    return this.service.GetConfigurationFile(filename);
+  }
+  protected errorCount = 0;
+
+  protected static async getModel<T>(service: Host) {
+    const files = await service.ListInputs();
+    const filename = files[0];
+    if (files.length === 0) {
+      throw new Error('Inputs missing.');
+    }
+    return {
+      filename,
+      model: deserialize<T>(await service.ReadFile(filename), filename)
+    };
+  }
+
+
+  cache!: Array<any>;
+  replacer(key: string, value: any) {
+    this.cache = this.cache || new Array<any>();
+
+    if (typeof value === 'object' && value !== null) {
+      if (this.cache.indexOf(value) !== -1) {
+        // Duplicate reference found
+        try {
+          // If this value does not reference a parent it can be deduped
+          return JSON.parse(JSON.stringify(value));
+        } catch (error) {
+          // discard key if value cannot be deduped
+          return;
+        }
+      }
+      // Store value in our collection
+      this.cache.push(value);
+    }
+    return value;
+  }
+
+  async resolveVariables(input: string): Promise<string> {
+    let output = input;
+    for (const rx of [/\$\((.*?)\)/g, /\$\{(.*?)\}/g]) {
+      /* eslint-disable */
+      for (let match; match = rx.exec(input);) {
+        const text = match[0];
+        const inner = match[1];
+        let value = await this.getValue<any>(inner, null);
+
+        if (value !== undefined && value !== null) {
+          if (typeof value === 'object') {
+            value = JSON.stringify(value, this.replacer, 2);
+          }
+          if (value === '{}') {
+            value = 'true';
+          }
+          output = output.replace(text, value);
+        }
+      }
+    }
+    return output;
+  }
+
+
+  public path(...childPath: JsonPath) {
+    // this strategy for tracking source path locations
+    // has proved fundementally crappy.
+
+    // will be removing this stuff and transitioning to source-track method.
+
+    //const result = new ModelState<T>(this.service, <any>this);
+    //result.currentPath = [...this.currentPath, ...childPath];
+    // return result;
+    return this;
+  }
+
+  public checkpoint() {
+    if (this.errorCount > 0) {
+      throw new Error();
+    }
+  }
+
+  protected msg(channel: Channel, message: string, key: Array<string>, details: any) {
+    this.message({
+      Channel: channel,
+      Key: key,
+      Source: [
+        {
+          document: this.documentName,
+          Position: {
+            path: this.currentPath
+          }
+        }
+      ],
+      Text: message,
+      Details: details
+    });
+  }
+
+  public warning(message: string, key: Array<string>, details?: any) {
+    this.msg(Channel.Warning, message, key, details);
+  }
+  public hint(message: string, key: Array<string>, details?: any) {
+    this.msg(Channel.Hint, message, key, details);
+  }
+
+  public error(message: string, key: Array<string>, details?: any) {
+    this.errorCount++;
+    this.msg(Channel.Error, message, key, details);
+  }
+  public fatal(message: string, key: Array<string>, details?: any) {
+    this.errorCount++;
+    this.msg(Channel.Fatal, message, key, details);
+  }
+
+  protected output(channel: Channel, message: string, details?: any) {
+    this.message({
+      Channel: channel,
+      Text: message,
+      Details: details
+    });
+  }
+
+  public debug(message: string, details: any) {
+    this.output(Channel.Debug, message, details);
+  }
+  public verbose(message: string, details: any) {
+    this.output(Channel.Verbose, message, details);
+  }
+  public log(message: string, details: any) {
+    this.output(Channel.Information, message, details);
+  }
+}

--- a/powershell/utils/programatic-operation.ts
+++ b/powershell/utils/programatic-operation.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ImplementationDetails, IOperation, IParameter, LanguageDetails } from './components';
+import { Extensions } from './extensions';
+import { Schema } from './schema';
+import { Dictionary } from '@azure-tools/linq';
+import { uid } from './uid';
+import { DeepPartial } from '@azure-tools/codegen';
+
+export interface ProgrammaticOperation extends IOperation<IParameter> {
+  responses: Dictionary<Dictionary<Schema>>;
+  pure: boolean; // side-effect free? May be helpful for deciding how to generate code.
+}
+
+export interface IntrinsicOperation extends ProgrammaticOperation {
+
+}
+
+export class IntrinsicOperation extends Extensions implements IntrinsicOperation {
+  public details: LanguageDetails<ProgramaticOperationDetails>;
+
+  public responses = new Dictionary<Dictionary<Schema>>();
+  public operationType: 'IntrinsicOperation' = 'IntrinsicOperation';
+
+  constructor(name: string, deprecated: boolean, pure: boolean, initializer?: DeepPartial<IntrinsicOperation>) {
+    super();
+    this.details = {
+      default: {
+        uid: `intrinsic-operation:${uid()}`,
+        description: initializer?.description || '',
+        name,
+      }
+    };
+    this.deprecated = deprecated;
+    this.pure = pure;
+
+    this.apply(initializer);
+  }
+}
+
+export interface ProgramaticOperationDetails extends ImplementationDetails {
+}

--- a/powershell/utils/programatic-operation.ts
+++ b/powershell/utils/programatic-operation.ts
@@ -5,7 +5,8 @@
 
 import { ImplementationDetails, IOperation, IParameter, LanguageDetails } from './components';
 import { Extensions } from './extensions';
-import { Schema } from './schema';
+//import { Schema } from './schema';
+import { Schema } from '@azure-tools/codemodel';
 import { Dictionary } from '@azure-tools/linq';
 import { uid } from './uid';
 import { DeepPartial } from '@azure-tools/codegen';

--- a/powershell/utils/resolve-conflicts.ts
+++ b/powershell/utils/resolve-conflicts.ts
@@ -1,0 +1,60 @@
+import { VirtualProperties } from './schema';
+import { VirtualParameters, VirtualParameter } from './command-operation';
+import { selectName } from '@azure-tools/codegen';
+import { values } from '@azure-tools/linq';
+
+export function resolvePropertyNames(reservedNames: Iterable<string>, virtualProperties: VirtualProperties) {
+  const usedNames = new Set(reservedNames);
+
+  const allProps = values(virtualProperties.owned, virtualProperties.inherited, virtualProperties.inlined).toArray();
+
+  for (const prop of allProps) {
+    if (usedNames.has(prop.name)) {
+      prop.name = selectName(prop.nameOptions, usedNames);
+    } else {
+      usedNames.add(prop.name);
+    }
+  }
+
+}
+
+export function resolveParameterNames(reservedNames: Iterable<string>, virtualParameters: VirtualParameters) {
+  const usedNames = new Set(reservedNames);
+  const collisions = new Set<VirtualParameter>();
+
+  // we need to make sure we avoid name collisions. operation parameters get first crack.
+  for (const each of values(virtualParameters.operation)) {
+    if (usedNames.has(each.name)) {
+      collisions.add(each);
+    } else {
+      usedNames.add(each.name);
+    }
+  }
+
+  // handle operation parameters
+  for (const each of collisions) {
+    each.name = selectName(each.nameOptions, usedNames);
+  }
+  collisions.clear();
+
+  // now do body parameters.
+  for (const each of values(virtualParameters.body)) {
+    if (usedNames.has(each.name)) {
+      collisions.add(each);
+    } else {
+      usedNames.add(each.name);
+    }
+  }
+
+  for (const each of collisions) {
+    each.name = selectName(each.nameOptions, usedNames);
+  }
+}
+
+export function allVirtualProperties(virtualProperties?: VirtualProperties) {
+  return virtualProperties ? values(virtualProperties.owned, virtualProperties.inherited, virtualProperties.inlined).toArray() : [];
+}
+
+export function allVirtualParameters(virtualParameters?: VirtualParameters) {
+  return virtualParameters ? values(virtualParameters.operation, virtualParameters.body).toArray() : [];
+}

--- a/powershell/utils/schema.ts
+++ b/powershell/utils/schema.ts
@@ -1,0 +1,296 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ExternalDocumentation, ImplementationDetails, LanguageDetails } from './components';
+import { Extensions } from './extensions';
+import { DeepPartial, } from '@azure-tools/codegen';
+import { Dictionary, values } from '@azure-tools/linq';
+import { uid } from './uid';
+
+export interface PropertyDetails extends ImplementationDetails {
+  required: boolean;
+  readOnly: boolean;
+}
+
+export interface EnumValue {
+  value: any;
+  description: string;
+  name: string;
+}
+
+export interface EnumDetails {
+  modelAsString: boolean;
+  values: Array<EnumValue>;
+  name: string;
+}
+
+export enum Purpose {
+  Header = 'Header',
+}
+
+export interface VirtualProperty {
+  /** The property that this represents */
+  property: Property;
+
+  /** The things that went into building the name */
+  nameComponents: Array<string>;
+
+  /** Names To use in priority order */
+  nameOptions: Array<string>;
+
+  /** the name of this virtual property */
+  name: string;
+
+  /** the member that should be called to get to the virtual property. (may be recursive) */
+  accessViaProperty?: VirtualProperty;
+
+  accessViaMember?: VirtualProperty;
+
+  /** the member's schema */
+  accessViaSchema?: Schema;
+
+  originalContainingSchema: Schema;
+
+  private?: boolean;
+
+  alias: Array<string>;
+
+  description: string;
+
+  format?: PropertyFormat;
+
+  required: boolean;
+
+  sharedWith?: Array<VirtualProperty>;
+}
+
+
+interface PropertyFormat {
+  suppressFormat?: boolean;
+  index?: number;
+  width?: number;
+  label?: string;
+}
+
+export interface VirtualProperties {
+  owned: Array<VirtualProperty>;
+  inherited: Array<VirtualProperty>;
+  inlined: Array<VirtualProperty>;
+}
+
+export interface SchemaDetails extends ImplementationDetails {
+  /** namespace of the implementation of this item */
+  namespace?: string;
+
+  enum?: EnumDetails;
+  purpose?: Purpose;
+  virtualProperties?: VirtualProperties;
+
+  /** if this is a child of a polymorphic class, this will have the value of the descriminator.  */
+  discriminatorValue?: string;
+
+  suppressFormat?: boolean;
+}
+
+export class Schema extends Extensions implements Schema {
+  public details: LanguageDetails<SchemaDetails>;
+  public required = new Array<string>();
+  public enum = new Array<any>();
+  public allOf = new Array<Schema>();
+  public oneOf = new Array<Schema>();
+  public anyOf = new Array<Schema>();
+  public properties = new Dictionary<Property>();
+  public extensions = new Dictionary<any>();
+
+  constructor(name: string, initializer?: DeepPartial<Schema>) {
+    super();
+    this.details = {
+      default: {
+        uid: `schema:${uid()}`,
+        description: '',
+        name
+      }
+    };
+    this.apply(initializer);
+  }
+}
+
+export function getPolymorphicBases(schema: Schema): Array<Schema> {
+  // are any of my parents polymorphic directly, or any of their parents?
+  return [...values(schema.allOf).where(parent => parent.discriminator ? true : false), ...values(schema.allOf).selectMany(getPolymorphicBases)];
+}
+
+export function getAllProperties(schema: Schema): Array<Property> {
+  return [...values(schema.allOf).selectMany(getAllProperties), ...values(schema.properties)];
+}
+
+export function getAllPublicVirtualProperties(virtualProperties?: VirtualProperties): Array<VirtualProperty> {
+  const props = virtualProperties || {
+    owned: [],
+    inherited: [],
+    inlined: []
+  };
+
+  return values(props.owned, props.inherited, props.inlined).where(each => !each.private).toArray();
+}
+
+export function getAllVirtualProperties(virtualProperties?: VirtualProperties): Array<VirtualProperty> {
+  const props = virtualProperties || {
+    owned: [],
+    inherited: [],
+    inlined: []
+  };
+
+  return values(props.owned, props.inherited, props.inlined).toArray();
+}
+
+export function getVirtualPropertyFromPropertyName(virtualProperties: VirtualProperties | undefined, propertyName: string): VirtualProperty | undefined {
+  const props = virtualProperties || {
+    owned: [],
+    inherited: [],
+    inlined: []
+  };
+  return values([...values(props.owned), ...values(props.inherited), ...values(props.inlined)]).first(each => each.property.serializedName === propertyName);
+}
+
+
+export interface Property extends Extensions {
+  details: LanguageDetails<PropertyDetails>;
+
+  /** description can be on the property reference, so that properties can have a description different from the type description. */
+  description?: string;
+
+  schema: Schema;
+}
+
+export class Property extends Extensions implements Property {
+  public serializedName: string;
+  public details: LanguageDetails<PropertyDetails>;
+  public extensions = new Dictionary<any>();
+
+  constructor(name: string, initializer?: DeepPartial<Property>) {
+    super();
+    this.serializedName = name;
+    this.details = {
+      default: {
+        readOnly: false,
+        uid: `property:${uid()}`,
+        description: initializer?.description || '',
+        name,
+        required: false
+      }
+    };
+    this.apply(initializer);
+  }
+}
+
+export class Discriminator extends Extensions implements Discriminator {
+  public extensions = new Dictionary<any>();
+  public mapping = new Dictionary<string>();
+
+  constructor(public propertyName: string, initializer?: DeepPartial<Discriminator>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export interface Discriminator extends Extensions {
+  propertyName: string;
+  mapping: Dictionary<string>;
+}
+
+export enum JsonType {
+  Array = 'array',
+  Boolean = 'boolean',
+  Integer = 'integer',
+  Number = 'number',
+  Object = 'object',
+  String = 'string'
+}
+
+export function isJsonType(type: JsonType, schema?: Schema): schema is Schema {
+  return schema ? schema.type === type : false;
+}
+
+export function isSchemaObject(schema?: Schema): schema is Schema {
+  return isJsonType(JsonType.Object, schema);
+}
+
+export class XML extends Extensions implements XML {
+  public extensions = new Dictionary<any>();
+  public attribute = false;
+  public wrapped = false;
+
+  constructor(initializer?: DeepPartial<XML>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export interface XML extends Extensions {
+  name?: string;
+  namespace?: string; // url
+  prefix?: string;
+  attribute: boolean;
+  wrapped: boolean;
+}
+
+export interface Schema extends Extensions {
+
+  details: LanguageDetails<SchemaDetails>;
+
+  /* common properties */
+  type?: JsonType;
+  title?: string;
+  description?: string;
+  format?: string;
+  nullable: boolean;
+  readOnly: boolean;
+  writeOnly: boolean;
+  deprecated: boolean;
+  required: Array<string>;
+
+  /* number restrictions */
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  exclusiveMinimum?: boolean;
+
+  /* string restrictions */
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string; // regex
+
+  /* array restrictions */
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+
+  /* object restrictions */
+  maxProperties?: number;
+  minProperties?: number;
+
+  /* unbounded properties */
+  example?: any;
+  default?: any;
+
+  /* Properties that are objects */
+  discriminator?: Discriminator;
+  externalDocs?: ExternalDocumentation;
+  xml?: XML;
+
+  /* Properties that are collections of things that are not references */
+  enum: Array<any>;
+
+  /* properties with potential references */
+  not?: Schema;
+  allOf: Array<Schema>;
+  oneOf: Array<Schema>;
+  anyOf: Array<Schema>;
+  items?: Schema;
+  properties: Dictionary<Property>;
+  additionalProperties?: boolean | Schema;
+}

--- a/powershell/utils/security-scheme.ts
+++ b/powershell/utils/security-scheme.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Extensions } from './extensions';
+import { ParameterLocation } from './http-operation';
+import { Dictionary } from '@azure-tools/linq';
+import { DeepPartial } from '@azure-tools/codegen';
+
+export enum Scheme {
+  Bearer = 'bearer'
+}
+export enum SecurityType {
+  ApiKey = 'apiKey',
+  Http = 'http',
+  OAuth2 = 'oauth2',
+  OpenIDConnect = 'openIdConnect'
+}
+
+export class APIKeySecurityScheme extends Extensions implements APIKeySecurityScheme {
+  extensions = new Dictionary<any>();
+
+  constructor(public name: string, inWhere: ParameterLocation, initializer?: DeepPartial<APIKeySecurityScheme>) {
+    super();
+    this.in = inWhere;
+    this.type = SecurityType.ApiKey;
+    this.apply(initializer);
+  }
+}
+
+export class BearerHTTPSecurityScheme extends Extensions implements BearerHTTPSecurityScheme {
+  extensions = new Dictionary<any>();
+  scheme = Scheme.Bearer;
+
+  constructor(initializer?: DeepPartial<BearerHTTPSecurityScheme>) {
+    super();
+    this.type = SecurityType.Http;
+    this.apply(initializer);
+  }
+}
+
+export class ImplicitOAuthFlow extends Extensions implements ImplicitOAuthFlow {
+  extensions = new Dictionary<any>();
+  scopes = new Dictionary<string>();
+
+  constructor(public authorizationUrl: string, initializer?: DeepPartial<ImplicitOAuthFlow>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export class NonBearerHTTPSecurityScheme extends Extensions implements NonBearerHTTPSecurityScheme {
+  extensions = new Dictionary<any>();
+
+  constructor(public scheme: string, initializer?: DeepPartial<NonBearerHTTPSecurityScheme>) {
+    super();
+    this.apply(initializer);
+    this.type = SecurityType.Http;
+  }
+}
+
+export class OAuth2SecurityScheme extends Extensions implements OAuth2SecurityScheme {
+  extensions = new Dictionary<any>();
+
+  constructor(public flows: OAuthFlows, initializer?: DeepPartial<OAuth2SecurityScheme>) {
+    super();
+    this.type = SecurityType.OAuth2;
+    this.apply(initializer);
+  }
+
+}
+
+export class OAuthFlows extends Extensions implements OAuthFlows {
+  extensions = new Dictionary<any>();
+
+  constructor(initializer?: DeepPartial<OAuthFlows>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export interface OpenIdConnectSecurityScheme extends Extensions {
+
+  type: SecurityType.OpenIDConnect;
+  openIdConnectUrl: string; // url
+  description?: string;
+}
+
+export class OpenIdConnectSecurityScheme extends Extensions implements OpenIdConnectSecurityScheme {
+  extensions = new Dictionary<any>();
+
+  constructor(public openIdConnectUrl: string, initializer?: DeepPartial<OpenIdConnectSecurityScheme>) {
+    super();
+    this.type = SecurityType.OpenIDConnect;
+    this.apply(initializer);
+  }
+}
+
+export interface PasswordOAuthFlow extends Extensions {
+
+  tokenUrl: string; // uriref
+  refreshUrl?: string; // uriref
+  scopes: Dictionary<string>;
+}
+
+export class PasswordOAuthFlow extends Extensions implements PasswordOAuthFlow {
+  extensions = new Dictionary<any>();
+  scopes = new Dictionary<string>();
+
+  constructor(public tokenUrl: string, initializer?: DeepPartial<PasswordOAuthFlow>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export type HTTPSecurityScheme = NonBearerHTTPSecurityScheme | BearerHTTPSecurityScheme;
+export type SecurityScheme =
+  APIKeySecurityScheme
+  | HTTPSecurityScheme
+  | OAuth2SecurityScheme
+  | OpenIdConnectSecurityScheme;
+
+export interface APIKeySecurityScheme extends Extensions {
+
+  type: SecurityType.ApiKey;
+  name: string;
+  in: ParameterLocation;
+  description?: string;
+}
+
+export class AuthorizationCodeOAuthFlow extends Extensions implements AuthorizationCodeOAuthFlow {
+  extensions = new Dictionary<any>();
+  scopes = new Dictionary<string>();
+  constructor(public authorizationUrl: string, tokenUrl: string, initializer?: DeepPartial<AuthorizationCodeOAuthFlow>) {
+    super();
+    this.apply(initializer);
+  }
+}
+export class ClientCredentialsFlow extends Extensions implements ClientCredentialsFlow {
+  extensions = new Dictionary<any>();
+  scopes = new Dictionary<string>();
+  constructor(public tokenUrl: string, initializer?: DeepPartial<ClientCredentialsFlow>) {
+    super();
+    this.apply(initializer);
+  }
+}
+
+export interface AuthorizationCodeOAuthFlow extends Extensions {
+  authorizationUrl: string; // uriref
+  tokenUrl: string; // uriref
+  refreshUrl?: string; // uriref
+  scopes: Dictionary<string>;
+}
+
+export interface BearerHTTPSecurityScheme extends Extensions {
+  scheme: Scheme.Bearer;
+  bearerFormat?: string;
+  type: SecurityType.Http;
+  description?: string;
+}
+
+export interface ClientCredentialsFlow extends Extensions {
+  tokenUrl: string; // uriref
+  refreshUrl?: string; // uriref
+  scopes: Dictionary<string>;
+}
+
+export interface ImplicitOAuthFlow extends Extensions {
+  authorizationUrl: string; // uriref
+  refreshUrl?: string; // uriref
+  scopes: Dictionary<string>;
+}
+
+export interface NonBearerHTTPSecurityScheme extends Extensions {
+  scheme: string;
+  description?: string;
+  type: SecurityType.Http;
+}
+
+export interface OAuth2SecurityScheme extends Extensions {
+  type: SecurityType.OAuth2;
+  flows: OAuthFlows;
+  description?: string;
+}
+
+export interface OAuthFlows extends Extensions {
+  implicit?: ImplicitOAuthFlow;
+  password?: PasswordOAuthFlow;
+  clientCredentials?: ClientCredentialsFlow;
+  authorizationCode?: AuthorizationCodeOAuthFlow;
+}

--- a/powershell/utils/uid.ts
+++ b/powershell/utils/uid.ts
@@ -1,0 +1,5 @@
+let n = 0;
+
+export function uid() {
+  return n++;
+}

--- a/samples/Xkcd/xkcd.yaml
+++ b/samples/Xkcd/xkcd.yaml
@@ -30,6 +30,7 @@ consumes:
   - application/json
   
 paths:
+
   /info.0.json:
     get:
       operationId: xkcd_getComicForToday
@@ -39,45 +40,5 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/comic'
-  '/{comicId}/info.0.json':
-    get:
-      operationId: xkcd_getComic
-      description: |
-        Fetch comics and metadata  by comic id.
-      parameters:
-        - in: path
-          name: comicId
-          required: true
-          type: number
-      responses:
-        '200':
-          description: OK
-          schema:
-            $ref: '#/definitions/comic'
-definitions:
-  comic:
-    properties:
-      alt:
-        type: string
-      day:
-        type: string
-      img:
-        type: string
-      link:
-        type: string
-      month:
-        type: string
-      news:
-        type: string
-      num:
-        type: number
-      safe_title:
-        type: string
-      title:
-        type: string
-      transcript:
-        type: string
-      year:
-        type: string
-    type: object
+            type: string
+  


### PR DESCRIPTION
There is still a block issue in the powershell-v2 plugin. So now actually it generates the c# SDK with modelerfour, and the powershell part with remodeler. Please try to generate the code with following command after going to the folder samples/Xkcd.

`autorest --input-file=.\xkcd.yaml --use:..\..\..\autorest.powershell`