### PR TITLE
Escape angle brackets for placeholders

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -491,7 +491,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var leftOptional = !IsMandatory ? "[" : String.Empty;
             var leftPositional = Position != null ? "[" : String.Empty;
             var rightPositional = Position != null ? "]" : String.Empty;
-            var type = ParameterType != typeof(SwitchParameter) ? $" <{ParameterType.ToSyntaxTypeName()}>" : String.Empty;
+            var type = ParameterType != typeof(SwitchParameter) ? $" \\<{ParameterType.ToSyntaxTypeName()}\\>" : String.Empty;
             var rightOptional = !IsMandatory ? "]" : String.Empty;
             var space = IncludeSpace ? " " : String.Empty;
             var dash = IncludeDash ? "-" : String.Empty;

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -491,7 +491,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var leftOptional = !IsMandatory ? "[" : String.Empty;
             var leftPositional = Position != null ? "[" : String.Empty;
             var rightPositional = Position != null ? "]" : String.Empty;
-            var type = ParameterType != typeof(SwitchParameter) ? $" \\<{ParameterType.ToSyntaxTypeName()}\\>" : String.Empty;
+            var type = ParameterType != typeof(SwitchParameter) ? $" <{ParameterType.ToSyntaxTypeName()}>" : String.Empty;
             var rightOptional = !IsMandatory ? "]" : String.Empty;
             var space = IncludeSpace ? " " : String.Empty;
             var dash = IncludeDash ? "-" : String.Empty;
@@ -604,7 +604,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 return ni.IsComplexInterface
                     ? ni.ToNoteOutput(nestedIndent, includeDashes, includeBackticks, false)
                     : RenderProperty(ni, nestedIndent, includeDashes, includeBackticks);
-            }).Prepend(RenderProperty(complexInterfaceInfo, currentIndent, !isFirst && includeDashes, !isFirst && includeBackticks));
+            }).Prepend(RenderProperty(complexInterfaceInfo, currentIndent, !isFirst && includeDashes, includeBackticks));
             return String.Join(Environment.NewLine, nested);
         }
     }


### PR DESCRIPTION
This PR is supposed to fix issues https://github.com/MicrosoftDocs/microsoftgraph-docs-powershell/issues/44 and https://github.com/microsoftgraph/msgraph-sdk-powershell/issues/1135. 
The fix is as a result of guidance from docs (https://review.docs.microsoft.com/en-us/help/contribute/validation-ref/disallowed-html-tag?branch=main) information on unrestricted HTML containing scripting that can be used to hack docs site.
The particular scripting found is the angle brackets used as placeholders.