### PR TITLE
Add a configuration for users to exclude properties from table view

### DIFF
--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -113,6 +113,7 @@ export class Project extends codeDomProject {
   public nuspec!: string;
   public gitIgnore!: string;
   public gitAttributes!: string;
+  public propertiesExcludedForTableview!: string;
   public readme!: string;
   public dllName!: string;
   public dll!: string;
@@ -249,6 +250,10 @@ export class Project extends codeDomProject {
     this.gitIgnore = `${this.baseFolder}/.gitignore`;
     this.gitAttributes = `${this.baseFolder}/.gitattributes`;
     this.readme = `${this.baseFolder}/readme.md`;
+
+    // excluded properties in table view
+    const excludedList = <Array<string>>values(<any>(await this.state.getValue('exclude-tableview-properties', []))).toArray();
+    this.propertiesExcludedForTableview = excludedList ? excludedList.join(',') : '';
 
     // add project namespace
     this.serviceNamespace = new ModuleNamespace(this.state);

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportFormatPs1xml.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportFormatPs1xml.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
     private const string ModelNamespace = @"${$project.modelsExtensions.fullName}";
     private const string SupportNamespace = @"${$project.supportNamespace.fullName}";
+    private const string PropertiesExcludedForTableview = @"${$project.propertiesExcludedForTableview}";
+
     private static readonly bool IsAzure = Convert.ToBoolean(@"${$project.azure}");
 
     protected override void ProcessRecord()
@@ -55,7 +57,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
       return types.Select(t => new ViewParameters(t, t.GetProperties()
           .Select(p => new PropertyFormat(p))
           .Where(pf => !pf.Property.GetCustomAttributes<DoNotFormatAttribute>().Any()
-                       && (!IsAzure || pf.Property.Name != "Id")
+                       && (!PropertiesExcludedForTableview.Split(',').Contains(pf.Property.Name))
                        && (pf.FormatTable != null || (pf.Origin != PropertyOrigin.Inlined && pf.Property.PropertyType.IsPsSimple())))
           .OrderByDescending(pf => pf.Index.HasValue)
           .ThenBy(pf => pf.Index)


### PR DESCRIPTION
1. Remove hardcode excluded property Id for Azure services
2. Add a configuration for users to exclude properties from table view

> Following is an example
``` yaml $(default-exclude-tableview-properties)
exclude-tableview-properties:
  - Id
  - Type
```