### PR TITLE
Enclose prerelease module versions in psd1 with quotes

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportPsd1.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportPsd1.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
                 if (previewVersion != null)
                 {
-                    sb.AppendLine($@"{Indent}{Indent}{Indent}Prerelease = {previewVersion}");
+                    sb.AppendLine($@"{Indent}{Indent}{Indent}Prerelease = '{previewVersion}'");
                 }
                 sb.AppendLine($@"{Indent}{Indent}{Indent}Tags = {"${$project.metadata.tags}".Split(' ').ToPsList().NullIfEmpty() ?? "''"}");
                 sb.AppendLine($@"{Indent}{Indent}{Indent}LicenseUri = '{"${$project.metadata.licenseUri}"}'");


### PR DESCRIPTION
This PR closes #976 by ensuring prerelease module versions in psd1 are surrounded in quotes as stated in [PowerShell module prerelease support](https://docs.microsoft.com/en-us/powershell/scripting/gallery/concepts/module-prerelease-support?view=powershell-7.2#identifying-a-module-version-as-a-prerelease).