### PR TITLE
sdk - Add support for x-ms-client-flatten in request body

### DIFF
--- a/powershell/resources/templates/method.ejs
+++ b/powershell/resources/templates/method.ejs
@@ -11,6 +11,19 @@
         /// <%=parameter.language.default.description%>
         /// </param>
 <% });}-%>
+<% (method.requests[0].parameters || []).filter(p=>p.protocol.http.in == 'body').forEach(function(parameter){-%>
+<%if(parameter.extensions && parameter.extensions['x-ms-client-flatten'] ) {-%>
+<%project.helper.GetAllPublicVirtualProperties(parameter.schema.language.default.virtualProperties).forEach(function(vp) {-%>
+        /// <param name='<%-vp.property.language.default.name%>'>
+        /// <%= vp.property.language.default.description%>
+        /// </param>
+<%});-%>
+<%} else {-%>
+        /// <param name='<%-parameter.language.default.name%>'>
+        /// <%= parameter.language.default.description%>
+        /// </param>
+<%}-%>
+<% });-%>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>

--- a/powershell/resources/templates/methodBodyRestCall.ejs
+++ b/powershell/resources/templates/methodBodyRestCall.ejs
@@ -1,8 +1,10 @@
-<% (method.requests[0].parameters || []).filter(p =>p.protocol.http.in == 'body').forEach(function (parameter) {-%>
+<% (method.requests[0].parameters || []).filter(p=>p.protocol.http.in == 'body').forEach(function(parameter){-%>
+<%if(!(parameter.extensions && parameter.extensions['x-ms-client-flatten'])) {-%>
             if (<%-parameter.language.default.name%> == null)
             {
                 throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "<%-parameter.language.default.name%>");
             }
+<%}-%>
 <% });-%>
 <%  if(method.parameters) { method.parameters.filter(p => (p.schema.type != 'constant' && p.language.default.name != '$host') || p.language.default.name == 'ApiVersion').forEach(function (parameter) {-%>
 <%# ToDo: add check IsNullable with required -%>
@@ -17,6 +19,18 @@
 <%});}-%>
 <%# ToDo: add support for p => p.IsConstant && !p.IsClientProperty -%>
 <%# ToDo: add support for BuildInputMappings -%>
+<% (method.requests[0].parameters || []).filter(p=>p.protocol.http.in == 'body').forEach(function(parameter){-%>
+            <%-method.language.default.returnType%> <%-parameter.language.default.name%> = new <%-method.language.default.returnType%>();
+<%if(parameter.extensions && parameter.extensions['x-ms-client-flatten']) {-%>
+<% var vps = project.helper.GetAllPublicVirtualProperties(parameter.schema.language.default.virtualProperties)-%>
+            if(<%-vps.map(vp=>`${vp.property.language.default.name} != null`).join('||')%>)
+            {
+<%vps.forEach(function(vp) {-%>
+                <%-parameter.language.default.name%>.<%-vp.property.language.csharp.name%> = <%-vp.property.language.default.name%>;
+<%});-%>
+            }
+<%}-%>
+<% });-%>
             // Tracing
             bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
             string _invocationId = null;

--- a/powershell/resources/templates/methodGroupInterface.ejs
+++ b/powershell/resources/templates/methodGroupInterface.ejs
@@ -29,9 +29,17 @@ namespace <%- project.namespace %>
         /// </param>
 <% }); -%>
 <% (method.requests[0].parameters || []).filter(p=>p.protocol.http.in == 'body').forEach(function(parameter){-%>
+<%if(parameter.extensions && parameter.extensions['x-ms-client-flatten'] ) {-%>
+<%project.helper.GetAllPublicVirtualProperties(parameter.schema.language.default.virtualProperties).forEach(function(vp) {-%>
+        /// <param name='<%-vp.property.language.default.name%>'>
+        /// <%= vp.property.language.default.description%>
+        /// </param>
+<%});-%>
+<%} else {-%>
         /// <param name='<%-parameter.language.default.name%>'>
         /// <%= parameter.language.default.description%>
         /// </param>
+<%}-%>
 <% });-%>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.

--- a/powershell/sdk/utility.ts
+++ b/powershell/sdk/utility.ts
@@ -12,6 +12,10 @@ export class Helper {
       return index === 0 ? word.toLowerCase() : word.toUpperCase();
     }).replace(/\s+/g, '');
   }
+  public PascalCase(str: string): string {
+    return str = str.replace(/(\w)(\w*)/g,
+      function (g0, g1, g2) { return g1.toUpperCase() + g2.toLowerCase(); });
+  }
   public GetAllPublicVirtualProperties(virtualProperties?: VirtualProperties): Array<VirtualProperty> {
     return getAllPublicVirtualPropertiesForSdk(virtualProperties);
   }


### PR DESCRIPTION
Below is an example of swagger.
```
          {
            "name": "parameters",
            "in": "body",
            "x-ms-client-flatten": true,
            "required": true,
            "schema": {
              "$ref": "#/definitions/operation"
            },
            "description": "Parameters supplied to the create or update a workspace."
          }
```