### PR TITLE
Initial support to add cmdlet parameters through directive

### DIFF
--- a/powershell/utils/command-operation.ts
+++ b/powershell/utils/command-operation.ts
@@ -56,6 +56,8 @@ export interface VirtualParameter {
   alias: Array<string>;
   completerInfo?: CompleterInfo;
   hidden?: boolean;
+  // for cmdlet parameter added through a directive, we should add the type. 
+  type?: string;
 }
 
 export class CommandOperation extends Extensions implements CommandOperation {


### PR DESCRIPTION
The directive to add a parameter should be as below.
```
- where:
	subject: subject-name
	variant: variant-name
  add:
	parameters:
	   - name: name
	     type: string
	     required: true
             completer:
                 name: xxx
                 description: xxx
                 script: xxx
             default:
                 name: xxx
                 description: xxx
                 script: xxx
	     description: "This is a parameter"
```