### PR TITLE
Provide flag to exclude `.Notes` section from ProxyCmdletDefinitions.ps1

### DIFF
--- a/powershell/resources/assets/build-module.ps1
+++ b/powershell/resources/assets/build-module.ps1
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------------
-param([switch]$Isolated, [switch]$Run, [switch]$Test, [switch]$Docs, [switch]$Pack, [switch]$Code, [switch]$Release, [switch]$Debugger, [switch]$NoDocs)
+param([switch]$Isolated, [switch]$Run, [switch]$Test, [switch]$Docs, [switch]$Pack, [switch]$Code, [switch]$Release, [switch]$Debugger, [switch]$NoDocs, [switch]$ExcludeExampleTemplates, [switch] $ExcludeNotesSection)
 $ErrorActionPreference = 'Stop'
 
 if($PSEdition -ne 'Core') {
@@ -131,7 +131,7 @@ if($NoDocs) {
     $null = Get-ChildItem -Path $docsFolder -Recurse -Exclude 'readme.md' | Remove-Item -Recurse -ErrorAction SilentlyContinue
   }
   $null = New-Item -ItemType Directory -Force -Path $docsFolder
-  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ModuleDescription $moduleDescription -DocsFolder $docsFolder -ExamplesFolder $examplesFolder -ModuleGuid $guid
+  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ModuleDescription $moduleDescription -DocsFolder $docsFolder -ExamplesFolder $examplesFolder -ModuleGuid $guid -ExcludeExampleTemplates:$ExcludeExampleTemplates -ExcludeNotesSection:$ExcludeNotesSection
 }
 
 Write-Host -ForegroundColor Green 'Creating format.ps1xml...'

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         [Parameter(Mandatory = true, ParameterSetName = "NoDocs")]
         public SwitchParameter ExcludeDocs { get; set; }
 
+        [Parameter(Mandatory = false, ParameterSetName = "Docs")]
+        public SwitchParameter ExcludeExampleTemplates { get; set; }
+
+        [Parameter(Mandatory = false, ParameterSetName = "Docs")]
+        public SwitchParameter ExcludeNotesSection { get; set; }
+
         protected override void ProcessRecord()
         {
           try {
@@ -97,13 +103,13 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 # limitations under the License.
 # ----------------------------------------------------------------------------------
 ");
-                sb.Append($"{Environment.NewLine}");
-                sb.Append(variantGroup.ToHelpCommentOutput());
-                sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
-                sb.Append(variantGroup.Aliases.ToAliasOutput());
-                sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
-                sb.Append(variantGroup.ToCmdletBindingOutput());
-                sb.Append(variantGroup.ProfileName.ToProfileOutput());
+                    sb.Append($"{Environment.NewLine}");
+                    sb.Append(variantGroup.ToHelpCommentOutput(ExcludeExampleTemplates, ExcludeNotesSection));
+                    sb.Append($"function {variantGroup.CmdletName} {{{Environment.NewLine}");
+                    sb.Append(variantGroup.Aliases.ToAliasOutput());
+                    sb.Append(variantGroup.OutputTypes.ToOutputTypeOutput());
+                    sb.Append(variantGroup.ToCmdletBindingOutput());
+                    sb.Append(variantGroup.ProfileName.ToProfileOutput());
 
                 sb.Append("param(");
                 sb.Append($"{(parameterGroups.Any() ? Environment.NewLine : String.Empty)}");


### PR DESCRIPTION
Provide flag `-ExcludeNoteSection` to control writing of `.Notes` section into `ProxyCmdletDefinitions.ps1`.
Refer user to use `Get-Help -Online`.
This reduce module bloat.
![image](https://user-images.githubusercontent.com/1641829/128094035-2116c3c4-3690-4f2a-b2a6-7850e6835320.png)

cc. @maisarissi, @peombwa, @shemogumbe