### PR TITLE
Add initial support for data plane

### DIFF
--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -90,6 +90,8 @@ export class Project extends codeDomProject {
   public license!: string;
   public cmdletFolder!: string;
   public modelCmdletFolder!: string;
+  public endpointKeyName!: string;
+  public endpointSuffixKeyName!: string;
 
   public customFolder!: string;
   public utilsFolder!: string;
@@ -201,6 +203,11 @@ export class Project extends codeDomProject {
     this.subjectPrefix = this.model.language.default.subjectPrefix;
     this.moduleName = await this.state.getValue('module-name');
     this.dllName = await this.state.getValue('dll-name');
+    // Azure PowerShell data plane configuration
+    if (this.azure) {
+      this.endpointKeyName = await this.state.getValue('endpoint-key-name', '');
+      this.endpointSuffixKeyName = await this.state.getValue('endpoint-suffix-key-name', '');
+    }
 
     // Folders
     this.baseFolder = await this.state.getValue('current-folder');

--- a/powershell/llcsharp/model/namespace.ts
+++ b/powershell/llcsharp/model/namespace.ts
@@ -99,6 +99,8 @@ export class ModelsNamespace extends Namespace {
 
         const ns = this.subNamespaces[fullname] || this.add(new ApiVersionNamespace(fullname));
 
+        ns.header = this.state.project.license;
+
         const mc = schema.language.csharp?.classImplementation || new ModelClass(ns, td, <State>this.state, { description: schema.language.csharp?.description });
 
         // this gets implicity created during class creation:

--- a/powershell/models/model-extensions.ts
+++ b/powershell/models/model-extensions.ts
@@ -69,6 +69,7 @@ export class ModelExtensionsNamespace extends Namespace {
           const fullname = schema.language.csharp?.namespace || this.fullName;
           const ns = this.subNamespaces[fullname] || this.add(new ApiVersionModelExtensionsNamespace(this.outputFolder, fullname));
 
+          ns.header = this.state.project.license;
           // create the model extensions for each object model
           // 2. A partial interface with the type converter attribute
           const modelInterface = new Interface(ns, interfaceName, {


### PR DESCRIPTION
For dataplane, following two configurations are required in readme.md.
```
endpoint-key-name: "AppConfigurationEndpointResourceId"
endpoint-suffix-key-name: "AppConfigurationEndpointSuffix"
```

And besides, users could implement `partial void CustomInit()` in their custom code to add a `tokenaudienceconverter` and assign it to `_tokenAudienceConverter  `