### PR TITLE
Fixed an issue caused by details: null is set in examples of swagger

### DIFF
--- a/powershell/plugins/ps-namer-v2.ts
+++ b/powershell/plugins/ps-namer-v2.ts
@@ -55,7 +55,7 @@ async function tweakModel(state: State): Promise<PwshModel> {
 
   // make sure recursively that every details field has csharp
   for (const { index, instance } of linq.visitor(state.model)) {
-    if ((index === 'details' || index === 'language') && instance.default && !instance.csharp) {
+    if ((index === 'details' || index === 'language') && instance && instance.default && !instance.csharp) {
       instance.csharp = linq.clone(instance.default, false, undefined, undefined, ['schema', 'origin']);
     }
   }


### PR DESCRIPTION
The swagger that triggers this issue is as https://github.com/Azure/azure-rest-api-specs/blob/main/specification/guestconfiguration/resource-manager/Microsoft.GuestConfiguration/stable/2020-06-25/examples/listAllGuestConfigurationAssignmentReports.json#L51.