### PR TITLE
Intial support for customization through input handler pipeline

### DIFF
--- a/powershell/cmdlets/namespace.ts
+++ b/powershell/cmdlets/namespace.ts
@@ -22,6 +22,7 @@ export class CmdletNamespace extends Namespace {
 
   async init() {
     this.add(new ImportDirective(`static ${ClientRuntime.Extensions}`));
+    this.add(new ImportDirective(`${ClientRuntime.Cmdlets}`));
     this.add(new ImportDirective('System'));
 
     // generate cmdlet classes on top of the SDK

--- a/powershell/generators/inputhandler.custom.ts
+++ b/powershell/generators/inputhandler.custom.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Project } from '../internal/project';
+
+export async function generateInputHandlersCustom(project: Project) {
+  const handlers = project.inputHandlers;
+  for (const handler of handlers) {
+    let content = await project.state.readFile(`${project.customFolder}\\input-handlers\\${handler}.cs`) || '';
+    if (content !== '') {
+      // skip generation since it has been generated before.
+      continue;
+    }
+    content = `${project.csharpCommentHeader}
+
+namespace ${project.projectNamespace}.Runtime.Cmdlets
+{
+    public class ${handler} : InputHandler
+    {
+        public override void Process( ${project.projectNamespace}.Runtime.IContext context)
+        {
+            // ToDO: Add the custom code here
+            NextHandler?.Process(context);
+        }
+    }
+}`;
+    project.state.writeFile(`${project.customFolder}\\input-handlers\\${handler}.cs`, content, undefined, 'source-file-csharp');
+  }
+}

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -91,6 +91,7 @@ export class Project extends codeDomProject {
   public license!: string;
   public pwshCommentHeader!: string;
   public pwshCommentHeaderForCsharp!: string;
+  public csharpCommentHeader!: string;
   public cmdletFolder!: string;
   public modelCmdletFolder!: string;
   public endpointResourceIdKeyName!: string;
@@ -130,6 +131,7 @@ export class Project extends codeDomProject {
   public moduleVersion!: string;
   public profiles!: Array<string>;
   public modelCmdlets!: Array<string>;
+  public inputHandlers!: Array<string>;
 
   public prefix!: string;
   public subjectPrefix!: string;
@@ -194,6 +196,7 @@ export class Project extends codeDomProject {
     // if pwsh license header is not set, use the license set by license-header
     this.pwshCommentHeader = comment(pwshLicenseHeader ? pwshHeaderText(pwshLicenseHeader, await this.service.GetValue('header-definitions')) : this.license, '#');
     this.pwshCommentHeaderForCsharp = this.pwshCommentHeader.replace(/"/g, '""');
+    this.csharpCommentHeader = comment(pwshLicenseHeader ? pwshHeaderText(pwshLicenseHeader, await this.service.GetValue('header-definitions')) : this.license, '//');
 
     // modelcmdlets are models that we will create cmdlets for.
     this.modelCmdlets = [];
@@ -203,6 +206,8 @@ export class Project extends codeDomProject {
     for (const directive of directives.filter(each => each['model-cmdlet'])) {
       this.modelCmdlets = this.modelCmdlets.concat(<ConcatArray<string>>values(directive['model-cmdlet']).toArray());
     }
+    // input handlers
+    this.inputHandlers = await this.state.getValue('input-handlers', []);
     // Flags
     this.azure = this.model.language.default.isAzure;
     this.addToString = await this.state.getValue('nested-object-to-string', false);

--- a/powershell/llcsharp/clientruntime.ts
+++ b/powershell/llcsharp/clientruntime.ts
@@ -44,10 +44,12 @@ export const ClientRuntime = intersect(clientRuntimeNamespace, {
   EventDataConverter: new ClassType(clientRuntimeNamespace, 'EventDataConverter'),
   ISendAsync: new Interface(clientRuntimeNamespace, 'ISendAsync'),
   Extensions: new ClassType(clientRuntimeNamespace, 'Extensions'),
+  Cmdlets: new ClassType(clientRuntimeNamespace, 'Cmdlets'),
   IJsonSerializable: new Interface(clientRuntimeNamespace, 'IJsonSerializable'),
   JsonSerializable: new Interface(clientRuntimeNamespace, 'JsonSerializable'),
   IXmlSerializable: new Interface(clientRuntimeNamespace, 'IXmlSerializable'),
   IEventListener: new Interface(clientRuntimeNamespace, 'IEventListener'),
+  IContext: new Interface(clientRuntimeNamespace, 'IContext'),
   IValidates: new Interface(clientRuntimeNamespace, 'IValidates'),
   IHeaderSerializable: new Interface(clientRuntimeNamespace, 'IHeaderSerializable'),
   SerializationMode: intersect(serializationMode, {

--- a/powershell/llcsharp/project.ts
+++ b/powershell/llcsharp/project.ts
@@ -68,6 +68,7 @@ export class Project extends codeDomProject {
 
       'Carbon.Json': `${this.projectNamespace}.Runtime.Json`,
       'Microsoft.Rest.ClientRuntime': `${this.projectNamespace}.Runtime`,
+      'Microsoft.RestClient': `${this.projectNamespace}.${this.state.model.language.csharp?.name}`,
       'Microsoft.Rest': this.projectNamespace,
       '#define DICT_PROPERTIES': this.exportPropertiesForDict ? '#define DICT_PROPERTIES' : '#define NO_DICT_PROPERTIES'
     };

--- a/powershell/plugins/powershell-v2.ts
+++ b/powershell/plugins/powershell-v2.ts
@@ -11,6 +11,7 @@ import { Project } from '../internal/project';
 import { generatePsm1 } from '../generators/psm1';
 import { generateCsproj } from '../generators/csproj';
 import { generatePsm1Custom } from '../generators/psm1.custom';
+import { generateInputHandlersCustom } from '../generators/inputhandler.custom'
 import { generatePsm1Internal } from '../generators/psm1.internal';
 import { generateNuspec } from '../generators/nuspec';
 import { generateGitIgnore } from '../generators/gitignore';
@@ -66,6 +67,7 @@ export async function powershellV2(service: Host) {
     await copyRequiredFiles(project);
     await generateCsproj(project);
     await generatePsm1(project);
+    await generateInputHandlersCustom(project);
     await generatePsm1Custom(project);
     await generatePsm1Internal(project);
     await generateNuspec(project);

--- a/powershell/resources/runtime/csharp/client/Context.cs
+++ b/powershell/resources/runtime/csharp/client/Context.cs
@@ -1,0 +1,33 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace Microsoft.Rest.ClientRuntime
+{
+
+    using System;
+    using System.Linq;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using GetEventData = System.Func<EventData>;
+    using static Microsoft.Rest.ClientRuntime.Extensions;
+
+    /// <summary>
+    /// The IContext Interface defines the communication mechanism for input customization.
+    /// </summary>
+    /// <remarks>
+    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// </remarks>
+    public interface IContext
+    {
+        System.Management.Automation.InvocationInfo InvocationInformation { get; set; }
+        System.Threading.CancellationTokenSource CancellationTokenSource { get; set; }
+        System.Collections.Generic.IDictionary<String, Object> ExtensibleParameters { get; }
+        HttpPipeline Pipeline { get; set; }
+        Microsoft.RestClient Client { get; }
+    }
+}

--- a/powershell/resources/runtime/csharp/client/InputHandler.cs
+++ b/powershell/resources/runtime/csharp/client/InputHandler.cs
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Rest.ClientRuntime.Cmdlets
+{
+    public abstract class InputHandler
+    {
+        protected InputHandler NextHandler = null;
+
+        public void SetNextHandler(InputHandler nextHandler)
+        {
+            this.NextHandler = nextHandler;
+        }
+
+        public abstract void Process(Microsoft.Rest.ClientRuntime.IContext context);
+    }
+}


### PR DESCRIPTION
Following is an example about how to use it.
```
# Add a new paramter 
 - where:
      subject: Workspace
      variant: ^Get$|^GetViaIdentity$|^List$
      verb: Get
    add:
      parameters:
        - name: ResourceId
          type: string
          required: true
          description: "Add a new parameter"
# Hide the parameter, which will be calculated from the new added one
  - where:
      subject: Workspace
      verb: Get
      parameter-name: ResourceGroupName
    hide: true
  - where:
      verb: Get
      subject: Workspace
    add:
      pipelines:
        input-pipeline:
          - name: IdToName
```
As a result, we will generate a file named IdToName in custom/input-handlers, and developers should implement it based on their requirement.