### PR TITLE
throw undelaredResponseException when LRO

### DIFF
--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -475,21 +475,24 @@ export class CallMethod extends Method {
 // if we got back an OK, take a peek inside and see if it's done
 if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
 {
+    var error = false;
     try {
         if( ${ClientRuntime.JsonNode.Parse(toExpression(`await ${response.value}.Content.ReadAsStringAsync()`))} is ${ClientRuntime.JsonObject} json)
         {
             var state = json.Property("properties")?.PropertyT<${ClientRuntime.JsonString}>("provisioningState") ?? json.PropertyT<${ClientRuntime.JsonString}>("status");
             if( state is null ) 
             {
-              // the body doesn't contain any information that has the state of the LRO
-              // we're going to just get out, and let the consumer have the result
-              break;
+                // the body doesn't contain any information that has the state of the LRO
+                // we're going to just get out, and let the consumer have the result
+                break;
             }
 
             switch( state?.ToString()?.ToLower() )
             {
-              case "succeeded":
               case "failed":
+                  error = true;
+                  break;
+              case "succeeded":
               case "canceled":
                 // we're done polling.
                 break;
@@ -503,6 +506,9 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
     } catch {
         // if we run into a problem peeking into the result, 
         // we really don't want to do anything special.
+    }
+    if (error) {
+        throw new ${ClientRuntime.fullName}.UndeclaredResponseException(${response.value});
     }
 }`;
 

--- a/powershell/resources/runtime/csharp/client/UndeclaredResponseException.cs
+++ b/powershell/resources/runtime/csharp/client/UndeclaredResponseException.cs
@@ -42,8 +42,13 @@ namespace Microsoft.Rest.ClientRuntime
                 // try to parse the body as JSON, and see if a code and message are in there.
                 var json = Microsoft.Rest.ClientRuntime.Json.JsonNode.Parse(ResponseBody) as Microsoft.Rest.ClientRuntime.Json.JsonObject;
 
+                // error message could be in properties.statusMessage
+                { message = If(json?.Property("properties"), out var p)
+                    && If(p?.PropertyT<Microsoft.Rest.ClientRuntime.Json.JsonString>("statusMessage"), out var sm)
+                    ? (string)sm : (string)Message; }
+
                 // see if there is an error block in the body
-                json = json.Property("error") ?? json;
+                json = json?.Property("error") ?? json;
 
                 { Code = If(json?.PropertyT<Microsoft.Rest.ClientRuntime.Json.JsonString>("code"), out var c) ? (string)c : (string)StatusCode.ToString(); }
                 { message = If(json?.PropertyT<Microsoft.Rest.ClientRuntime.Json.JsonString>("message"), out var m) ? (string)m : (string)Message; }


### PR DESCRIPTION
fix https://github.com/Azure/autorest.powershell/issues/580
fix https://github.com/Azure/autorest.powershell/issues/613

During long running operation polling, if state is failed, throw an exception with message from `error` or `properties.statusMessage`.