### PR TITLE
Correct bad format in XML comments

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1130,9 +1130,9 @@ export class CmdletClass extends Class {
       initialValue: new LiteralExpression(`new ${System.Threading.CancellationTokenSource.declaration}()`),
       description: `The <see cref="${System.Threading.CancellationTokenSource}" /> for this operation.`
     }));
-    this.add(new LambdaProperty(`${ClientRuntime.IEventListener}.Token`, System.Threading.CancellationToken, new LiteralExpression(`${cts.value}.Token`), { getAccess: Access.Default, setAccess: Access.Default, description: '<see cref="IEventListener" /> cancellation token.' }));
+    this.add(new LambdaProperty(`${ClientRuntime.IEventListener}.Token`, System.Threading.CancellationToken, new LiteralExpression(`${cts.value}.Token`), { getAccess: Access.Default, setAccess: Access.Default, description: `<see cref="${ClientRuntime}.IEventListener" /> cancellation token.` }));
     this.cancellationToken = toExpression(`((${ClientRuntime.IEventListener})this).Token`);
-    this.add(new LambdaProperty(`${ClientRuntime.IEventListener}.Cancel`, System.Action(), new LiteralExpression(`${cts.value}.Cancel`), { getAccess: Access.Default, setAccess: Access.Default, description: '<see cref="IEventListener" /> cancellation delegate. Stops the cmdlet when called.' }));
+    this.add(new LambdaProperty(`${ClientRuntime.IEventListener}.Cancel`, System.Action(), new LiteralExpression(`${cts.value}.Cancel`), { getAccess: Access.Default, setAccess: Access.Default, description: `<see cref="${ClientRuntime}.IEventListener" /> cancellation delegate. Stops the cmdlet when called.` }));
 
     const id = new Parameter('id', dotnet.String, { description: 'The message id' });
     const token = new Parameter('token', System.Threading.CancellationToken, { description: 'The message cancellation token. When this call is cancelled, this should be <c>true</c>' });

--- a/powershell/llcsharp/model/model-class.ts
+++ b/powershell/llcsharp/model/model-class.ts
@@ -368,7 +368,7 @@ export class ModelClass extends Class implements EnhancedTypeDeclaration {
         async: Modifier.Async,
         parameters: [this.validationEventListener],
         description: 'Validates that this object meets the validation criteria.',
-        returnsDescription: `A < see cref = "${System.Threading.Tasks.Task()}" /> that will be complete when validation is completed.`
+        returnsDescription: `A <see cref = "${System.Threading.Tasks.Task()}" /> that will be complete when validation is completed.`
       }));
       this.validateMethod.add(this.validationStatements);
     }

--- a/powershell/models/model-extensions.ts
+++ b/powershell/models/model-extensions.ts
@@ -112,7 +112,7 @@ export class ModelExtensionsNamespace extends Namespace {
             static: Modifier.Static,
             parameters: [new Parameter('jsonText', dotnet.String, { description: 'a string containing a JSON serialized instance of this model.' })],
             description: `Creates a new instance of <see cref="${td.schema.language.csharp?.name}" />, deserializing the content from a json string.`,
-            returnsDescription: 'an instance of the <see cref="className" /> model class.'
+            returnsDescription: `an instance of the <see cref="${className}" /> model class.`
           }));
 
           model.add(new LambdaMethod('ToJsonString', dotnet.String, new LiteralExpression(`ToJson(${dotnet.Null}, ${ClientRuntime.SerializationMode.IncludeAll})?.ToString()`), {
@@ -201,7 +201,7 @@ export class ModelExtensionsNamespace extends Namespace {
             parameters: [
               new Parameter('sourceValue', dotnet.Dynamic, { description: `the <see cref="System.Object" /> instance to check if it can be converted to the <see cref="${className}" /> type.` }),
             ],
-            description: 'Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" /> parameter.',
+            description: `Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="${className}" type/>.`,
             returnsDescription: `<c>true</c> if the instance could be converted to a <see cref="${className}" /> type, otherwise <c>false</c> `
           })).add(function* () {
             yield If('null == sourceValue', Return(dotnet.True));


### PR DESCRIPTION
- The space in tag < see> should be removed.
```
/// A < see cref = "global::System.Threading.Tasks.Task" /> that will be complete when validation is completed.
->
/// A <see cref = "global::System.Threading.Tasks.Task" /> that will be complete when validation is completed.
```

See https://github.com/Azure/autorest.powershell/issues/842
- <paramref name="destinationType" /> should be removed from
```
/// <summary>
/// Determines if the converter can convert the <see cref="sourceValue"/> parameter to the <see cref="destinationType" />
/// parameter.
/// </summary>
public static bool CanConvertFrom(dynamic sourceValue)
 {}
```

- Full namespace
```
<see cref="IEventListener" />
 -> 
<see cref="Microsoft.Azure.PowerShell.Cmdlets.ADDomainServices.Runtime.IEventListener" />
```

- Replace placeholder
```
<see cref="className" />
 -> 
<see cref="IAdDomainServicesIdentity" />
```
