### PR TITLE
Add category for body object

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1629,6 +1629,20 @@ export class CmdletClass extends Class {
         if (cat) {
           regularCmdletParameter.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.${pascalCase((cat.protocol.http?.in))}`] }));
         }
+      } else {
+        const cat = operation.callGraph[0].requests?.[0].parameters?.find(
+          (param) => param.language.csharp?.name === vParam.origin.name
+        );
+
+        if (cat) {
+          regularCmdletParameter.add(
+            new Attribute(CategoryAttribute, {
+              parameters: [
+                `${ParameterCategory}.${pascalCase(cat.protocol.http?.in)}`,
+              ],
+            })
+          );
+        }
       }
 
 

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1630,16 +1630,11 @@ export class CmdletClass extends Class {
           regularCmdletParameter.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.${pascalCase((cat.protocol.http?.in))}`] }));
         }
       } else {
-        const cat = operation.callGraph[0].requests?.[0].parameters?.find(
-          (param) => param.language.csharp?.name === vParam.origin.name
-        );
-
-        if (cat) {
+        const isBodyParameter = origin ? origin.details.csharp.isBodyParameter : false
+        if (isBodyParameter) {
           regularCmdletParameter.add(
             new Attribute(CategoryAttribute, {
-              parameters: [
-                `${ParameterCategory}.${pascalCase(cat.protocol.http?.in)}`,
-              ],
+              parameters: [`${ParameterCategory}.Body`],
             })
           );
         }

--- a/powershell/resources/assets/generate-portal-ux.ps1
+++ b/powershell/resources/assets/generate-portal-ux.ps1
@@ -82,6 +82,7 @@ function Test-FunctionSupported()
     $customFiles = Get-ChildItem -Path custom -Filter "$cmdletName.*"
     if ($customFiles.Length -ne 0)
     {
+        Write-Host -ForegroundColor Yellow "There are come custom files for $cmdletName, skip generate UX data for it."
         return $false
     }
 


### PR DESCRIPTION
Currently the unexpanded object from http body will miss the `Category` attribute.