### PR TITLE
Improvement for test, #789 and #788

### DIFF
--- a/powershell/resources/assets/test-module.ps1
+++ b/powershell/resources/assets/test-module.ps1
@@ -11,14 +11,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ----------------------------------------------------------------------------------
-param([switch]$Isolated, [switch]$Live, [switch]$Record, [switch]$Playback, [switch]$RegenerateSupportModule)
+param([switch]$Isolated, [switch]$Live, [switch]$Record, [switch]$Playback, [switch]$RegenerateSupportModule, [switch]$UsePreviousConfigForRecord, [string[]]$TestName)
 $ErrorActionPreference = 'Stop'
 
-if(-not $Isolated) {
+if(-not $Isolated)
+{
   Write-Host -ForegroundColor Green 'Creating isolated process...'
+  if ($PSBoundParameters.ContainsKey("TestName")) {
+    $PSBoundParameters["TestName"] = $PSBoundParameters["TestName"] -join ","
+  }
   $pwsh = [System.Diagnostics.Process]::GetCurrentProcess().Path
   & "$pwsh" -NonInteractive -NoLogo -NoProfile -File $MyInvocation.MyCommand.Path @PSBoundParameters -Isolated
   return
+}
+
+# This is a workaround, since for string array parameter, pwsh -File will only take the first element
+if ($PSBoundParameters.ContainsKey("TestName") -and ($TestName.count -eq 1) -and ($TestName[0].Contains(','))) {
+  $TestName = $TestName[0].Split(",")
 }
 
 $ProgressPreference = 'SilentlyContinue'
@@ -27,7 +36,8 @@ $requireResourceModule = (($baseName -ne "Resources") -and ($Record.IsPresent -o
 . (Join-Path $PSScriptRoot 'check-dependencies.ps1') -Isolated -Accounts:$false -Pester -Resources:$requireResourceModule -RegenerateSupportModule:$RegenerateSupportModule
 . ("$PSScriptRoot\test\utils.ps1")
 
-if ($requireResourceModule) {
+if ($requireResourceModule)
+{
   # Load the latest Az.Accounts installed
   Import-Module -Name Az.Accounts -RequiredVersion (Get-Module -Name Az.Accounts -ListAvailable | Sort-Object -Property Version -Descending)[0].Version
   $resourceModulePSD = Get-Item -Path (Join-Path $HOME '.PSSharedModules\Resources\Az.Resources.TestSupport.psd1')
@@ -35,7 +45,8 @@ if ($requireResourceModule) {
 }
 
 $localModulesPath = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFolder, $project.dependencyModuleFolder)}'
-if(Test-Path -Path $localModulesPath) {
+if(Test-Path -Path $localModulesPath)
+{
   $env:PSModulePath = "$localModulesPath$([IO.Path]::PathSeparator)$env:PSModulePath"
 }
 
@@ -47,22 +58,34 @@ Import-Module -Name Pester
 Import-Module -Name $modulePath
 
 $TestMode = 'playback'
-if($Live) {
+$ExcludeTag = @("LiveOnly")
+if($Live)
+{
   $TestMode = 'live'
+  $ExcludeTag = @()
 }
-if($Record) {
+if($Record)
+{
   $TestMode = 'record'
 }
-try {
-  if ($TestMode -ne 'playback') {
+try
+{
+  if ($TestMode -ne 'playback')
+  {
     setupEnv
   }
   $testFolder = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFolder, $project.testFolder)}'
-  Invoke-Pester -Script @{ Path = $testFolder } -EnableExit -OutputFile (Join-Path $testFolder "$moduleName-TestResults.xml")
-}
-Finally
+  if ($null -ne $TestName)
+  {
+    Invoke-Pester -Script @{ Path = $testFolder } -TestName $TestName -ExcludeTag $ExcludeTag -EnableExit -OutputFile (Join-Path $testFolder "$moduleName-TestResults.xml")
+  } else
+  {
+    Invoke-Pester -Script @{ Path = $testFolder } -ExcludeTag $ExcludeTag -EnableExit -OutputFile (Join-Path $testFolder "$moduleName-TestResults.xml")
+  }
+} Finally
 {
-  if ($TestMode -ne 'playback') {
+  if ($TestMode -ne 'playback')
+  {
     cleanupEnv
   }
 }

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportTestStub.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportTestStub.cs
@@ -57,6 +57,13 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
     }
 }
 $env = @{}
+if ($UsePreviousConfigForRecord) {
+    $previousEnv = Get-Content (Join-Path $PSScriptRoot 'env.json') | ConvertFrom-Json
+    $previousEnv.psobject.properties | Foreach-Object { $env[$_.Name] = $_.Value }
+}
+# Add script method called AddWithCache to $env, when useCache is set true, it will try to get the value from the $env first.
+# example: $val = $env.AddWithCache('key', $val, $true)
+$env | Add-Member -Type ScriptMethod -Value { param( [string]$key, [object]$val, [bool]$useCache) if ($this.Contains($key) -and $useCache) { return $this[$key] } else { $this[$key] = $val; return $val } } -Name 'AddWithCache'
 function setupEnv() {
     # Preload subscriptionId and tenant from context, which will be used in test
     # as default. You could change them if needed.
@@ -94,20 +101,24 @@ function cleanupEnv() {
           foreach (var variantGroup in variantGroups)
           {
             var sb = new StringBuilder();
-            sb.AppendLine(@"$loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
-if (-Not (Test-Path -Path $loadEnvPath)) {
-    $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
-}
-. ($loadEnvPath)"
+            sb.AppendLine($"if(($null -eq $TestName) -or ($TestName -contains '{variantGroup.CmdletName}'))");
+            sb.AppendLine(@"{
+  $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
+  if (-Not (Test-Path -Path $loadEnvPath)) {
+      $loadEnvPath = Join-Path $PSScriptRoot '..\loadEnv.ps1'
+  }
+  . ($loadEnvPath)"
 );
-            sb.AppendLine($@"$TestRecordingFile = Join-Path $PSScriptRoot '{variantGroup.CmdletName}.Recording.json'");
-            sb.AppendLine(@"$currentPath = $PSScriptRoot
-while(-not $mockingPath) {
-    $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
-    $currentPath = Split-Path -Path $currentPath -Parent
+            sb.AppendLine(@"  $TestRecordingFile = Join-Path $PSScriptRoot '{variantGroup.CmdletName}.Recording.json'");
+            sb.AppendLine(@"  $currentPath = $PSScriptRoot
+  while(-not $mockingPath) {
+      $mockingPath = Get-ChildItem -Path $currentPath -Recurse -Include 'HttpPipelineMocking.ps1' -File
+      $currentPath = Split-Path -Path $currentPath -Parent
+  }
+  . ($mockingPath | Select-Object -First 1).FullName
 }
-. ($mockingPath | Select-Object -First 1).FullName
 ");
+
 
             sb.AppendLine($"Describe '{variantGroup.CmdletName}' {{");
             var variants = variantGroup.Variants


### PR DESCRIPTION
# Live Only Test

```powershell
Describe 'New-AzDatabricksWorkspace' -Tag 'LiveOnly'{
}
```

# Run Specific Test Cases

```powershell
./test-module.ps1 -TestName Get-AzDatabricksWorkspace,new-AzDatabricksWorkspace
```

# Record Specific Test Cases

```powershell
# -UsePreviousConfigForRecord
# When this switch is turned on, we will try to use values defined in env.json instead of randomly
# generating them 
./test-module.ps1 -TestName Get-AzDatabricksWorkspace,new-AzDatabricksWorkspace -Record -UsePreviousConfigForRecord
```

## Required Code Change to Support Recording Specific Cases

### Change #1

**Previous**

```powershell
$null = $env.Add("rstr5", $rstr5)
```

**Now**

```powershell
$rstr5 = $env.AddWithCache("rstr5", $rstr5, $UsePreviousConfigForRecord)
```

Or

Use following if some values are generated in service side.

```powershell
$rstr5 = $env.AddWithCache("rstr5", $rstr5, $false)
```

### Change #2

Add following **if** clause in the header of each test script which ends with .Tests.ps1. And you should replace 'Get-AzDatabricksVNetPeering' with the name in your test **Describe**.

```powershell
if (($null -eq $TestName) -or ($TestName -contains 'Get-AzDatabricksVNetPeering')) {
    $loadEnvPath = Join-Path $PSScriptRoot 'loadEnv.ps1'
		.....
		. ($mockingPath | Select-Object -First 1).FullName
}
```

# Limitations When Supporting Recording Specific Cases

## Subscription can not be changed

Solutions:

- Full record
- After partial recording, replace the old subscription Id with the new one

### Some data is generated in service side

For data like this, we can not use the previous one in env.json.