### PR TITLE
Fix an issue when users run 'foreach-object -Parallel'

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             {
                 return $@"
 {Indent}{Indent}if ($null -eq [Microsoft.WindowsAzure.Commands.Utilities.Common.AzurePSCmdlet]::PowerShellVersion) {{
-{Indent}{Indent}{Indent}[Microsoft.WindowsAzure.Commands.Utilities.Common.AzurePSCmdlet]::PowerShellVersion = $Host.Runspace.Version.ToString()
+{Indent}{Indent}{Indent}[Microsoft.WindowsAzure.Commands.Utilities.Common.AzurePSCmdlet]::PowerShellVersion = $Host.Version.ToString()
 {Indent}{Indent}}}         
 {Indent}{Indent}$preTelemetryId = [Microsoft.WindowsAzure.Commands.Common.MetricHelper]::TelemetryId
 {Indent}{Indent}if ($preTelemetryId -eq '') {{


### PR DESCRIPTION
The root cause is when users run `foreach-object -Parallel`, $Host.Runspace.Version will be null.