### PR TITLE
Use synopsis in module page

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Models/PsHelpMarkdownOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsHelpMarkdownOutputs.cs
@@ -141,7 +141,7 @@ Locale: en-US
         }
 
         public override string ToString() => $@"### [{HelpInfo.CmdletName}]({HelpInfo.CmdletName}.md)
-{HelpInfo.Description.ToDescriptionFormat()}
+{HelpInfo.Synopsis.ToDescriptionFormat()}
 
 ";
     }


### PR DESCRIPTION
Fixed https://github.com/Azure/autorest.powershell/issues/871, should use synopsis instead of description in module page