### PR TITLE
Support ExternalDocs for autorest.powershell

### DIFF
--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -19,7 +19,7 @@ modelerfour:
 
 ``` yaml !isLoaded('@autorest/modelerfour')
 use-extension:
-  "@autorest/modelerfour": "4.24.3"
+  "@autorest/modelerfour": "~4.24.3"
 
 # will use highest 2.0.x 
 ```

--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -19,7 +19,7 @@ modelerfour:
 
 ``` yaml !isLoaded('@autorest/modelerfour')
 use-extension:
-  "@autorest/modelerfour": "4.24.2"
+  "@autorest/modelerfour": "4.24.3"
 
 # will use highest 2.0.x 
 ```

--- a/powershell/autorest-configuration.md
+++ b/powershell/autorest-configuration.md
@@ -12,13 +12,14 @@ modelerfour:
   additional-checks: false
   always-create-content-type-parameter: false
   always-seal-x-ms-enums: true
+  treat-type-object-as-anything: true
 ```
 
 > if the modeler is loaded already, use that one, otherwise grab it.
 
 ``` yaml !isLoaded('@autorest/modelerfour')
 use-extension:
-  "@autorest/modelerfour": "4.15.414"
+  "@autorest/modelerfour": "4.24.2"
 
 # will use highest 2.0.x 
 ```

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -14,7 +14,7 @@ import {
   Switch, System, TerminalCase, toExpression, Try, Using, valueOf, Field, IsNull, Or, ExpressionOrLiteral, TerminalDefaultCase, xmlize, TypeDeclaration, And, IsNotNull, PartialMethod, Case, While
 } from '@azure-tools/codegen-csharp';
 import { ClientRuntime, EventListener, Schema, ArrayOf, EnumImplementation } from '../llcsharp/exports';
-import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute } from '../internal/powershell-declarations';
+import { Alias, ArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, ExternalDocsAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute } from '../internal/powershell-declarations';
 import { State } from '../internal/state';
 import { Channel } from '@azure-tools/autorest-extension-base';
 import { IParameter } from '@azure-tools/codemodel-v3/dist/code-model/components';
@@ -1727,6 +1727,15 @@ export class CmdletClass extends Class {
     }
 
     this.add(new Attribute(DescriptionAttribute, { parameters: [new StringExpression(this.description)] }));
+
+    // If defines externalDocs for operation
+    if (operation.details.default.externalDocsUrl) {
+      this.add(new Attribute(ExternalDocsAttribute, {
+        parameters: [`${new StringExpression(this.operation.details.default.externalDocsUrl ?? "")}`,
+        `${new StringExpression(this.operation.details.default.externalDocsDescription ?? "")}`]
+      }));
+    }
+
     this.add(new Attribute(GeneratedAttribute));
     if (operation.extensions && operation.extensions['x-ms-metadata'] && operation.extensions['x-ms-metadata'].profiles) {
       const profileNames = Object.keys(operation.extensions && operation.extensions['x-ms-metadata'].profiles);

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1729,10 +1729,10 @@ export class CmdletClass extends Class {
     this.add(new Attribute(DescriptionAttribute, { parameters: [new StringExpression(this.description)] }));
 
     // If defines externalDocs for operation
-    if (operation.details.default.externalDocsUrl) {
+    if (operation.details.default.externalDocs) {
       this.add(new Attribute(ExternalDocsAttribute, {
-        parameters: [`${new StringExpression(this.operation.details.default.externalDocsUrl ?? "")}`,
-        `${new StringExpression(this.operation.details.default.externalDocsDescription ?? "")}`]
+        parameters: [`${new StringExpression(this.operation.details.default.externalDocs?.url ?? "")}`,
+        `${new StringExpression(this.operation.details.default.externalDocs?.description ?? "")}`]
       }));
     }
 

--- a/powershell/internal/powershell-declarations.ts
+++ b/powershell/internal/powershell-declarations.ts
@@ -40,6 +40,7 @@ export const AsyncCommandRuntime = new ClassType(ClientRuntime, 'PowerShell.Asyn
 export const AsyncJob = new ClassType(ClientRuntime, 'PowerShell.AsyncJob');
 
 export const DescriptionAttribute: TypeDeclaration = new ClassType(rest, 'Description');
+export const ExternalDocsAttribute: TypeDeclaration = new ClassType(rest, 'ExternalDocs');
 export const DoNotExportAttribute: TypeDeclaration = new ClassType(rest, 'DoNotExport');
 export const InternalExportAttribute: TypeDeclaration = new ClassType(rest, 'InternalExport');
 export const GeneratedAttribute: TypeDeclaration = new ClassType(rest, 'Generated');

--- a/powershell/llcsharp/schema/schema-resolver.ts
+++ b/powershell/llcsharp/schema/schema-resolver.ts
@@ -20,6 +20,7 @@ import { EnumImplementation } from './enum';
 import { Numeric } from './integer';
 import { ObjectImplementation } from './object';
 import { String } from './string';
+import { Uri } from './uri';
 import { Uuid } from './Uuid';
 import { EnhancedTypeDeclaration } from './extended-type-declaration';
 import { PwshModel } from '../../utils/PwshModel';
@@ -71,6 +72,8 @@ export class SchemaDefinitionResolver {
         return new Binary(<BinarySchema>schema, required);
       case SchemaType.Duration:
         return new Duration(<DurationSchema>schema, required);
+      case SchemaType.Uri:
+        return new Uri(<StringSchema>schema, required);
       case SchemaType.Uuid:
         return new Uuid(<StringSchema>schema, required);
       case SchemaType.DateTime:

--- a/powershell/llcsharp/schema/uri.ts
+++ b/powershell/llcsharp/schema/uri.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { nameof } from '@azure-tools/codegen';
+import { Variable } from '@azure-tools/codegen-csharp';
+import { Schema } from '../code-model';
+import { StringSchema } from '@azure-tools/codemodel';
+import { String } from './string';
+
+
+export class Uri extends String {
+  constructor(schema: StringSchema, isRequired: boolean) {
+    super(schema, isRequired);
+  }
+
+  get declaration(): string {
+    return 'string';
+  }
+  public validatePresence(eventListener: Variable, property: Variable): string {
+    return this.isRequired ? `await ${eventListener}.AssertNotNull(${nameof(property.value)},${property});`.trim() : '';
+  }
+  validateValue(eventListener: Variable, property: Variable): string {
+    return `await ${eventListener}.AssertRegEx(${nameof(property.value)},${property},@"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$");`;
+  }
+}

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -394,8 +394,7 @@ export /* @internal */ class Inferrer {
           verb: variant.verb,
           name: vname,
           alias: variant.alias,
-          externalDocsDescription: operation.externalDocs?.description,
-          externalDocsUrl: operation.externalDocs?.url
+          externalDocs: operation.externalDocs
         }
       },
       // operationId is not needed any more

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -19,7 +19,7 @@ import { CommandOperation } from '../utils/command-operation';
 
 type State = ModelState<PwshModel>;
 
-const specialWords : { [key: string]: Array<string> } = {in: <Array<string>>['sign']};
+const specialWords: { [key: string]: Array<string> } = { in: <Array<string>>['sign'] };
 
 // UNUSED: Moved to plugin-tweak-model.ts in remodeler
 // For now, we are not dynamically changing the service-name. Instead, we would figure out a method to change it during the creation of service readme's.
@@ -73,12 +73,12 @@ function filterSpecialWords(preposition: string, parts: Array<string>) {
   if (specialWords[preposition] !== undefined) {
     do {
       idx = parts.indexOf(preposition, start);
-      if (idx <= 0 || !specialWords[preposition].includes(parts[idx -1])) {
+      if (idx <= 0 || !specialWords[preposition].includes(parts[idx - 1])) {
         return idx;
       } else {
         start = idx + 1;
       }
-    // eslint-disable-next-line no-constant-condition
+      // eslint-disable-next-line no-constant-condition
     } while (true);
   }
   return parts.indexOf(preposition);
@@ -393,7 +393,9 @@ export /* @internal */ class Inferrer {
           subjectPrefix: variant.subjectPrefix,
           verb: variant.verb,
           name: vname,
-          alias: variant.alias
+          alias: variant.alias,
+          externalDocsDescription: operation.externalDocs?.description,
+          externalDocsUrl: operation.externalDocs?.url
         }
       },
       // operationId is not needed any more

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -47,9 +47,9 @@ function getNameOptions(typeName: string, components: Array<string>) {
 function getCombinedDescription(rawDescription: string, externalDocsUrl?: string, externalDocsDescription?: string): string {
   let description = rawDescription ?? "";
   if (undefined !== externalDocsUrl && "" !== externalDocsUrl) {
-    description = description.concat("Please visit external url ", externalDocsUrl, " to get more information. ")
+    description = description.concat(" Please visit external url ", externalDocsUrl, " to get more information.")
     if (undefined !== externalDocsDescription && "" !== externalDocsDescription) {
-      description = description.concat("The content of external url is about '", externalDocsDescription, " '. ")
+      description = description.concat(" The content of external url is about '", externalDocsDescription, " '.")
     }
   }
   return description;
@@ -224,9 +224,6 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
 
         const components = [...removeSequentialDuplicates([propertyName, ...inlinedProperty.nameComponents])];
 
-        const combinedDescription = getCombinedDescription(inlinedProperty.property.language.default.description, inlinedProperty.property.schema.externalDocs?.url, inlinedProperty.property.schema.externalDocs?.description);
-        inlinedProperty.property.language.default.description = combinedDescription;
-
         virtualProperties.inlined.push({
           name: proposedName,
           property: inlinedProperty.property,
@@ -357,9 +354,6 @@ function createVirtualParameters(operation: CommandOperation) {
             // private or readonly properties aren't needed as parameters. 
             continue;
           }
-
-          const combinedDescription = getCombinedDescription(virtualProperty.property.language.default.description, virtualProperty.property.schema.externalDocs?.url, virtualProperty.property.schema.externalDocs?.description);
-          virtualProperty.property.language.default.description = combinedDescription;
 
           virtualParameters.body.push({
             name: virtualProperty.name,

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -193,7 +193,7 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
 
       // if the child property is low enough (or it's 'properties'), let's create virtual properties for each one.
       // create a private property for the inlined ones to use.
-      const combinedDescription = getCombinedDescription(property.language.default.description, property.schema?.externalDocs?.url, property.schema?.externalDocs?.description);
+      const combinedDescription = getCombinedDescription(property.language.default.description, property.schema?.externalDocs?.url);
       property.language.default.description = combinedDescription;
       const privateProperty = {
         name: getPascalIdentifier(propertyName),
@@ -280,7 +280,7 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
     // however, we can add it to our list of virtual properties
     // so that our consumers can get it.
 
-    const combinedDescription = getCombinedDescription(property.language.default.description, property.schema?.externalDocs?.url, property.schema?.externalDocs?.description);
+    const combinedDescription = getCombinedDescription(property.language.default.description, property.schema?.externalDocs?.url);
     property.language.default.description = combinedDescription;
 
     virtualProperties.owned.push({
@@ -362,7 +362,7 @@ function createVirtualParameters(operation: CommandOperation) {
       }
     } else {
       // dolauli if not drop body or not body parameter add it to operation 
-      const combinedDescription = getCombinedDescription(parameter.schema.language.default.description, parameter.schema.externalDocs?.url, parameter.schema.externalDocs?.description);
+      const combinedDescription = getCombinedDescription(parameter.schema.language.default.description, parameter.schema.externalDocs?.url);
       parameter.schema.language.default.description = combinedDescription;
 
       virtualParameters.operation.push({

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -44,14 +44,10 @@ function getNameOptions(typeName: string, components: Array<string>) {
   return [...result.values()];
 }
 
-function getCombinedDescription(rawDescription: string, externalDocsUrl?: string, externalDocsDescription?: string): string {
+function getCombinedDescription(rawDescription: string, externalDocsUrl?: string): string {
   let description = rawDescription ?? "";
   if (!!externalDocsUrl && !!externalDocsUrl.trim()) {
-    if (!!externalDocsDescription && !!externalDocsDescription.trim()) {
-      description = description.concat(` Please visit external docs [${externalDocsDescription}](${externalDocsUrl}) to get more information.`)
-    } else {
-      description = description.concat(` Please visit external url ${externalDocsUrl} to get more information.`)
-    }
+    description = description.concat(` Please visit external url ${externalDocsUrl} to get more information.`)
   }
   return description;
 }
@@ -254,9 +250,6 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
 
         const proposedName = getPascalIdentifier(inlinedProperty.name);
         const components = [...removeSequentialDuplicates([propertyName, ...inlinedProperty.nameComponents])];
-
-        const combinedDescription = getCombinedDescription(inlinedProperty.property.language.default.description, inlinedProperty.property.schema.externalDocs?.url, inlinedProperty.property.schema.externalDocs?.description);
-        inlinedProperty.property.language.default.description = combinedDescription;
 
         virtualProperties.inlined.push({
           name: proposedName,

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -6,6 +6,7 @@
 import { codeModelSchema, CodeModel, ObjectSchema, ConstantSchema, GroupSchema, isObjectSchema, SchemaType, GroupProperty, ParameterLocation, Operation, Parameter, ImplementationLocation, OperationGroup, Request, SchemaContext } from '@azure-tools/codemodel';
 import { getPascalIdentifier, removeSequentialDuplicates, pascalCase, fixLeadingNumber, deconstruct, selectName, EnglishPluralizationService, serialize } from '@azure-tools/codegen';
 import { length, values, } from '@azure-tools/linq';
+import { ExternalDocumentation } from '../utils/components';
 import { Host, Session, startSession } from '@azure-tools/autorest-extension-base';
 import { CommandOperation } from '../utils/command-operation';
 import { PwshModel } from '../utils/PwshModel';
@@ -43,6 +44,16 @@ function getNameOptions(typeName: string, components: Array<string>) {
   return [...result.values()];
 }
 
+function getCombinedDescription(rawDescription: string, externalDocsUrl?: string, externalDocsDescription?: string): string {
+  let description = rawDescription ?? "";
+  if (undefined !== externalDocsUrl && "" !== externalDocsUrl) {
+    description = description.concat("Please visit external url ", externalDocsUrl, " to get more information. ")
+    if (undefined !== externalDocsDescription && "" !== externalDocsDescription) {
+      description = description.concat("The content of external url is about '", externalDocsDescription, " '. ")
+    }
+  }
+  return description;
+}
 
 function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, threshold: number, conflicts: Array<string>) {
   // Some properties should be removed are wrongly kept as null and need to clean them
@@ -185,6 +196,8 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
 
       // if the child property is low enough (or it's 'properties'), let's create virtual properties for each one.
       // create a private property for the inlined ones to use.
+      const combinedDescription = getCombinedDescription(property.language.default.description, property.schema?.externalDocs?.url, property.schema?.externalDocs?.description);
+      property.language.default.description = combinedDescription;
       const privateProperty = {
         name: getPascalIdentifier(propertyName),
         propertySchema: schema,
@@ -210,6 +223,10 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
         const proposedName = getPascalIdentifier(`${propertyName === 'properties' || /*objectProperties.length === 1*/ propertyName === 'error' ? '' : pascalCase(fixLeadingNumber(deconstruct(propertyName)).map(each => singularize(each)))} ${inlinedProperty.name}`);
 
         const components = [...removeSequentialDuplicates([propertyName, ...inlinedProperty.nameComponents])];
+
+        const combinedDescription = getCombinedDescription(inlinedProperty.property.language.default.description, inlinedProperty.property.schema.externalDocs?.url, inlinedProperty.property.schema.externalDocs?.description);
+        inlinedProperty.property.language.default.description = combinedDescription;
+
         virtualProperties.inlined.push({
           name: proposedName,
           property: inlinedProperty.property,
@@ -239,6 +256,10 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
 
         const proposedName = getPascalIdentifier(inlinedProperty.name);
         const components = [...removeSequentialDuplicates([propertyName, ...inlinedProperty.nameComponents])];
+
+        const combinedDescription = getCombinedDescription(inlinedProperty.property.language.default.description, inlinedProperty.property.schema.externalDocs?.url, inlinedProperty.property.schema.externalDocs?.description);
+        inlinedProperty.property.language.default.description = combinedDescription;
+
         virtualProperties.inlined.push({
           name: proposedName,
           property: inlinedProperty.property,
@@ -252,7 +273,7 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
           description: inlinedProperty.description,
           alias: [],
           readOnly: inlinedProperty.readOnly || property.readOnly,
-          required: inlinedProperty.required && privateProperty.required
+          required: inlinedProperty.required && privateProperty.required,
         });
       }
     } else {
@@ -267,6 +288,10 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
     // so we don't need to do any inlining
     // however, we can add it to our list of virtual properties
     // so that our consumers can get it.
+
+    const combinedDescription = getCombinedDescription(property.language.default.description, property.schema?.externalDocs?.url, property.schema?.externalDocs?.description);
+    property.language.default.description = combinedDescription;
+
     virtualProperties.owned.push({
       name,
       property,
@@ -276,7 +301,7 @@ function createVirtualProperties(schema: ObjectSchema, stack: Array<string>, thr
       originalContainingSchema: schema,
       alias: [],
       readOnly: property.readOnly,
-      required: property.required || property.language.default.required
+      required: property.required || property.language.default.required,
     });
   }
 
@@ -332,6 +357,10 @@ function createVirtualParameters(operation: CommandOperation) {
             // private or readonly properties aren't needed as parameters. 
             continue;
           }
+
+          const combinedDescription = getCombinedDescription(virtualProperty.property.language.default.description, virtualProperty.property.schema.externalDocs?.url, virtualProperty.property.schema.externalDocs?.description);
+          virtualProperty.property.language.default.description = combinedDescription;
+
           virtualParameters.body.push({
             name: virtualProperty.name,
             description: virtualProperty.property.language.default.description,
@@ -345,6 +374,9 @@ function createVirtualParameters(operation: CommandOperation) {
       }
     } else {
       // dolauli if not drop body or not body parameter add it to operation 
+      const combinedDescription = getCombinedDescription(parameter.schema.language.default.description, parameter.schema.externalDocs?.url, parameter.schema.externalDocs?.description);
+      parameter.schema.language.default.description = combinedDescription;
+
       virtualParameters.operation.push({
         name: parameter.details.default.name,
         nameOptions: [parameter.details.default.name],

--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -46,10 +46,11 @@ function getNameOptions(typeName: string, components: Array<string>) {
 
 function getCombinedDescription(rawDescription: string, externalDocsUrl?: string, externalDocsDescription?: string): string {
   let description = rawDescription ?? "";
-  if (undefined !== externalDocsUrl && "" !== externalDocsUrl) {
-    description = description.concat(" Please visit external url ", externalDocsUrl, " to get more information.")
-    if (undefined !== externalDocsDescription && "" !== externalDocsDescription) {
-      description = description.concat(" The content of external url is about '", externalDocsDescription, " '.")
+  if (!!externalDocsUrl && !!externalDocsUrl.trim()) {
+    if (!!externalDocsDescription && !!externalDocsDescription.trim()) {
+      description = description.concat(` Please visit external docs [${externalDocsDescription}](${externalDocsUrl}) to get more information.`)
+    } else {
+      description = description.concat(` Please visit external url ${externalDocsUrl} to get more information.`)
     }
   }
   return description;

--- a/powershell/plugins/plugin-tweak-model.ts
+++ b/powershell/plugins/plugin-tweak-model.ts
@@ -236,8 +236,8 @@ async function tweakModelV2(state: State): Promise<PwshModel> {
 
   // remove well-known header parameters from operations and add mark the operation has supporting that feature
 
-  for (const operationGruops of values(model.operationGroups)) {
-    for (const operation of values(operationGruops.operations)) {
+  for (const operationGroups of values(model.operationGroups)) {
+    for (const operation of values(operationGroups.operations)) {
       // if we have an operation with a body, and content-type is a multipart/formdata
       // then we should go thru the parameters of the body and look for a string/binary parameters
       // and remember to add another parameter for the filename of the string/binary

--- a/powershell/resources/psruntime/Attributes/ExternalDocsAttribute.cs
+++ b/powershell/resources/psruntime/Attributes/ExternalDocsAttribute.cs
@@ -1,0 +1,30 @@
+﻿/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+namespace Microsoft.Rest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    public class ExternalDocsAttribute : Attribute
+    {
+
+        public string Description { get; }
+
+        public string Url { get; }
+
+        public ExternalDocsAttribute(string url)
+        {
+            Url = url;
+        }
+
+        public ExternalDocsAttribute(string url, string description)
+        {
+            Url = url;
+            Description = description;
+        }
+    }
+}

--- a/powershell/resources/psruntime/Attributes/ExternalDocsAttribute.cs
+++ b/powershell/resources/psruntime/Attributes/ExternalDocsAttribute.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Rest
     using System.Collections.Generic;
     using System.Text;
 
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
     public class ExternalDocsAttribute : Attribute
     {
 

--- a/powershell/resources/psruntime/BuildTime/Models/PsMarkdownTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsMarkdownTypes.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public string[] Inputs { get; }
         public string[] Outputs { get; }
         public ComplexInterfaceInfo[] ComplexInterfaceInfos { get; }
-        public string[] RelatedLinks { get; }
+        public MarkdownRelatedLinkInfo[] RelatedLinks { get; }
 
         public bool SupportsShouldProcess { get; }
         public bool SupportsPaging { get; }
@@ -67,7 +67,11 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
             ComplexInterfaceInfos = variantGroup.ComplexInterfaceInfos;
             OnlineVersion = commentInfo.OnlineVersion;
-            RelatedLinks = commentInfo.RelatedLinks;
+            
+            var relatedLinkLists = new List<MarkdownRelatedLinkInfo>();
+            relatedLinkLists.AddRange(commentInfo.RelatedLinks?.Select(link => new MarkdownRelatedLinkInfo(link)));
+            relatedLinkLists.AddRange(variantGroup.Variants.SelectMany(v => v.Attributes).OfType<ExternalDocsAttribute>()?.Distinct()?.Select(link => new MarkdownRelatedLinkInfo(link.Url, link.Description)));
+            RelatedLinks = relatedLinkLists?.ToArray(); 
 
             SupportsShouldProcess = variantGroup.SupportsShouldProcess;
             SupportsPaging = variantGroup.SupportsPaging;
@@ -215,6 +219,37 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             AcceptsPipelineByValue = parameterHelpInfos.Select(phi => phi.SupportsPipelineInput?.Contains("ByValue")).FirstOrDefault(bv => bv == true) ?? parameterGroup.ValueFromPipeline;
             AcceptsPipelineByPropertyName = parameterHelpInfos.Select(phi => phi.SupportsPipelineInput?.Contains("ByPropertyName")).FirstOrDefault(bv => bv == true) ?? parameterGroup.ValueFromPipelineByPropertyName;
             AcceptsWildcardCharacters = parameterGroup.SupportsWildcards;
+        }
+    }
+
+    internal class MarkdownRelatedLinkInfo
+    {
+        public string Url { get; }
+        public string Description { get; }
+
+        public MarkdownRelatedLinkInfo(string url)
+        {
+            Url = url;
+        }
+
+        public MarkdownRelatedLinkInfo(string url, string description)
+        {
+            Url = url;
+            Description = description;
+        }
+
+        public override string ToString()
+        {
+            if (string.IsNullOrEmpty(Description))
+            {
+                return Url;
+            }
+            else
+            {
+                return $@"[{Description}]({Url})";
+
+            }
+            
         }
     }
 

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -357,6 +357,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var notesText = !String.IsNullOrEmpty(notes) ? $"{Environment.NewLine}.Notes{Environment.NewLine}{ComplexParameterHeader}{notes}" : String.Empty;
             var relatedLinks = String.Join(Environment.NewLine, CommentInfo.RelatedLinks.Select(l => $".Link{Environment.NewLine}{l}"));
             var relatedLinksText = !String.IsNullOrEmpty(relatedLinks) ? $"{Environment.NewLine}{relatedLinks}" : String.Empty;
+            var externalUrls = String.Join(Environment.NewLine, CommentInfo.ExternalUrls.Select(l => $".Link{Environment.NewLine}{l}"));
+            var externalUrlsText = !String.IsNullOrEmpty(externalUrls) ? $"{Environment.NewLine}{externalUrls}" : String.Empty;
             var examples = "";
             foreach (var example in VariantGroup.HelpInfo.Examples)
             {
@@ -369,7 +371,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 {CommentInfo.Description.ToDescriptionFormat(false)}
 {examples}{inputsText}{outputsText}{notesText}
 .Link
-{CommentInfo.OnlineVersion}{relatedLinksText}
+{CommentInfo.OnlineVersion}{relatedLinksText}{externalUrlsText}
 #>
 ";
         }

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyTypes.cs
@@ -366,6 +366,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
         public string OnlineVersion { get; }
         public string[] RelatedLinks { get; }
+        public string[] ExternalUrls { get; }
 
         private const string HelpLinkPrefix = @"${$project.helpLinkPrefix}";
 
@@ -391,6 +392,9 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
             var moduleName = variantGroup.RootModuleName == "" ? variantGroup.ModuleName.ToLowerInvariant() : variantGroup.RootModuleName.ToLowerInvariant();
             OnlineVersion = helpInfo.OnlineVersion?.Uri.NullIfEmpty() ?? $@"{HelpLinkPrefix}{moduleName}/{variantGroup.CmdletName.ToLowerInvariant()}";
             RelatedLinks = helpInfo.RelatedLinks.Select(rl => rl.Text).ToArray();
+
+            // Get external urls from attribute
+            ExternalUrls = variantGroup.Variants.SelectMany(v => v.Attributes).OfType<ExternalDocsAttribute>()?.Select(e => e.Url)?.Distinct()?.ToArray();
         }
     }
 

--- a/powershell/utils/components.ts
+++ b/powershell/utils/components.ts
@@ -100,10 +100,7 @@ export interface ImplementationDetails extends Dictionary<any> {
   deprecationMessage?: string;
 
   /** external docs description */
-  externalDocsDescription?: string;
-
-  /** external docs description */
-  externalDocsUrl?: string;
+  externalDocs?: ExternalDocumentation;
 
 }
 

--- a/powershell/utils/components.ts
+++ b/powershell/utils/components.ts
@@ -98,6 +98,13 @@ export interface ImplementationDetails extends Dictionary<any> {
 
   /** message used to go along with deprecation */
   deprecationMessage?: string;
+
+  /** external docs description */
+  externalDocsDescription?: string;
+
+  /** external docs description */
+  externalDocsUrl?: string;
+
 }
 
 export enum ImplementationLocation {


### PR DESCRIPTION
Support ExternalDocs for autorest.powershell
- if externalDocs is added to operation, its content will be added to three parts:
  - the attribute of c# cmdlet
![image](https://user-images.githubusercontent.com/19869716/197913328-c76ea50e-27ba-4b5b-a3dd-5cfc10a02233.png)
 
  - the result of Get-Help {cmdlet-name} 
![image](https://user-images.githubusercontent.com/19869716/194821551-051d6f53-e332-4c29-bea6-bd473d63a454.png)

  - the  related links section of docs/MDs
![image](https://user-images.githubusercontent.com/19869716/194821773-f1def1ee-3a04-478a-ab56-fa962154283b.png)

See generated details: https://github.com/Azure/azure-powershell/blob/demo/Search/src/Search/docs/New-AzSearchService.md#related-links

  - Support adding externalDocs by customization
![image](https://user-images.githubusercontent.com/19869716/194821414-eda5dc32-461f-4432-a20a-88ccc86e21c9.png)
see https://github.com/Azure/azure-powershell/blob/demo/Search/src/Search/docs/Get-AzSearchAdminKey.md#related-links

- if externalDocs is added to parameter, its content will be added to parameter description:
![image](https://user-images.githubusercontent.com/19869716/197913741-63aadf71-60ab-4559-90b7-856fe63ec6ad.png)
![image](https://user-images.githubusercontent.com/19869716/197913787-9c999a07-252c-4af2-ae02-796f7a12a440.png)

- if externalDocs is added to property, its content will be add to the xml comment of property:
![image](https://user-images.githubusercontent.com/19869716/197913935-88503a92-5213-4e5c-befa-b9cd66cbfa0f.png)

See generated details from demo projects: https://github.com/Azure/azure-powershell/blob/demo/Search/src/ContainerService/docs/New-AzContainerServiceComponent.md#-hockeyappid
