### PR TITLE
Add support to specify the version manually

### DIFF
--- a/.scripts/publish.yaml
+++ b/.scripts/publish.yaml
@@ -24,7 +24,12 @@ steps:
     npx @microsoft/rush update 
 
     # set the actual package versions and update again
-    npx @microsoft/rush set-versions
+    if [ "$(skipSetVersion)" == "false" ]
+    then
+      npx @microsoft/rush set-versions
+    else
+      echo "Use the version set in package.json"
+    fi
     npx @microsoft/rush sync-versions
     npx @microsoft/rush update 
 


### PR DESCRIPTION
The change is needed by the azure pipeline so that we could use the version from the package.json directly.