### PR TITLE
sdk - remove redundant constructor for model without properties

### DIFF
--- a/powershell/resources/templates/model.ejs
+++ b/powershell/resources/templates/model.ejs
@@ -39,7 +39,7 @@ namespace <%- project.namespace %>.Models
             CustomInit();
         }
 <%#ToDo support for constructorParameters in the model, the constructorParameter is mapped to properties for the time being%>
-<% if (model.properties || model.parents) {-%>
+<% if ((model.properties || []).filter(p => !p.isDiscriminator).length > 0 || model.parents) {-%>
         /// <summary>
         /// Initializes a new instance of the <%=model.language.default.name%> class.
         /// </summary>


### PR DESCRIPTION
[Here ](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/preview/2022-08-15-preview/dataTransferService.json#L297)is an example swagger.
For the case above, we will generate a model class without properties, in which there are two same constructors without parameters generated. And we need to remove one.