### PR TITLE
fix some issues

### DIFF
--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -17,7 +17,7 @@ import { codemodel, PropertyDetails, exportedModels as T, ModelState, JsonType, 
 import { DeepPartial } from '@azure-tools/codegen';
 import { PwshModel } from '../utils/PwshModel';
 import { NewModelState } from '../utils/model-state';
-import { BooleanSchema, Schema as NewSchema, SchemaType } from '@azure-tools/codemodel';
+import { BooleanSchema, ConstantSchema, Schema as NewSchema, SchemaType } from '@azure-tools/codemodel';
 
 export type Schema = T.SchemaT<LanguageDetails<SchemaDetails>, LanguageDetails<PropertyDetails>>;
 
@@ -72,7 +72,7 @@ export class NewPSSchemaResolver extends NewSchemaDefinitionResolver {
     try {
       if (!this.inResolve) {
         this.inResolve = true;
-        if (schema && schema.type === SchemaType.Boolean) {
+        if (schema && (schema.type === SchemaType.Boolean || (schema.type === SchemaType.Constant && (<ConstantSchema>schema).valueType.type === SchemaType.Boolean))) {
           return new NewPSSwitch(<BooleanSchema>schema, required);
         }
       }

--- a/powershell/llcsharp/schema/date-time.ts
+++ b/powershell/llcsharp/schema/date-time.ts
@@ -11,7 +11,7 @@ import { OneOrMoreStatements } from '@azure-tools/codegen-csharp';
 import { Variable } from '@azure-tools/codegen-csharp';
 import { ClientRuntime } from '../clientruntime';
 import { Schema } from '../code-model';
-import { Schema as NewSchema, DateTimeSchema, UnixTimeSchema } from '@azure-tools/codemodel';
+import { Schema as NewSchema, DateTimeSchema, UnixTimeSchema, DateSchema } from '@azure-tools/codemodel';
 import { Primitive, NewPrimitive } from './primitive';
 
 export class DateTime extends Primitive {
@@ -183,7 +183,7 @@ export class NewDateTime extends NewPrimitive {
     }
     return (`/* serializeToContainerMember doesn't support '${mediaType}' ${__filename}*/`);
   }
-  constructor(schema: DateTimeSchema, public isRequired: boolean) {
+  constructor(schema: DateTimeSchema | DateSchema, public isRequired: boolean) {
     super(schema);
   }
   // public static string DateFormat = "yyyy-MM-dd";

--- a/powershell/llcsharp/schema/date.ts
+++ b/powershell/llcsharp/schema/date.ts
@@ -5,7 +5,7 @@
 
 import { StringExpression } from '@azure-tools/codegen-csharp';
 import { Schema } from '../code-model';
-import { Schema as NewSchema, DateTimeSchema } from '@azure-tools/codemodel';
+import { DateSchema } from '@azure-tools/codemodel';
 import { DateTime, NewDateTime } from './date-time';
 
 export class Date extends DateTime {
@@ -17,7 +17,7 @@ export class Date extends DateTime {
 
 export class NewDate extends NewDateTime {
   public DateTimeFormat = new StringExpression('yyyy-MM-dd');
-  constructor(schema: DateTimeSchema, isRequired: boolean) {
+  constructor(schema: DateSchema, isRequired: boolean) {
     super(schema, isRequired);
   }
 }

--- a/powershell/llcsharp/schema/schema-resolver.ts
+++ b/powershell/llcsharp/schema/schema-resolver.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { codeModelSchema, ArraySchema, CodeModel, Schema as NewSchema, StringSchema, BooleanSchema, NumberSchema, ByteArraySchema, DateTimeSchema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext, ConstantSchema, ChoiceSchema, DurationSchema } from '@azure-tools/codemodel';
+import { codeModelSchema, ArraySchema, CodeModel, Schema as NewSchema, StringSchema, BooleanSchema, NumberSchema, ByteArraySchema, DateTimeSchema, ObjectSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, VirtualParameter, getAllProperties, ImplementationLocation, OperationGroup, Request, SchemaContext, ConstantSchema, ChoiceSchema, DurationSchema, BinarySchema, DateSchema } from '@azure-tools/codemodel';
 
 import { ModelState, codemodel, IntegerFormat, NumberFormat, StringFormat, JsonType } from '@azure-tools/codemodel-v3';
 import { Schema } from '../code-model';
@@ -189,6 +189,8 @@ export class NewSchemaDefinitionResolver {
         return new NewString(<StringSchema>schema, required);
 
       }
+      case SchemaType.Binary:
+        return new NewBinary(<BinarySchema>schema, required);
       case SchemaType.Duration:
         return new NewDuration(<DurationSchema>schema, required);
       case SchemaType.Uuid:
@@ -198,6 +200,8 @@ export class NewSchemaDefinitionResolver {
           return new NewDateTime1123(<DateTimeSchema>schema, required);
         }
         return new NewDateTime(<DateTimeSchema>schema, required);
+      case SchemaType.Date:
+        return new NewDate(<DateSchema>schema, required);
       case SchemaType.ByteArray:
         return new NewByteArray(<ByteArraySchema>schema, required);
       case SchemaType.Boolean:
@@ -210,6 +214,7 @@ export class NewSchemaDefinitionResolver {
           // skip-for-time-being
           // case IntegerFormat.UnixTime:
           //   return new UnixTime(schema, required);
+          case 16:
           case 32:
             return new NewNumeric(<NumberSchema>schema, required, required ? 'int' : 'int?');
         }
@@ -229,18 +234,7 @@ export class NewSchemaDefinitionResolver {
         return new NewNumeric(<NumberSchema>schema, required, required ? 'float' : 'float?');
 
       case SchemaType.Constant:
-        switch ((<ConstantSchema>schema).valueType.type) {
-          case SchemaType.String:
-            return new NewEnumImplementation(<StringSchema>schema, required);
-          case SchemaType.DateTime:
-            if ((<any>schema).valueType.format === StringFormat.DateTimeRfc1123) {
-              return new NewDateTime1123(<DateTimeSchema>schema, required);
-            }
-            return new NewDateTime(<DateTimeSchema>schema, required);
-          default:
-            state.error(`Unsupported constant type. Schema '${schema.language.csharp?.name}' is declared with invalid type '${schema.type}'`, message.UnknownJsonType);
-            throw new Error('Unknown Model. Fatal.');
-        }
+        return this.resolveTypeDeclaration((<ConstantSchema>schema).valueType, required, state);
       case SchemaType.Choice: {
         const choiceSchema = schema as ChoiceSchema;
         if ((<any>choiceSchema.choiceType).type === SchemaType.DateTime && (<any>choiceSchema.choiceType).format === StringFormat.DateTimeRfc1123) {

--- a/powershell/models/model-extensions.ts
+++ b/powershell/models/model-extensions.ts
@@ -284,57 +284,6 @@ export class NewModelExtensionsNamespace extends Namespace {
           continue;
         }
 
-        if (schema.type === SchemaType.Dictionary) {
-          // xichen: 
-          // Case1: dictionary schema is only used in parents:
-          // "definitions": {
-          //   "PetAPInPropertiesWithAPString": {
-          //     "type": "object",
-          //       "properties": {
-          //       "id": {
-          //         "type": "integer"
-          //       }
-          //     },
-          //     "additionalProperties": {
-          //       "type": "string"
-          //     }
-          //   }
-          // } 
-          //
-          // Case2: we will have a dictionary property:
-          // "definitions": {
-          //   "PetAPInProperties": {
-          //     "type": "object",
-          //       "properties": {
-          //       "id": {
-          //         "type": "integer"
-          //       },
-          //       "additionalProperties": {
-          //         "type": "object",
-          //           "additionalProperties": {
-          //           "type": "number"
-          //         }
-          //       }
-          //     }
-          //   }
-          // }
-          //
-          // We only create model class for case 2, because in m3 case 2 will has independent scheam for additionalProperties, 
-          // But for case 1, PetAPInPropertiesWithAPString will only have additionalProperties.
-          //
-          // This is to make generated code same as m3. Actually there wont be side effect if we skip this check.
-          const objSchemas = schemas['objects'];
-          const usedByProp = schemas['objects']?.some((objSchema) => {
-            if ((<ObjectSchema>objSchema).properties?.some((prop) => prop.schema === schema)) {
-              return true;
-            }
-            return false;
-          });
-          if (!usedByProp) {
-            continue;
-          }
-        }
-
         const td = this.resolver.resolveTypeDeclaration(schema, true, state);
         if (td instanceof NewObjectImplementation) {
 

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -287,8 +287,8 @@ export /* @internal */ class Inferrer {
       }));
 
       // let's add a variant where it's expanded out.
-      // *IF* the body is an object
-      if (body.schema.type === SchemaType.Object) {
+      // *IF* the body is an object or dictionary
+      if (body.schema.type === SchemaType.Object || body.schema.type === SchemaType.Dictionary) {
         const opExpanded = await this.addCommandOperation(`${vname}Expanded`, parameters, operation, variant, state);
         opExpanded.details.default.dropBodyParameter = true;
         opExpanded.parameters.push(new IParameter(`${bodyParameterName}Body`, body.schema, {

--- a/powershell/plugins/cs-namer-v2.ts
+++ b/powershell/plugins/cs-namer-v2.ts
@@ -182,14 +182,14 @@ async function setOperationNames(state: State, resolver: NewSchemaDefinitionReso
 
       operation.language.csharp = {
         ...details, // inherit
-        name: getPascalIdentifier(operationName),
+        name: operationName,
       };
 
       // parameters are camelCased.
       for (const parameter of values(operation.parameters)) {
         const parameterDetails = parameter.language.default;
 
-        let propName = camelCase(fixLeadingNumber(deconstruct(parameterDetails.name)));
+        let propName = camelCase(fixLeadingNumber(deconstruct(parameterDetails.serializedName)));
 
         if (propName === 'default') {
           propName = '@default';

--- a/tests-upgrade/Configuration.json
+++ b/tests-upgrade/Configuration.json
@@ -37,7 +37,8 @@
     "extension-ms-paramlocation",
     "directive-aliasremoval",
     "directive-cmdlet",
-    "directive-parameter"
+    "directive-parameter",
+    "datamodels-datatypes-file"
   ],
   "BlackList": [
     "basic-get-querystr",


### PR DESCRIPTION
Add test datamodels-datatypes-file

We cannot enable following cases. They will make ci failed. But they are not blocking issues.
**1. For cases: datamodels-datatypes-boolean, datamodels-datatypes-date, datamodels-datatypes-byte**
a. comment in /* diff:
```
datamodels-datatype-boolean - \generated\api\DatabricksClient.cs
datamodels-datatypes-byte - \generated\api\DatabricksClient.cs
datemodels-datatypes-date - \generated\api\DatabricksClient.cs
```

b. Body parameter description is lost in m3:
`\generated\cmdlets\SetAzDatabricksByteNonAscii_Put.cs`

**2. For case: component-param-resourceasarraay**
a. For schema definied in response, m3 and m4 will use different name pattern. It's not visiable for user and won't block command execution
```
\generated\api\DatabricksClient.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct.dictionary.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct.json.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct.PowerShell.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct.TypeConverter.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct1.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct1.dictionary.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct1.json.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct1.PowerShell.cs
\generated\api\Models\Api20180401\DictionaryOfFlattenedProduct1.TypeConverter.cs
\generated\cmdlets\GetAzDatabricksDictionary_Get.cs
\generated\api\Models\Api20180401\Paths3P7DclAzureResourceFlattenDictionaryGetResponses200ContentApplicationJsonSchema.cs
\generated\api\Models\Api20180401\Paths3P7DclAzureResourceFlattenDictionaryGetResponses200ContentApplicationJsonSchema.dictionary.cs
\generated\api\Models\Api20180401\Paths3P7DclAzureResourceFlattenDictionaryGetResponses200ContentApplicationJsonSchema.json.cs
\generated\api\Models\Api20180401\Paths3P7DclAzureResourceFlattenDictionaryGetResponses200ContentApplicationJsonSchema.PowerShell.cs
\generated\api\Models\Api20180401\Paths3P7DclAzureResourceFlattenDictionaryGetResponses200ContentApplicationJsonSchema.TypeConverter.cs
\generated\api\Models\Api20180401\PathsLx8Sp0AzureResourceFlattenDictionaryPutRequestbodyContentApplicationJsonSchema.cs
\generated\api\Models\Api20180401\PathsLx8Sp0AzureResourceFlattenDictionaryPutRequestbodyContentApplicationJsonSchema.dictionary.cs
\generated\api\Models\Api20180401\PathsLx8Sp0AzureResourceFlattenDictionaryPutRequestbodyContentApplicationJsonSchema.json.cs
\generated\api\Models\Api20180401\PathsLx8Sp0AzureResourceFlattenDictionaryPutRequestbodyContentApplicationJsonSchema.PowerShell.cs
\generated\api\Models\Api20180401\PathsLx8Sp0AzureResourceFlattenDictionaryPutRequestbodyContentApplicationJsonSchema.TypeConverter.cs
\generated\cmdlets\SetAzDatabricksDictionary_PutExpanded.cs
```
b. Body parameter name has been changed by m4 (ResourceComplexObject - > resourceComplexObject). The original one is lost
```
\generated\cmdlets\SetAzDatabricksArray_Put.cs
\generated\cmdlets\SetAzDatabricksDictionary_Put.cs
\generated\cmdlets\SetAzDatabricksDictionary_PutExpanded.cs
```
c. Field order issue
```
\generated\api\Models\Api20180401\Resource.cs
\generated\api\Models\Api20180401\ResourceCollection.cs
```

**3. For case: component-param-specialproperties**
a. 'x-ms-skip-url-encoding' does not work in m3
`\generated\api\DatabricksClient.cs`
b. Parameter description depends on depends on load order. It should does not matter
` \generated\api\Models\DatabricksIdentity.cs`
c. Header description is lost in m4
```
\generated\api\Models\HeaderCustomNamedRequestIdHeadOkResponseHeaders.cs
\generated\api\Models\HeaderCustomNamedRequestIdOkResponseHeaders.cs
\generated\api\Models\HeaderCustomNamedRequestIdParamGroupingOkResponseHeaders.cs
```