### PR TITLE
Add support for wildcard response code supported in oas 3

### DIFF
--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -338,13 +338,15 @@ export class CallMethod extends Method {
 
           // add response handlers
           yield Switch(`${response}.StatusCode`, function* () {
-            for (const responses of [...values(opMethod.operation.responses), ...values(opMethod.operation.exceptions)]) {
-              if (responses.protocol.http?.statusCodes[0] !== 'default') {
-                const responseCode = responses.protocol.http?.statusCodes[0];
+            var responses = [...values(opMethod.operation.responses), ...values(opMethod.operation.exceptions)].sort(function (a, b) { return (<string>(a.protocol.http?.statusCodes[0])).localeCompare(<string>(b.protocol.http?.statusCodes[0]))});
+            for (const resp of responses) {
+              if (resp.protocol.http?.statusCodes[0] !== 'default') {
+                const responseCode = resp.protocol.http?.statusCodes[0];
+                var leadNum = parseInt(responseCode[0]);
                 // will use enum when it can, fall back to casting int when it can't
-                yield Case(System.Net.HttpStatusCode[responseCode] ? System.Net.HttpStatusCode[responseCode].value : `(${System.Net.HttpStatusCode.declaration})${responseCode}`, $this.responsesEmitter($this, opMethod, [responses], eventListener));
+                yield Case(System.Net.HttpStatusCode[responseCode] ? System.Net.HttpStatusCode[responseCode].value : `${System.Net.HttpStatusCode.declaration} n when((int)n >= ${leadNum * 100} && (int)n < ${leadNum * 100 + 100})`, $this.responsesEmitter($this, opMethod, [resp], eventListener));
               } else {
-                yield DefaultCase($this.responsesEmitter($this, opMethod, [responses], eventListener));
+                yield DefaultCase($this.responsesEmitter($this, opMethod, [resp], eventListener));
               }
             }
 

--- a/powershell/resources/psruntime/BuildTime/Models/PsMarkdownTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsMarkdownTypes.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public MarkdownHelpInfo(VariantGroup variantGroup, string examplesFolder, string externalHelpFilename = "")
         {
             ExternalHelpFilename = externalHelpFilename;
-            ModuleName = variantGroup.ModuleName;
+            ModuleName = variantGroup.RootModuleName != "" ? variantGroup.RootModuleName : variantGroup.ModuleName;
             var helpInfo = variantGroup.HelpInfo;
             var commentInfo = variantGroup.CommentInfo;
             Schema = Version.Parse("2.0.0");


### PR DESCRIPTION
This change is to support wildcard response status supported in OAS 3 as blelow.
> Any HTTP status code can be used as the property name, but only one property per code, to describe the expected response for that HTTP status code. A Reference Object can link to a response that is defined in the OpenAPI Object's components/responses section. This field MUST be enclosed in quotation marks (for example, "200") for compatibility between JSON and YAML. To define a range of response codes, this field MAY contain the uppercase wildcard character X. For example, 2XX represents all response codes between [200-299]. Only the following range definitions are allowed: 1XX, 2XX, 3XX, 4XX, and 5XX. If a response is defined using an explicit code, the explicit code definition takes precedence over the range definition for that code.