### PR TITLE
Add condition check for default value directive

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -209,7 +209,8 @@ export function addDefaultInfo(targetProperty: Property, parameter: any) {
       parameters: [
         new LiteralExpression(`\nName = ${new StringExpression(parameter.defaultInfo.name || '').value}`),
         new LiteralExpression(`\nDescription =${new StringExpression(parameter.defaultInfo.description || '').value}`),
-        new LiteralExpression(`\nScript = ${new StringExpression(parameter.defaultInfo.script).value}`)
+        new LiteralExpression(`\nScript = ${new StringExpression(parameter.defaultInfo.script).value}`),
+        new LiteralExpression(`\nSetCondition = ${new StringExpression(parameter.defaultInfo['set-condition'] || '').value}`)
       ]
     }));
   }

--- a/powershell/plugins/modifiers-v2.ts
+++ b/powershell/plugins/modifiers-v2.ts
@@ -89,6 +89,7 @@ interface WhereCommandDirective {
       name: string;
       description: string;
       script: string;
+      'set-condition': string
     };
     'clientside-pagination'?: boolean;
   };

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -262,7 +262,11 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 var variantListString = defaultInfo.ParameterGroup.VariantNames.ToPsList();
                 var parameterName = defaultInfo.ParameterGroup.ParameterName;
                 sb.AppendLine();
-                sb.AppendLine($"{Indent}{Indent}if (({variantListString}) -contains $parameterSet -and -not $PSBoundParameters.ContainsKey('{parameterName}')) {{");
+                var setCondition = " ";
+                if (!String.IsNullOrEmpty(defaultInfo.SetCondition)) {
+                    setCondition = $" -and {defaultInfo.SetCondition}";
+                }
+                sb.AppendLine($"{Indent}{Indent}if (({variantListString}) -contains $parameterSet -and -not $PSBoundParameters.ContainsKey('{parameterName}'){setCondition}) {{");
                 sb.AppendLine($"{Indent}{Indent}{Indent}$PSBoundParameters['{parameterName}'] = {defaultInfo.Script}");
                 sb.Append($"{Indent}{Indent}}}");
             }

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
@@ -425,6 +425,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public string Name { get; }
         public string Description { get; }
         public string Script { get; }
+        public string SetCondition { get; }
         public ParameterGroup ParameterGroup { get; }
 
         public DefaultInfo(DefaultInfoAttribute infoAttribute, ParameterGroup parameterGroup)
@@ -432,6 +433,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             Name = infoAttribute.Name;
             Description = infoAttribute.Description;
             Script = infoAttribute.Script;
+            SetCondition = infoAttribute.SetCondition;
             ParameterGroup = parameterGroup;
         }
 

--- a/powershell/resources/runtime/csharp/client/InfoAttribute.cs
+++ b/powershell/resources/runtime/csharp/client/InfoAttribute.cs
@@ -33,5 +33,6 @@ namespace Microsoft.Rest.ClientRuntime
         public string Script { get; set; } = "";
         public string Name { get; set; } = "";
         public string Description { get; set; } = "";
+        public string SetCondition { get; set; } = "";
     }
 }


### PR DESCRIPTION
The syntax should be as below.
```
  - where:
      parameter-name: SubscriptionId
    set:
      default:
        script: '(Get-AzContext).Subscription.Id'
        set-condition: "$PSBoundParameters.ContainsKey('some-other-parameter')"
```