### PR TITLE
Prevent redundant model generation

### DIFF
--- a/powershell/plugins/cs-namer-v2.ts
+++ b/powershell/plugins/cs-namer-v2.ts
@@ -62,6 +62,9 @@ function setSchemaNames(schemaGroups: Dictionary<Array<Schema>>, azure: boolean,
 
   for (const group of values(schemaGroups)) {
     for (const schema of group) {
+      if (schema.language.default.skip) {
+        continue;
+      }
       let thisNamespace = baseNamespace;
       let thisApiversion = '';
 

--- a/powershell/plugins/plugin-tweak-m4-model.ts
+++ b/powershell/plugins/plugin-tweak-m4-model.ts
@@ -130,7 +130,9 @@ function addDictionaryApiVersion(model: CodeModel) {
         if (parent.type !== SchemaType.Dictionary || parent.apiVersions) {
           continue;
         }
-        parent.apiVersions = JSON.parse(JSON.stringify(schema.apiVersions));
+        // for object which both contains properties and additional properties, 
+        // we need to skip the model generation for redundant dict.
+        parent.language.default.skip = true;
       }
     }
   })


### PR DESCRIPTION
If an object both contains properties and additionalproperties, there will be a redundant model class generated, And this change is to fix it.