### PR TITLE
[Provider-aks] Fixed issue in model constructor parameters declaration

### DIFF
--- a/powershell/plugins/sdk-tweak-model.ts
+++ b/powershell/plugins/sdk-tweak-model.ts
@@ -73,7 +73,7 @@ function tweakSchema(model: SdkModel) {
         continue;
       }
       let type = virtualProperty.property.schema.language.csharp?.fullname || '';
-      type = (valueType(virtualProperty.property.schema.type) || (virtualProperty.property.schema.type === SchemaType.SealedChoice && (<SealedChoiceSchema>virtualProperty.property.schema).choiceType.type !== SchemaType.String || (virtualProperty.property.schema.extensions && !virtualProperty.property.schema.extensions['x-ms-model-as-string']))) && !virtualProperty.required ? `${type}?` : type;
+      type = (valueType(virtualProperty.property.schema.type) || (virtualProperty.property.schema.type === SchemaType.SealedChoice && ((<SealedChoiceSchema>virtualProperty.property.schema).choiceType.type !== SchemaType.String || (virtualProperty.property.schema.extensions && !virtualProperty.property.schema.extensions['x-ms-model-as-string'])))) && !virtualProperty.required ? `${type}?` : type;
       const CamelName = virtualProperty.property.language.default.name;
       virtualProperty.required ? requiredParameters.push(`${type} ${CamelName}`) : optionalParameters.push(`${type} ${CamelName} = default(${type})`);
     }

--- a/powershell/resources/templates/longRunningOperationMethod.ejs
+++ b/powershell/resources/templates/longRunningOperationMethod.ejs
@@ -5,7 +5,7 @@
         /// </summary>
 <% };-%>
 <%# ToDo: add remark if both description and summary is provided, question here is in m4, there is no summary provided-%>
-<%  if(method.parameters) { method.parameters.filter(p => p.implementation != 'Client').forEach(function (parameter) {-%>
+<%  if(method.parameters&&!method.language.default.pageable?.nextPageOperation) { method.parameters.filter(p => p.implementation != 'Client').forEach(function (parameter) {-%>
 <%# ToDo: should use camel name instead of pascal name here -%>
         /// <param name='<%-parameter.language.default.name%>'>
         /// <%=parameter.language.default.description%>
@@ -24,6 +24,11 @@
         /// </param>
 <%}-%>
 <% });-%>
+<% if(method.language.default.pageable?.nextPageOperation) {-%>
+        /// <param name='nextPageLink'>
+        /// The NextLink from the previous successful call to List operation.
+        /// </param>
+<% } -%>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>

--- a/powershell/resources/templates/method.ejs
+++ b/powershell/resources/templates/method.ejs
@@ -5,7 +5,7 @@
         /// </summary>
 <% };-%>
 <%# ToDo: add remark if both description and summary is provided, question here is in m4, there is no summary provided-%>
-<%  if(method.parameters) { method.parameters.filter(p => p.implementation != 'Client').forEach(function (parameter) {-%>
+<%  if(method.parameters&&!method.language.default.pageable?.nextPageOperation) { method.parameters.filter(p => p.implementation != 'Client').forEach(function (parameter) {-%>
 <%# ToDo: should use camel name instead of pascal name here -%>
         /// <param name='<%-parameter.language.default.name%>'>
         /// <%=parameter.language.default.description%>
@@ -24,6 +24,11 @@
         /// </param>
 <%}-%>
 <% });-%>
+<% if(method.language.default.pageable?.nextPageOperation) {-%>
+        /// <param name='nextPageLink'>
+        /// The NextLink from the previous successful call to List operation.
+        /// </param>
+<% } -%>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>


### PR DESCRIPTION
[Bug fix] Removed unexpected ? in constructor parameters declaration

#### Code generated by autorest.csharp

```dotnetcli
        public AgentPoolAvailableVersions(string id = default(string), string name = default(string), string type = default(string), System.Collections.Generic.IList<AgentPoolAvailableVersionsPropertiesAgentPoolVersionsItem> agentPoolVersions = default(System.Collections.Generic.IList<AgentPoolAvailableVersionsPropertiesAgentPoolVersionsItem>))
        {
            this.Id = id;
            this.Name = name;
            this.Type = type;
            this.AgentPoolVersions = agentPoolVersions;
            CustomInit();
        }
```

#### Code generated by autorest.powershell

```dotnetcli
        public AgentPoolAvailableVersions(string id = default(string), string name = default(string), string type = default(string), System.Collections.Generic.IList<AgentPoolAvailableVersionsPropertiesAgentPoolVersionsItem>? agentPoolVersions = default(System.Collections.Generic.IList<AgentPoolAvailableVersionsPropertiesAgentPoolVersionsItem>**?**))

        {
            this.Id = id;
            this.Name = name;
            this.Type = type;
            this.AgentPoolVersions = agentPoolVersions;
            CustomInit();
        }
```
