### PR TITLE
Fix ArgumentNullException when Generating without docs `-NoDocs` switch

### DIFF
--- a/powershell/resources/assets/build-module.ps1
+++ b/powershell/resources/assets/build-module.ps1
@@ -122,7 +122,7 @@ $null = New-Item -ItemType Directory -Force -Path $examplesFolder
 
 if($NoDocs) {
   Write-Host -ForegroundColor Green 'Creating exports...'
-  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ExcludeDocs
+  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ExcludeDocs -ExamplesFolder $examplesFolder
 } else {
   Write-Host -ForegroundColor Green 'Creating exports and docs...'
   $moduleDescription = '${$project.metadata.description}'

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         [ValidateNotNullOrEmpty]
         public string DocsFolder { get; set; }
 
+        [Parameter(Mandatory = true)]
         [ValidateNotNullOrEmpty]
         public string ExamplesFolder { get; set; }
 

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         [ValidateNotNullOrEmpty]
         public string DocsFolder { get; set; }
 
-        [Parameter(Mandatory = true, ParameterSetName = "Docs")]
         [ValidateNotNullOrEmpty]
         public string ExamplesFolder { get; set; }
 


### PR DESCRIPTION
Currently the code path below, throws `ArgumentNullException` when `Export-ProxyCmdlet` is invoked in the `-NoDocs` code path.
https://github.com/Azure/autorest.powershell/blob/f9b8e887b9787c1d21727a6db4f1095b2601b506/powershell/resources/assets/build-module.ps1#L123-L134
Exception is thrown here at `Path.Combine`, since `ExamplesFolder` will be null.
https://github.com/Azure/autorest.powershell/blob/6390998136582908155e819cc9393aa95bd2c33a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs#L76

***Solution***
Allow `ExamplesFolder` to be passed along for all param sets, since examples are already always generated. (Example Stubs).
https://github.com/Azure/autorest.powershell/blob/6390998136582908155e819cc9393aa95bd2c33a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs#L45-L47
Pass along `-ExamplesFolder` since its required in all code paths.