### PR TITLE
Add support for client side pagination

### DIFF
--- a/powershell/cmdlets/namespace.ts
+++ b/powershell/cmdlets/namespace.ts
@@ -22,6 +22,7 @@ export class CmdletNamespace extends Namespace {
 
   async init() {
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
+    this.add(new ImportDirective(`System`));
 
     // generate cmdlet classes on top of the SDK
     for (const { key: index, value: operation } of items(this.state.model.commands.operations)) {

--- a/powershell/plugins/modifiers-v2.ts
+++ b/powershell/plugins/modifiers-v2.ts
@@ -64,6 +64,7 @@ interface WhereCommandDirective {
       description: string;
       script: string;
     };
+    'clientside-pagination'?: boolean;
   };
   'clear-alias': boolean;
   hide?: boolean;
@@ -289,6 +290,7 @@ async function tweakModel(state: State): Promise<PwshModel> {
       const paramDescriptionReplacer = (directive.set !== undefined) ? directive.set['parameter-description'] : undefined;
       const paramCompleterReplacer = (directive.set !== undefined) ? directive.set['completer'] : undefined;
       const paramDefaultReplacer = (directive.set !== undefined) ? directive.set['default'] : undefined;
+      const cliensidePagination = (directive.set !== undefined) ? directive.set['clientside-pagination'] : undefined;
 
       // select all operations
       let operations: Array<CommandOperation> = values(state.model.commands.operations).toArray();
@@ -425,6 +427,10 @@ See https://github.com/Azure/autorest.powershell/blob/main/docs/directives.md#de
           const newVerb = operation.details.csharp.verb;
           const newVariantName = operation.details.csharp.name;
           const newCommandName = getCmdletName(newVerb, newSubjectPrefix, newSubject, newVariantName);
+
+          if (cliensidePagination) {
+            operation.details.csharp.clientsidePagination = cliensidePagination;
+          }
           if (breakingChange) {
             operation.details.csharp.breakingChange = operation.details.csharp.breakingChange ? operation.details.csharp.breakingChange : <any>{}
             if (variantRegex) {

--- a/powershell/resources/psruntime/AsyncCommandRuntime.cs
+++ b/powershell/resources/psruntime/AsyncCommandRuntime.cs
@@ -38,6 +38,10 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             this.originalThread = System.Threading.Thread.CurrentThread;
             this.cancellationToken = cancellationToken;
             this.cmdlet = cmdlet;
+            if (cmdlet.PagingParameters != null)
+            {
+                WriteDebug("Client side pagination is enabled for this cmdlet");
+            }
             cmdlet.CommandRuntime = this;
         }
 

--- a/powershell/resources/psruntime/BuildTime/MarkdownRenderer.cs
+++ b/powershell/resources/psruntime/BuildTime/MarkdownRenderer.cs
@@ -53,13 +53,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                         sb.Append(parameter.ToHelpParameterOutput());
                     }
                 }
-                if (markdownInfo.SupportsPaging)
-                {
-                    foreach (var parameter in SupportsPagingParameters)
-                    {
-                        sb.Append(parameter.ToHelpParameterOutput());
-                    }
-                }
 
                 sb.Append($"### CommonParameters{Environment.NewLine}This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).{Environment.NewLine}{Environment.NewLine}");
 

--- a/powershell/resources/psruntime/BuildTime/Models/PsMarkdownTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsMarkdownTypes.cs
@@ -132,10 +132,6 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             {
                 parameterStrings = parameterStrings.Append(" [-Confirm]").Append(" [-WhatIf]");
             }
-            if (Variant.SupportsPaging)
-            {
-                parameterStrings = parameterStrings.Append(" [-First <UInt64>]").Append(" [-IncludeTotalCount]").Append(" [-Skip <UInt64>]");
-            }
             parameterStrings = parameterStrings.Append(" [<CommonParameters>]");
 
             var lines = new List<string>(20);

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
@@ -468,12 +468,21 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         {
             var parameters = variant.Metadata.Parameters.AsEnumerable();
             var parameterHelp = variant.HelpInfo.Parameters.AsEnumerable();
+
             if (variant.HasParameterSets)
             {
                 parameters = parameters.Where(p => p.Value.ParameterSets.Keys.Any(k => k == variant.VariantName || k == AllParameterSets));
-                parameterHelp = parameterHelp.Where(ph => !ph.ParameterSetNames.Any() || ph.ParameterSetNames.Any(psn => psn == variant.VariantName || psn == AllParameterSets));
+                parameterHelp = parameterHelp.Where(ph => (!ph.ParameterSetNames.Any() || ph.ParameterSetNames.Any(psn => psn == variant.VariantName || psn == AllParameterSets)) && ph.Name != "IncludeTotalCount");
             }
-            return parameters.Select(p => new Parameter(variant.VariantName, p.Key, p.Value, parameterHelp.FirstOrDefault(ph => ph.Name == p.Key))).ToArray();
+            var result = parameters.Select(p => new Parameter(variant.VariantName, p.Key, p.Value, parameterHelp.FirstOrDefault(ph => ph.Name == p.Key)));
+            if (variant.SupportsPaging) {
+                // If supportsPaging is set, we will need to add First and Skip parameters since they are treated as common parameters which as not contained on Metadata>parameters
+                variant.Info.Parameters["First"].Attributes.OfType<ParameterAttribute>().FirstOrDefault(pa => pa.ParameterSetName == variant.VariantName || pa.ParameterSetName == AllParameterSets).HelpMessage = "Gets only the first 'n' objects.";
+                variant.Info.Parameters["Skip"].Attributes.OfType<ParameterAttribute>().FirstOrDefault(pa => pa.ParameterSetName == variant.VariantName || pa.ParameterSetName == AllParameterSets).HelpMessage = "Ignores the first 'n' objects and then gets the remaining objects.";
+                result = result.Append(new Parameter(variant.VariantName, "First", variant.Info.Parameters["First"], parameterHelp.FirstOrDefault(ph => ph.Name == "First")));
+                result = result.Append(new Parameter(variant.VariantName, "Skip", variant.Info.Parameters["Skip"], parameterHelp.FirstOrDefault(ph => ph.Name == "Skip")));
+            }
+            return result.ToArray();
         }
 
         public static Attribute[] ToAttributes(this Variant variant) => variant.IsFunction

--- a/powershell/resources/runtime/csharp/client/Extensions.cs
+++ b/powershell/resources/runtime/csharp/client/Extensions.cs
@@ -5,9 +5,15 @@
 namespace Microsoft.Rest.ClientRuntime
 {
     using System.Linq;
+    using System;
 
     internal static partial class Extensions
     {
+        public static T[] SubArray<T>(this T[] array, int offset, int length)
+        {
+            return new ArraySegment<T>(array, offset, length)
+                        .ToArray();
+        }
 
         public static T ReadHeaders<T>(this T instance, global::System.Net.Http.Headers.HttpResponseHeaders headers) where T : class
         {


### PR DESCRIPTION
Related issue is https://github.com/Azure/autorest.powershell/issues/253.
To support client side pagination, normally there are two steps need to be done.

1. If the skip or first/top have been supported by service, these parameters should be removed from swagger through autorest transform directive
2.  Client side pagination is enabled through directive on cmdlet/variant level. And following is an example.
```
  - where:
      verb: Get
      variant: ^List(.*)
    set:
      clientside-pagination: true  
```