### PR TITLE
Fix ArgumentNullException when Generating without docs `-NoDocs` switch

### DIFF
--- a/powershell/resources/assets/build-module.ps1
+++ b/powershell/resources/assets/build-module.ps1
@@ -122,7 +122,7 @@ $null = New-Item -ItemType Directory -Force -Path $examplesFolder
 
 if($NoDocs) {
   Write-Host -ForegroundColor Green 'Creating exports...'
-  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ExcludeDocs
+  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ExcludeDocs -ExamplesFolder $examplesFolder
 } else {
   Write-Host -ForegroundColor Green 'Creating exports and docs...'
   $moduleDescription = '${$project.metadata.description}'

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         [ValidateNotNullOrEmpty]
         public string DocsFolder { get; set; }
 
-        [Parameter(Mandatory = true, ParameterSetName = "Docs")]
+        [Parameter(Mandatory = true)]
         [ValidateNotNullOrEmpty]
         public string ExamplesFolder { get; set; }
 


### PR DESCRIPTION
…ch (#711)

* Fix ArgumentNullException when Generating without docs `-NoDocs` features.
Pass along `-ExamplesFolder` since its required in all code paths.

* Make examples mandatory, for all paramsets

Co-authored-by: George Ndungu <gendungu@microsoft.com>