### PR TITLE
skip content type request parameter

### DIFF
--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -10,6 +10,7 @@ modelerfour:
   emit-yaml-tags: false
   lenient-model-deduplication: true
   additional-checks: false
+  always-create-content-type-parameter: false
 ```
 
 > if the modeler is loaded already, use that one, otherwise grab it.

--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -348,13 +348,15 @@ export class NewOperationMethod extends Method {
     // add body paramter if there should be one.
     if (this.operation.requests && this.operation.requests.length && this.operation.requests[0].parameters && this.operation.requests[0].parameters.length) {
       // this request does have a request body.
-      const param = this.operation.requests[0].parameters[0];
-      this.bodyParameter = new NewOperationBodyParameter(this, 'body', param.language.default.description, param.schema, param.required ?? false, this.state, {
-        // TODO: temp solution. We need a class like NewKnowMediaType
-        mediaType: knownMediaType(KnownMediaType.Json),
-        contentType: KnownMediaType.Json
-      });
-      this.addParameter(this.bodyParameter);
+      const param = this.operation.requests[0].parameters.find((p) => !p.origin || p.origin.indexOf('modelerfour:synthesized') < 0);
+      if (param) {
+        this.bodyParameter = new NewOperationBodyParameter(this, 'body', param.language.default.description, param.schema, param.required ?? false, this.state, {
+          // TODO: temp solution. We need a class like NewKnowMediaType
+          mediaType: knownMediaType(KnownMediaType.Json),
+          contentType: KnownMediaType.Json
+        });
+        this.addParameter(this.bodyParameter);
+      }
     }
 
     for (const response of [...values(this.operation.responses), ...values(this.operation.exceptions)]) {

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -408,7 +408,7 @@ export /* @internal */ class Inferrer {
 
     // the body parameter
     // xichen: How to handle if has multiple requests?
-    const body = (operation.requests && operation.requests[0].parameters) ? operation.requests[0].parameters[0] : null;
+    const body = operation.requests?.[0].parameters?.find((p) => !p.origin || p.origin.indexOf('modelerfour:synthesized') < 0) || null;
     // skip-for-time-being, looks x-ms-requestBody-name is not supported any more
     //const bodyParameterName = (operation.requestBody && operation.requestBody.extensions) ? operation.requestBody.extensions['x-ms-requestBody-name'] || 'bodyParameter' : '';
     const bodyParameterName = body ? body.language.default.name : '';


### PR DESCRIPTION
To support multipart, m4 add new content parameter into request. We should skip this parameters