### PR TITLE
Serialize `DictionaryEntry` types as value types

### DIFF
--- a/powershell/resources/runtime/csharp/json/Customizations/IJsonSerializable.cs
+++ b/powershell/resources/runtime/csharp/json/Customizations/IJsonSerializable.cs
@@ -75,10 +75,16 @@ namespace Microsoft.Rest.ClientRuntime
                 return new JsonBoolean(bValue);
             }
 
-            // dates 
+            // dates
             if (vValue is DateTime dtValue)
             {
                 return new JsonDate(dtValue);
+            }
+
+            // DictionaryEntity struct type
+            if (vValue is System.Collections.DictionaryEntry deValue)
+            {
+                return new JsonObject { { deValue.Key.ToString(), ToJsonValue(deValue.Value) } };
             }
 
             // sorry, no idea.
@@ -113,7 +119,7 @@ namespace Microsoft.Rest.ClientRuntime
             // if we got something out, let's use it.
             if (null != jsonValue)
             {
-                // JsonNumber is really a literal json value. Just don't try to cast that back to an actual number, ok? 
+                // JsonNumber is really a literal json value. Just don't try to cast that back to an actual number, ok?
                 return new JsonNumber(jsonValue.ToString());
             }
 
@@ -127,7 +133,7 @@ namespace Microsoft.Rest.ClientRuntime
         /// <returns>the serialized JsonNode (if successful), otherwise, <c>null</c></returns>
         internal static JsonNode ToJsonValue(object value)
         {
-            // things that implement our interface are preferred. 
+            // things that implement our interface are preferred.
             if (value is Microsoft.Rest.ClientRuntime.IJsonSerializable jsonSerializable)
             {
                 return jsonSerializable.ToJson();
@@ -139,7 +145,7 @@ namespace Microsoft.Rest.ClientRuntime
                 return new JsonString(value.ToString());
             }
 
-            // value types are fairly straightforward (fallback to ToJson()/ToJsonString() or literal JsonString ) 
+            // value types are fairly straightforward (fallback to ToJson()/ToJsonString() or literal JsonString )
             if (value is System.ValueType vValue)
             {
                 return ToJsonValue(vValue) ?? TryToJsonValue(vValue) ?? new JsonString(vValue.ToString());
@@ -159,7 +165,7 @@ namespace Microsoft.Rest.ClientRuntime
                 return Microsoft.Rest.ClientRuntime.JsonSerializable.ToJson(dict, null);
             }
 
-            // enumerable collections are handled like arrays (again, fallback to ToJson()/ToJsonString() or literal JsonString) 
+            // enumerable collections are handled like arrays (again, fallback to ToJson()/ToJsonString() or literal JsonString)
             if (value is System.Collections.IEnumerable enumerableValue)
             {
                 // some kind of enumerable value
@@ -185,7 +191,7 @@ namespace Microsoft.Rest.ClientRuntime
             {
                 foreach (var key in dictionary)
                 {
-                    // currently, we don't serialize null values. 
+                    // currently, we don't serialize null values.
                     if (null != key.Value)
                     {
                         container.Add(key.Key, ToJsonValue(key.Value));


### PR DESCRIPTION
This PR closes https://github.com/Azure/autorest.powershell/issues/867 by ensuring we fully serialize `DictionaryEntry` types into JSON. [DictionaryEntry](https://docs.microsoft.com/en-us/dotnet/api/system.collections.dictionaryentry?view=net-5.0) is a struct and should be serialized when handling value types.