### PR TITLE
Add --pwsh-license-header to set license for generated powershell code

### DIFF
--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -63,17 +63,7 @@ export async function generatePsm1(project: Project) {
     }
     azureInitialize = `
   # ----------------------------------------------------------------------------------
-  #
-  # Copyright Microsoft Corporation
-  # Licensed under the Apache License, Version 2.0 (the "License");
-  # you may not use this file except in compliance with the License.
-  # You may obtain a copy of the License at
-  # http://www.apache.org/licenses/LICENSE-2.0
-  # Unless required by applicable law or agreed to in writing, software
-  # distributed under the License is distributed on an "AS IS" BASIS,
-  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  # See the License for the specific language governing permissions and
-  # limitations under the License.
+  ${project.pwshCommentHeader}
   # ----------------------------------------------------------------------------------
   # Load required Az.Accounts module
   $accountsName = 'Az.Accounts'

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -9,12 +9,13 @@ import { State } from './state';
 import { Project as codeDomProject } from '@azure-tools/codegen-csharp';
 import { EnumNamespace } from '../enums/namespace';
 import { ModelExtensionsNamespace } from '../models/model-extensions';
+import { pwshHeaderText } from '../utils/powershell-comment';
 
 import { ModuleNamespace } from '../module/module-namespace';
 import { CmdletNamespace } from '../cmdlets/namespace';
 import { Host } from '@azure-tools/autorest-extension-base';
 import { codemodel, PropertyDetails, exportedModels as T } from '@azure-tools/codemodel-v3';
-import { DeepPartial } from '@azure-tools/codegen';
+import { DeepPartial, comment } from '@azure-tools/codegen';
 import { PwshModel } from '../utils/PwshModel';
 import { ModelState } from '../utils/model-state';
 import { BooleanSchema, ChoiceSchema, ConstantSchema, Schema as NewSchema, SchemaType } from '@azure-tools/codemodel';
@@ -88,6 +89,8 @@ export class Project extends codeDomProject {
   public azure!: boolean;
   public addToString!: boolean;
   public license!: string;
+  public pwshCommentHeader!: string;
+  public pwshCommentHeaderForCsharp!: string;
   public cmdletFolder!: string;
   public modelCmdletFolder!: string;
   public endpointResourceIdKeyName!: string;
@@ -185,6 +188,10 @@ export class Project extends codeDomProject {
     this.metadata = await this.state.getValue<Metadata>('metadata');
     this.preprocessMetadata();
     this.license = await this.state.getValue('header-text', '');
+    var pwshLicenseHeader = await this.state.getValue('pwsh-license-header', '');
+    // if pwsh license header is not set, use the license set by license-header
+    this.pwshCommentHeader = comment(!!pwshLicenseHeader ? pwshHeaderText(pwshLicenseHeader, await this.service.GetValue('header-definitions')) : this.license, '#');
+    this.pwshCommentHeaderForCsharp = this.pwshCommentHeader.replace(/"/g, '""');
 
     // modelcmdlets are models that we will create cmdlets for.
     this.modelCmdlets = [];

--- a/powershell/resources/assets/build-module.ps1
+++ b/powershell/resources/assets/build-module.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 param([switch]$Isolated, [switch]$Run, [switch]$Test, [switch]$Docs, [switch]$Pack, [switch]$Code, [switch]$Release, [switch]$Debugger, [switch]$NoDocs)
 $ErrorActionPreference = 'Stop'

--- a/powershell/resources/assets/check-dependencies.ps1
+++ b/powershell/resources/assets/check-dependencies.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 param([switch]$Isolated, [switch]$Accounts, [switch]$Pester, [switch]$Resources)
 $ErrorActionPreference = 'Stop'

--- a/powershell/resources/assets/create-model-cmdlets.ps1
+++ b/powershell/resources/assets/create-model-cmdlets.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 
 function CreateModelCmdlet {
@@ -112,57 +102,47 @@ function CreateModelCmdlet {
                 }
                 $ParameterDefineProperty = [System.String]::Join(", ", $ParameterDefinePropertyList)
                 $ParameterDefineScript = "
-            [Parameter($ParameterDefineProperty)]
-            [${Type}]
-            `$${Identifier}"
+        [Parameter($ParameterDefineProperty)]
+        [${Type}]
+        `$${Identifier}"
                 $ParameterDefineScriptList.Add($ParameterDefineScript)
                 $ParameterAssignScriptList.Add("
-            `$Object.${Identifier} = `$${Identifier}")
+        `$Object.${Identifier} = `$${Identifier}")
             }
         }
         $ParameterDefineScript = $ParameterDefineScriptList | Join-String -Separator ","
         $ParameterAssignScript = $ParameterAssignScriptList | Join-String -Separator ""
 
         $Script = "
-    # ----------------------------------------------------------------------------------
-    #
-    # Copyright Microsoft Corporation
-    # Licensed under the Apache License, Version 2.0 (the \`"License\`");
-    # you may not use this file except in compliance with the License.
-    # You may obtain a copy of the License at
-    # http://www.apache.org/licenses/LICENSE-2.0
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an \`"AS IS\`" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
-    # ----------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------
+${$project.pwshCommentHeaderForCsharp}
+# ----------------------------------------------------------------------------------
 
-    <#
-    .Synopsis
-    Create a in-memory object for ${ObjectType}
-    .Description
-    Create a in-memory object for ${ObjectType}
+<#
+.Synopsis
+Create a in-memory object for ${ObjectType}
+.Description
+Create a in-memory object for ${ObjectType}
 
-    .Outputs
-    ${ObjectTypeWithNamespace}
-    .Link
-    ${$project.helpLinkPrefix}az.${ModuleName}/new-Az${ModulePrefix}${ObjectType}Object
-    #>
-    function New-Az${ModulePrefix}${ObjectType}Object {
-        [OutputType('${ObjectTypeWithNamespace}')]
-        [CmdletBinding(PositionalBinding=`$false)]
-        Param(
-    ${ParameterDefineScript}
-        )
+.Outputs
+${ObjectTypeWithNamespace}
+.Link
+${$project.helpLinkPrefix}az.${ModuleName}/new-Az${ModulePrefix}${ObjectType}Object
+#>
+function New-Az${ModulePrefix}${ObjectType}Object {
+    [OutputType('${ObjectTypeWithNamespace}')]
+    [CmdletBinding(PositionalBinding=`$false)]
+    Param(
+${ParameterDefineScript}
+    )
 
-        process {
-            `$Object = [${ObjectTypeWithNamespace}]::New()
-    ${ParameterAssignScript}
-            return `$Object
-        }
+    process {
+        `$Object = [${ObjectTypeWithNamespace}]::New()
+${ParameterAssignScript}
+        return `$Object
     }
-    "
+}
+"
         Set-Content -Path $OutputPath -Value $Script
     }
 }

--- a/powershell/resources/assets/export-surface.ps1
+++ b/powershell/resources/assets/export-surface.ps1
@@ -1,15 +1,5 @@
 ﻿# ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 param([switch]$Isolated, [switch]$IncludeGeneralParameters, [switch]$UseExpandedFormat)
 $ErrorActionPreference = 'Stop'

--- a/powershell/resources/assets/generate-help.ps1
+++ b/powershell/resources/assets/generate-help.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 param([switch]$Isolated)
 $ErrorActionPreference = 'Stop'

--- a/powershell/resources/assets/pack-module.ps1
+++ b/powershell/resources/assets/pack-module.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 Write-Host -ForegroundColor Green 'Packing module...'
 dotnet pack $PSScriptRoot --no-build /nologo

--- a/powershell/resources/assets/run-module.ps1
+++ b/powershell/resources/assets/run-module.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 param([switch]$Isolated, [switch]$Code)
 $ErrorActionPreference = 'Stop'

--- a/powershell/resources/assets/test-module.ps1
+++ b/powershell/resources/assets/test-module.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 param([switch]$Isolated, [switch]$Live, [switch]$Record, [switch]$Playback, [switch]$RegenerateSupportModule, [switch]$UsePreviousConfigForRecord, [string[]]$TestName)
 $ErrorActionPreference = 'Stop'

--- a/powershell/resources/assets/test/loadEnv.ps1
+++ b/powershell/resources/assets/test/loadEnv.ps1
@@ -1,15 +1,5 @@
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeader}
 # ----------------------------------------------------------------------------------
 $envFile = 'env.json'
 if ($TestMode -eq 'live') {

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -73,17 +73,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 var license = new StringBuilder();
                 license.Append(@"
 # ----------------------------------------------------------------------------------
-#
-# Copyright Microsoft Corporation
-# Licensed under the Apache License, Version 2.0 (the ""License"");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an ""AS IS"" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+${$project.pwshCommentHeaderForCsharp}
 # ----------------------------------------------------------------------------------
 ");
                 HashSet<string> LicenseSet = new HashSet<string>();

--- a/powershell/utils/powershell-comment.ts
+++ b/powershell/utils/powershell-comment.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function pwshHeaderText(type: string, definitions: any): string {
+    switch (type.toLowerCase()) {
+
+        case "microsoft_mit_no_version":
+            return `${definitions.microsoft}\n${definitions.mit}\n${definitions["no-version"]}\n${definitions.warning}`;
+
+        case "microsoft_apache_no_version":
+            return `${definitions.microsoft}\n${definitions.apache}\n${definitions["no-version"]}${definitions.warning}`;
+
+        case "microsoft_apache_no_codegen":
+            return `${definitions.microsoft}\n${definitions.mit}\n${definitions["no-version"]}`;
+
+        case "none":
+            return "";
+
+        case "microsoft_mit_small_no_codegen":
+            return `${definitions.microsoft}\n${definitions["mit-small"]}\n${definitions["no-version"]}`;
+
+        default:
+            // if none is matched, we will assume type is the license content
+            return `${type}`;
+    }
+}


### PR DESCRIPTION
Add `--pwsh-license-header` to set license header for generated powershell code.
If `--pwsh-license-header` is not set, `--license-header` is applied.
And magic words for this setting include:
- microsoft_mit_no_version
- microsoft_apache_no_version
- microsoft_apache_no_codegen
- microsoft_mit_small_no_codegen