### PR TITLE
Add support for response of primitive type

### DIFF
--- a/powershell/llcsharp/schema/primitive.ts
+++ b/powershell/llcsharp/schema/primitive.ts
@@ -160,6 +160,11 @@ export abstract class NewPrimitive implements EnhancedTypeDeclaration {
 
   /** emits an expression to deserialize content from a content/response */
   deserializeFromResponse(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    switch (mediaType) {
+      case KnownMediaType.Json:
+        return toExpression(`${content}.Content.ReadAsStringAsync().ContinueWith( body => (${this.baseType}) global::System.Convert.ChangeType(body.Result, typeof(${this.baseType})))`);
+
+    }
     return toExpression(`null /* deserializeFromResponse doesn't support '${mediaType}' ${__filename}*/`);
   }
 

--- a/powershell/plugins/ps-namer-v2.ts
+++ b/powershell/plugins/ps-namer-v2.ts
@@ -55,7 +55,7 @@ async function tweakModel(state: State): Promise<PwshModel> {
 
   // make sure recursively that every details field has csharp
   for (const { index, instance } of linq.visitor(state.model)) {
-    if ((index === 'details' || index === 'language') && instance.default && !instance.csharp) {
+    if ((index === 'details' || index === 'language') && instance && instance.default && !instance.csharp) {
       instance.csharp = linq.clone(instance.default, false, undefined, undefined, ['schema', 'origin']);
     }
   }


### PR DESCRIPTION
Some rest API will return a primitive type like integer, bool instead of a json object. And this change is for that. And  https://github.com/Azure/autorest.powershell/issues/892 is one of the cases.