### PR TITLE
Fixed two minor issues - single quote related and uri.tostring related

### DIFF
--- a/powershell/resources/psruntime/BuildTime/PsHelpers.cs
+++ b/powershell/resources/psruntime/BuildTime/PsHelpers.cs
@@ -39,9 +39,10 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public static IEnumerable<FunctionInfo> GetScriptCmdlets(PSCmdlet cmdlet, string scriptFolder)
         {
             // https://stackoverflow.com/a/40969712/294804
+            var wrappedFolder = scriptFolder.Contains("'") ? $@"""{scriptFolder}""" : $@"'{scriptFolder}'";
             var getCmdletsCommand = $@"
 $currentFunctions = Get-ChildItem function:
-Get-ChildItem -Path '{scriptFolder}' -Recurse -Include '*.ps1' -File | ForEach-Object {{ . $_.FullName }}
+Get-ChildItem -Path {wrappedFolder} -Recurse -Include '*.ps1' -File | ForEach-Object {{ . $_.FullName }}
 Get-ChildItem function: | Where-Object {{ ($currentFunctions -notcontains $_) -and $_.CmdletBinding }}
 ";
             return cmdlet?.RunScript<FunctionInfo>(getCmdletsCommand) ?? RunScript<FunctionInfo>(getCmdletsCommand);

--- a/powershell/resources/runtime/csharp/pipeline/PipelineMocking.cs
+++ b/powershell/resources/runtime/csharp/pipeline/PipelineMocking.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Rest.ClientRuntime
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, IEventListener callback, ISendAsync next)
         {
             counter++;
-            var rqkey = $"{Description}+{Context}+{Scenario}+${request.Method.Method}+{request.RequestUri}+{counter}";
+            var rqkey = $"{Description}+{Context}+{Scenario}+${request.Method.Method}+{request.RequestUri.AbsoluteUri}+{counter}";
 
             switch (Mode)
             {

--- a/powershell/resources/runtime/csharp/pipeline/PipelineMocking.cs
+++ b/powershell/resources/runtime/csharp/pipeline/PipelineMocking.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Rest.ClientRuntime
         public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, IEventListener callback, ISendAsync next)
         {
             counter++;
-            var rqkey = $"{Description}+{Context}+{Scenario}+${request.Method.Method}+{request.RequestUri.AbsoluteUri}+{counter}";
+            var rqkey = $"{Description}+{Context}+{Scenario}+${request.Method.Method}+{request.RequestUri}+{counter}";
 
             switch (Mode)
             {


### PR DESCRIPTION
In .net framework 4 which is used by Windows PowerShell, uri.tostring function will un-escaped %2B to plus(+). 