### PR TITLE
Deserialize Enum Responses

### DIFF
--- a/powershell/llcsharp/schema/enum.ts
+++ b/powershell/llcsharp/schema/enum.ts
@@ -6,7 +6,8 @@
 import { Schema } from '../code-model';
 import { Schema as NewSchema } from '@azure-tools/codemodel';
 import { String } from './string';
-import { dotnet, toExpression } from '@azure-tools/codegen-csharp';
+import { dotnet, Expression, ExpressionOrLiteral, toExpression } from '@azure-tools/codegen-csharp';
+import { KnownMediaType } from '@azure-tools/codemodel-v3';
 
 export class EnumImplementation extends String {
   public isXmlAttribute = false;
@@ -29,4 +30,13 @@ export class EnumImplementation extends String {
 
 
   get declaration(): string { return `${this.schema.language.csharp?.namespace}.${this.schema.language.csharp?.name}${this.isRequired ? '' : '?'}`; }
+
+    /** emits an expression to deserialize content from a content/response */
+  deserializeFromResponse(mediaType: KnownMediaType, content: ExpressionOrLiteral, defaultValue: Expression): Expression | undefined {
+    switch (mediaType) {
+      case KnownMediaType.Json:
+        return toExpression(`${content}.Content.ReadAsStringAsync().ContinueWith( body => ${this.deserializeFromString(mediaType, 'body.Result', defaultValue)})`);
+    }
+    return toExpression(`null /* deserializeFromResponse doesn't support '${mediaType}' ${__filename}*/`);
+  }
 }


### PR DESCRIPTION
This PR closes #973 by adding `deserializeFromResponse` method to `EnumImplementation` class in `schema/enum.ts` for deserializing enum responses. The old implementation relied on `deserializeFromResponse` method from the extended `String` class.