### PR TITLE
Add support of json input

### DIFF
--- a/powershell/cmdlets/namespace.ts
+++ b/powershell/cmdlets/namespace.ts
@@ -3,11 +3,34 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
-import { ImportDirective, Namespace } from '@azure-tools/codegen-csharp';
+import {
+  Attribute,
+  ImportDirective,
+  Namespace,
+  Property,
+  System,
+} from '@azure-tools/codegen-csharp';
 import { Schema, ClientRuntime } from '../llcsharp/exports';
 import { State } from '../internal/state';
 import { CmdletClass } from './class';
 import { DeepPartial } from '@azure-tools/codegen';
+import {
+  CommandOperation,
+  VirtualParameter as CommandVirtualParameter,
+} from '../utils/command-operation';
+import { IParameter } from '../utils/components';
+import {
+  SchemaType,
+  Parameter,
+  Schema as SchemaModel,
+  Operation,
+} from '@azure-tools/codemodel';
+import {
+  CategoryAttribute,
+  ParameterAttribute,
+  ParameterCategory,
+  ValidateNotNull,
+} from '../internal/powershell-declarations';
 
 export class CmdletNamespace extends Namespace {
   inputModels = new Array<Schema>();
@@ -15,7 +38,11 @@ export class CmdletNamespace extends Namespace {
     return this.state.project.cmdletFolder;
   }
 
-  constructor(parent: Namespace, private state: State, objectInitializer?: DeepPartial<CmdletNamespace>) {
+  constructor(
+    parent: Namespace,
+    private state: State,
+    objectInitializer?: DeepPartial<CmdletNamespace>
+  ) {
     super('Cmdlets', parent);
     this.apply(objectInitializer);
   }
@@ -25,14 +52,220 @@ export class CmdletNamespace extends Namespace {
     this.add(new ImportDirective(`${ClientRuntime.Cmdlets}`));
     this.add(new ImportDirective('System'));
 
+    const processedViaJsonOperation = new Set();
+
     // generate cmdlet classes on top of the SDK
-    for (const { key: index, value: operation } of items(this.state.model.commands.operations)) {
+    for (const { key: index, value: operation } of items(
+      this.state.model.commands.operations
+    )) {
       // skip ViaIdentity for set-* cmdlets.
-      if (this.state.project.azure && operation.details.csharp.verb === 'Set' && operation.details.csharp.name.indexOf('ViaIdentity') > 0) {
+      if (
+        this.state.project.azure &&
+        operation.details.csharp.verb === 'Set' &&
+        operation.details.csharp.name.indexOf('ViaIdentity') > 0
+      ) {
         continue;
       }
-      this.addClass(await new CmdletClass(this, operation, this.state.path('commands', 'operations', index)).init());
+      this.addClass(
+        await new CmdletClass(
+          this,
+          operation,
+          this.state.path('commands', 'operations', index)
+        ).init()
+      );
+
+      if (
+        this.state.project.supportJsonInput &&
+        hasValidBodyParameters(operation)
+      ) {
+        const operationCommandId = `${operation.verb}-${
+          (<any>operation).subjectPrefix
+        }${(<any>operation).subject}`;
+        if (!processedViaJsonOperation.has(operationCommandId)) {
+          const callGraph = {
+            language: JSON.parse(
+              JSON.stringify(operation.callGraph[0].language)
+            ),
+            parameters: operation.callGraph[0].parameters!.map((p) => {
+              return { ...p };
+            }),
+            apiVersions: operation.callGraph[0].apiVersions,
+            requests: operation.callGraph[0].requests,
+            responses: operation.callGraph[0].responses,
+            exceptions: operation.callGraph[0].exceptions,
+            extensions: operation.callGraph[0].extensions,
+          };
+          if (callGraph.requests && callGraph.requests.length > 0) {
+            callGraph.requests[0].parameters =
+              callGraph.requests[0].parameters!.filter(
+                (r) => r.protocol.http?.in !== 'body'
+              );
+            callGraph.requests[0].signatureParameters =
+              callGraph.requests[0].signatureParameters!.filter(
+                (r) => r.protocol.http?.in !== 'body'
+              );
+          }
+          const jsonOperation = new CommandOperation('', {
+            verb: operation.verb,
+            noun: operation.noun,
+            variant: operation.variant,
+            parameters: [...operation.parameters],
+            details: { ...operation.details },
+            extensions: operation.extensions,
+            deprecated: operation.deprecated,
+            responses: operation.responses,
+            callGraph: [callGraph],
+          });
+          (<any>jsonOperation).subject = (<any>operation).subject;
+          (<any>jsonOperation).subjectPrefix = (<any>operation).subjectPrefix;
+          this.addJsonStringOperation(jsonOperation, index);
+          this.addJsonFilePathOperation(jsonOperation, index);
+          processedViaJsonOperation.add(operationCommandId);
+        }
+      }
     }
     return this;
   }
+
+  private async addJsonFilePathOperation(
+    operation: CommandOperation,
+    index: string
+  ) {
+    const name = 'JsonFilePath';
+    const description = `Json string supplied to the ${operation.variant} operation`;
+    operation.details.csharp.name = `${operation.variant}ViaJsonFilePath`;
+
+    const newClass = await new CmdletClass(
+      this,
+      operation,
+      this.state.path('commands', 'operations', index)
+    ).init();
+
+    const property = new Property(name, System.String);
+    property.add(
+      new Attribute(ParameterAttribute, {
+        parameters: ['Mandatory = true', `HelpMessage = "${description}"`],
+      })
+    );
+    property.add(new Attribute(ValidateNotNull));
+    property.add(
+      new Attribute(CategoryAttribute, {
+        parameters: [`${ParameterCategory}.Runtime`],
+      })
+    );
+
+    property.set = 'if (!System.IO.File.Exists(value)) { throw new Exception("Cannot find File " + value); } this._jsonString = System.IO.File.ReadAllText(value);';
+    newClass.addProperty(property);
+
+    const jsonStringProperty = newClass.properties.find(
+      (item) => item.name === 'JsonString'
+    );
+    jsonStringProperty!.attributes = [];
+
+    this.addClass(newClass);
+  }
+
+  private async addJsonStringOperation(
+    operation: CommandOperation,
+    index: string
+  ) {
+    operation.details.csharp.name = `${operation.variant}ViaJsonString`;
+    operation.details.csharp.hidden = false;
+    operation.parameters = operation.parameters.filter(
+      (item) => item.details.default.isBodyParameter !== true
+    );
+    operation.callGraph[0].language.csharp!.name = `${
+      (<any>operation.callGraph[0]).language.csharp!.name
+    }ViaJsonString`;
+    const name = 'JsonString';
+    const serializedName = 'jsonString';
+    const description = `Json string supplied to the ${operation.variant} operation`;
+    const language = {
+      default: {
+        name: name,
+        description: description,
+        serializedName: serializedName,
+      },
+      csharp: {
+        name: name,
+        description: description,
+        serializedName: serializedName,
+        byReference: false,
+      },
+    };
+    const schema = new SchemaModel(name, description, SchemaType.String);
+    schema.language = language;
+    const httpParameter = {
+      implementation: 'Method',
+      language: language,
+      schema: schema,
+      required: true,
+    };
+    const parameter = new IParameter(name, schema, {
+      description: description,
+      required: false,
+      details: {
+        default: {
+          description: description,
+          name: name,
+          isBodyParameter: false,
+        },
+        csharp: {
+          description: description,
+          name: name,
+          isBodyParameter: false,
+          httpParameter: httpParameter,
+        },
+      },
+      schema: schema,
+      allowEmptyValue: false,
+      deprecated: false,
+    });
+    (<any>parameter).httpParameter = httpParameter;
+    const classParameter = new Parameter(name, description, schema, {
+      language: language,
+      protocol: {
+        http: {
+          in: 'runtime',
+        },
+      },
+    });
+    operation.callGraph[0].parameters!.push(classParameter);
+    operation.parameters.push(parameter);
+    operation.details.csharp.virtualParameters!.operation =
+      operation.details.csharp.virtualParameters!.operation.filter(
+        (p) => (<any>p.origin).details.csharp.isBodyParameter !== true
+      );
+    const vparam: CommandVirtualParameter = {
+      name: name,
+      description: description,
+      required: true,
+      nameOptions: [],
+      schema: schema,
+      alias: [],
+      origin: parameter,
+    };
+    operation.details.csharp.virtualParameters?.operation.push(vparam);
+    const newClass = await new CmdletClass(
+      this,
+      operation,
+      this.state.path('commands', 'operations', index)
+    ).init();
+    this.addClass(newClass);
+  }
+}
+
+export function hasValidBodyParameters(operation: CommandOperation): boolean {
+  if (
+    operation.callGraph[0].requests &&
+    operation.callGraph[0].requests.length > 0 &&
+    operation.callGraph[0].requests[0].parameters &&
+    operation.callGraph[0].requests[0].parameters.length > 0
+  ) {
+    const param = operation.callGraph[0].requests[0].parameters.find(
+      (p) => !p.origin || p.origin.indexOf('modelerfour:synthesized') < 0
+    );
+    return !!param;
+  }
+  return false;
 }

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -3,38 +3,38 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dictionary, values } from '@azure-tools/linq';
+import { Dictionary, values } from "@azure-tools/linq";
 import {
   SchemaDetails,
   LanguageDetails,
   EnhancedTypeDeclaration,
   Boolean,
   SchemaDefinitionResolver,
-} from '../llcsharp/exports';
-import { State } from './state';
-import { Project as codeDomProject } from '@azure-tools/codegen-csharp';
-import { EnumNamespace } from '../enums/namespace';
-import { ModelExtensionsNamespace } from '../models/model-extensions';
-import { pwshHeaderText } from '../utils/powershell-comment';
+} from "../llcsharp/exports";
+import { State } from "./state";
+import { Project as codeDomProject } from "@azure-tools/codegen-csharp";
+import { EnumNamespace } from "../enums/namespace";
+import { ModelExtensionsNamespace } from "../models/model-extensions";
+import { pwshHeaderText } from "../utils/powershell-comment";
 
-import { ModuleNamespace } from '../module/module-namespace';
-import { CmdletNamespace } from '../cmdlets/namespace';
-import { Host } from '@azure-tools/autorest-extension-base';
+import { ModuleNamespace } from "../module/module-namespace";
+import { CmdletNamespace } from "../cmdlets/namespace";
+import { Host } from "@azure-tools/autorest-extension-base";
 import {
   codemodel,
   PropertyDetails,
   exportedModels as T,
-} from '@azure-tools/codemodel-v3';
-import { DeepPartial, comment } from '@azure-tools/codegen';
-import { PwshModel } from '../utils/PwshModel';
-import { ModelState } from '../utils/model-state';
+} from "@azure-tools/codemodel-v3";
+import { DeepPartial, comment } from "@azure-tools/codegen";
+import { PwshModel } from "../utils/PwshModel";
+import { ModelState } from "../utils/model-state";
 import {
   BooleanSchema,
   ChoiceSchema,
   ConstantSchema,
   Schema as NewSchema,
   SchemaType,
-} from '@azure-tools/codemodel';
+} from "@azure-tools/codemodel";
 
 export type Schema = T.SchemaT<
   LanguageDetails<SchemaDetails>,
@@ -79,7 +79,7 @@ export interface PsRequiredModule {
 export class NewPSSwitch extends Boolean {
   get declaration(): string {
     return `global::System.Management.Automation.SwitchParameter${
-      this.isRequired ? '' : '?'
+      this.isRequired ? "" : "?"
     }`;
   }
 }
@@ -176,6 +176,7 @@ export class Project extends codeDomProject {
   public metadata!: Metadata;
   public state!: State;
   public helpLinkPrefix!: string;
+  public supportJsonInput!: boolean;
   get model() {
     return <PwshModel>this.state.model;
   }
@@ -194,49 +195,49 @@ export class Project extends codeDomProject {
 
     this.schemaDefinitionResolver = new PSSchemaResolver();
 
-    this.projectNamespace = this.state.model.language.csharp?.namespace || '';
+    this.projectNamespace = this.state.model.language.csharp?.namespace || "";
 
     this.overrides = {
-      'Carbon.Json.Converters': `${this.projectNamespace}.Runtime.Json`,
-      'Carbon.Internal.Extensions': `${this.projectNamespace}.Runtime.Json`,
-      'Carbon.Internal': `${this.projectNamespace}.Runtime.Json`,
-      'Carbon.Data': `${this.projectNamespace}.Runtime.Json`,
-      'using Data;': '',
-      'using Parser;': '',
-      'using Converters;': '',
-      'using Internal.Extensions;': '',
+      "Carbon.Json.Converters": `${this.projectNamespace}.Runtime.Json`,
+      "Carbon.Internal.Extensions": `${this.projectNamespace}.Runtime.Json`,
+      "Carbon.Internal": `${this.projectNamespace}.Runtime.Json`,
+      "Carbon.Data": `${this.projectNamespace}.Runtime.Json`,
+      "using Data;": "",
+      "using Parser;": "",
+      "using Converters;": "",
+      "using Internal.Extensions;": "",
 
-      'Carbon.Json.Parser': `${this.projectNamespace}.Runtime.Json`,
-      'Carbon.Json': `${this.projectNamespace}.Runtime.Json`,
-      'Microsoft.Rest.ClientRuntime': `${this.projectNamespace}.Runtime`,
-      'Microsoft.Message.ClientRuntime': `${this.projectNamespace}.Runtime`,
-      'Microsoft.generated.runtime.Properties': `${this.projectNamespace}.generated.runtime.Properties`,
-      'Microsoft.Rest': `${this.projectNamespace}`,
+      "Carbon.Json.Parser": `${this.projectNamespace}.Runtime.Json`,
+      "Carbon.Json": `${this.projectNamespace}.Runtime.Json`,
+      "Microsoft.Rest.ClientRuntime": `${this.projectNamespace}.Runtime`,
+      "Microsoft.Message.ClientRuntime": `${this.projectNamespace}.Runtime`,
+      "Microsoft.generated.runtime.Properties": `${this.projectNamespace}.generated.runtime.Properties`,
+      "Microsoft.Rest": `${this.projectNamespace}`,
     };
 
     // Values
-    this.moduleVersion = await this.state.getValue('module-version');
+    this.moduleVersion = await this.state.getValue("module-version");
     // skip-for-time-being
     //this.profiles = this.model.info.extensions['x-ms-metadata'].profiles || [];
     this.profiles = [];
-    this.accountsVersionMinimum = '2.7.5';
-    this.helpLinkPrefix = await this.state.getValue('help-link-prefix');
-    this.metadata = await this.state.getValue<Metadata>('metadata');
+    this.accountsVersionMinimum = "2.7.5";
+    this.helpLinkPrefix = await this.state.getValue("help-link-prefix");
+    this.metadata = await this.state.getValue<Metadata>("metadata");
     this.preprocessMetadata();
-    this.license = await this.state.getValue('header-text', '');
+    this.license = await this.state.getValue("header-text", "");
     const pwshLicenseHeader = await this.state.getValue(
-      'pwsh-license-header',
-      ''
+      "pwsh-license-header",
+      ""
     );
     // if pwsh license header is not set, use the license set by license-header
     this.pwshCommentHeader = comment(
       pwshLicenseHeader
         ? pwshHeaderText(
-          pwshLicenseHeader,
-          await this.service.GetValue('header-definitions')
-        )
+            pwshLicenseHeader,
+            await this.service.GetValue("header-definitions")
+          )
         : this.license,
-      '#'
+      "#"
     );
     this.pwshCommentHeaderForCsharp = this.pwshCommentHeader.replace(
       /"/g,
@@ -245,96 +246,100 @@ export class Project extends codeDomProject {
     this.csharpCommentHeader = comment(
       pwshLicenseHeader
         ? pwshHeaderText(
-          pwshLicenseHeader,
-          await this.service.GetValue('header-definitions')
-        )
+            pwshLicenseHeader,
+            await this.service.GetValue("header-definitions")
+          )
         : this.license,
-      '//'
+      "//"
     );
 
     // modelcmdlets are models that we will create cmdlets for.
     this.modelCmdlets = [];
     let directives: Array<any> = [];
-    const allDirectives = await this.state.getValue('directive');
+    const allDirectives = await this.state.getValue("directive");
     directives = values(<any>allDirectives).toArray();
-    for (const directive of directives.filter((each) => each['model-cmdlet'])) {
+    for (const directive of directives.filter((each) => each["model-cmdlet"])) {
       this.modelCmdlets = this.modelCmdlets.concat(
-        <ConcatArray<string>>values(directive['model-cmdlet']).toArray()
+        <ConcatArray<string>>values(directive["model-cmdlet"]).toArray()
       );
     }
     // input handlers
-    this.inputHandlers = await this.state.getValue('input-handlers', []);
+    this.inputHandlers = await this.state.getValue("input-handlers", []);
     // Flags
     this.azure = this.model.language.default.isAzure;
     this.addToString = await this.state.getValue(
-      'nested-object-to-string',
+      "nested-object-to-string",
       false
     );
     // Names
     this.prefix = this.model.language.default.prefix;
     this.serviceName = this.model.language.default.serviceName;
     this.subjectPrefix = this.model.language.default.subjectPrefix;
-    this.moduleName = await this.state.getValue('module-name');
-    this.rootModuleName = await this.state.getValue('root-module-name', '');
-    this.dllName = await this.state.getValue('dll-name');
+    this.moduleName = await this.state.getValue("module-name");
+    this.rootModuleName = await this.state.getValue("root-module-name", "");
+    this.dllName = await this.state.getValue("dll-name");
     // Azure PowerShell data plane configuration
     if (this.azure) {
       this.endpointResourceIdKeyName = await this.state.getValue(
-        'endpoint-resource-id-key-name',
-        ''
+        "endpoint-resource-id-key-name",
+        ""
       );
       this.endpointSuffixKeyName = await this.state.getValue(
-        'endpoint-suffix-key-name',
-        ''
+        "endpoint-suffix-key-name",
+        ""
       );
     }
 
     // Folders
-    this.baseFolder = await this.state.getValue('current-folder');
-    this.moduleFolder = await this.state.getValue('module-folder');
-    this.cmdletFolder = await this.state.getValue('cmdlet-folder');
-    this.modelCmdletFolder = await this.state.getValue('model-cmdlet-folder');
+    this.baseFolder = await this.state.getValue("current-folder");
+    this.moduleFolder = await this.state.getValue("module-folder");
+    this.cmdletFolder = await this.state.getValue("cmdlet-folder");
+    this.modelCmdletFolder = await this.state.getValue("model-cmdlet-folder");
 
-    this.customFolder = await this.state.getValue('custom-cmdlet-folder');
-    this.utilsFolder = await this.state.getValue('utils-cmdlet-folder');
-    this.internalFolder = await this.state.getValue('internal-cmdlet-folder');
-    this.testFolder = await this.state.getValue('test-folder');
-    this.runtimeFolder = await this.state.getValue('runtime-folder');
-    this.apiFolder = await this.state.getValue('api-folder');
+    this.customFolder = await this.state.getValue("custom-cmdlet-folder");
+    this.utilsFolder = await this.state.getValue("utils-cmdlet-folder");
+    this.internalFolder = await this.state.getValue("internal-cmdlet-folder");
+    this.testFolder = await this.state.getValue("test-folder");
+    this.runtimeFolder = await this.state.getValue("runtime-folder");
+    this.apiFolder = await this.state.getValue("api-folder");
 
-    this.binFolder = await this.state.getValue('bin-folder');
-    this.objFolder = await this.state.getValue('obj-folder');
-    this.exportsFolder = await this.state.getValue('exports-folder');
-    this.docsFolder = await this.state.getValue('docs-folder');
+    this.binFolder = await this.state.getValue("bin-folder");
+    this.objFolder = await this.state.getValue("obj-folder");
+    this.exportsFolder = await this.state.getValue("exports-folder");
+    this.docsFolder = await this.state.getValue("docs-folder");
     this.dependencyModuleFolder = await this.state.getValue(
-      'dependency-module-folder'
+      "dependency-module-folder"
     );
-    this.examplesFolder = await this.state.getValue('examples-folder');
-    this.resourcesFolder = await this.state.getValue('resources-folder');
-    this.uxFolder = await this.state.getValue('ux-folder');
+    this.examplesFolder = await this.state.getValue("examples-folder");
+    this.resourcesFolder = await this.state.getValue("resources-folder");
+    this.uxFolder = await this.state.getValue("ux-folder");
 
     // File paths
-    this.csproj = await this.state.getValue('csproj');
-    this.dll = await this.state.getValue('dll');
-    this.psd1 = await this.state.getValue('psd1');
-    this.psm1 = await this.state.getValue('psm1');
-    this.psm1Custom = await this.state.getValue('psm1-custom');
-    this.psm1Internal = await this.state.getValue('psm1-internal');
-    this.formatPs1xml = await this.state.getValue('format-ps1xml');
-    this.nuspec = await this.state.getValue('nuspec');
+    this.csproj = await this.state.getValue("csproj");
+    this.dll = await this.state.getValue("dll");
+    this.psd1 = await this.state.getValue("psd1");
+    this.psm1 = await this.state.getValue("psm1");
+    this.psm1Custom = await this.state.getValue("psm1-custom");
+    this.psm1Internal = await this.state.getValue("psm1-internal");
+    this.formatPs1xml = await this.state.getValue("format-ps1xml");
+    this.nuspec = await this.state.getValue("nuspec");
     this.gitIgnore = `${this.baseFolder}/.gitignore`;
     this.gitAttributes = `${this.baseFolder}/.gitattributes`;
     this.readme = `${this.baseFolder}/README.md`;
+    this.supportJsonInput = await this.state.getValue(
+      "support-json-input",
+      false
+    );
 
     // excluded properties in table view
     const excludedList = <Array<string>>(
       values(
-        <any>await this.state.getValue('exclude-tableview-properties', [])
+        <any>await this.state.getValue("exclude-tableview-properties", [])
       ).toArray()
     );
     this.propertiesExcludedForTableview = excludedList
-      ? excludedList.join(',')
-      : '';
+      ? excludedList.join(",")
+      : "";
 
     // add project namespace
     this.serviceNamespace = new ModuleNamespace(this.state);
@@ -351,7 +356,7 @@ export class Project extends codeDomProject {
     this.modelsExtensions = new ModelExtensionsNamespace(
       this.serviceNamespace,
       <any>this.state.model.schemas,
-      this.state.path('components', 'schemas')
+      this.state.path("components", "schemas")
     );
     this.modelsExtensions.header = this.license;
     this.addNamespace(this.modelsExtensions);
@@ -379,12 +384,12 @@ export class Project extends codeDomProject {
         ...this.metadata,
         requiredModulesAsString: this.metadata.requiredModules
           ? this.metadata.requiredModules
-            .map(
-              (m) =>
-                `@{ModuleName = '${m.name}'; ModuleVersion = '${m.version}'}`
-            )
-            ?.join(', ')
-          : 'undefined',
+              .map(
+                (m) =>
+                  `@{ModuleName = '${m.name}'; ModuleVersion = '${m.version}'}`
+              )
+              ?.join(", ")
+          : "undefined",
         requiredAssembliesAsString: this.convertToPsListAsString(
           this.metadata.requiredAssemblies
         ),
@@ -414,6 +419,6 @@ export class Project extends codeDomProject {
   }
 
   private convertToPsListAsString(items: Array<string>): string {
-    return items ? items.map((i) => `'${i}'`).join(', ') : 'undefined';
+    return items ? items.map((i) => `'${i}'`).join(", ") : "undefined";
   }
 }

--- a/powershell/llcsharp/operation/api-class.ts
+++ b/powershell/llcsharp/operation/api-class.ts
@@ -3,19 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
-import { Class, Namespace } from '@azure-tools/codegen-csharp';
+import { items, values, keys, Dictionary, length } from "@azure-tools/linq";
+import { Class, Namespace } from "@azure-tools/codegen-csharp";
 
-import { State } from '../generator';
-import { OperationMethod, CallMethod, ValidationMethod } from '../operation/method';
-import { ParameterLocation } from '@azure-tools/codemodel-v3';
-import { DeepPartial } from '@azure-tools/codegen';
+import { State } from "../generator";
+import {
+  OperationMethod,
+  CallMethod,
+  ValidationMethod,
+} from "../operation/method";
+import { ParameterLocation } from "@azure-tools/codemodel-v3";
+import { DeepPartial } from "@azure-tools/codegen";
+import { hasValidBodyParameters } from "../../utils/http-operation";
 
 export class ApiClass extends Class {
-
   // protected sender: Property;
-  constructor(namespace: Namespace, protected state: State, objectInitializer?: DeepPartial<ApiClass>) {
-    super(namespace, state.model.language.csharp?.name || '');
+  constructor(
+    namespace: Namespace,
+    protected state: State,
+    objectInitializer?: DeepPartial<ApiClass>
+  ) {
+    super(namespace, state.model.language.csharp?.name || "");
     this.apply(objectInitializer);
 
     // add basics
@@ -26,19 +34,49 @@ export class ApiClass extends Class {
     // todo
     for (const operationGroup of state.model.operationGroups) {
       for (const operation of operationGroup.operations) {
-        const operationMethod = new OperationMethod(this, operation, false, state);
+        const operationMethod = new OperationMethod(
+          this,
+          operation,
+          false,
+          state
+        );
         this.addMethod(operationMethod);
-        // Compare with m3, m4 operation has one more parameter called '$host'. We should skip it
-        const parameters = operation.parameters?.filter((param) => param.language.default.serializedName !== '$host');
-        if ([...values(parameters).select(each => each.protocol.http?.in === ParameterLocation.Path)].length > 0) {
-          // method has parameters in the path, so it could support '...ViaIdentity' 
-          const identityMethod = new OperationMethod(this, operation, true, state);
-          identityMethod.emitCall(false);
-          this.addMethod(identityMethod);
 
+        if (hasValidBodyParameters(operation)) {
+          const jsonMethod = new OperationMethod(
+            this,
+            operation,
+            false,
+            state,
+            true
+          );
+          jsonMethod.emitCall(false);
+          this.addMethod(jsonMethod);
         }
 
-        // check if this exact method is been created before (because _call and _validate have less specific parameters than the api) 
+        // Compare with m3, m4 operation has one more parameter called '$host'. We should skip it
+        const parameters = operation.parameters?.filter(
+          (param) => param.language.default.serializedName !== "$host"
+        );
+        if (
+          [
+            ...values(parameters).select(
+              (each) => each.protocol.http?.in === ParameterLocation.Path
+            ),
+          ].length > 0
+        ) {
+          // method has parameters in the path, so it could support '...ViaIdentity'
+          const identityMethod = new OperationMethod(
+            this,
+            operation,
+            true,
+            state
+          );
+          identityMethod.emitCall(false);
+          this.addMethod(identityMethod);
+        }
+
+        // check if this exact method is been created before (because _call and _validate have less specific parameters than the api)
         const cm = new CallMethod(this, operationMethod, state);
         if (!this.hasMethodWithSameDeclaration(cm)) {
           this.addMethod(cm);
@@ -49,7 +87,6 @@ export class ApiClass extends Class {
           this.addMethod(vm);
         }
       }
-
     }
   }
 }

--- a/powershell/llcsharp/operation/method.ts
+++ b/powershell/llcsharp/operation/method.ts
@@ -3,77 +3,161 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { NewResponse, ParameterLocation } from '@azure-tools/codemodel-v3';
-import { Operation, SchemaResponse, BinaryResponse, Schema as NewSchema, Response, BinarySchema } from '@azure-tools/codemodel';
-import { items, values, keys, Dictionary, length } from '@azure-tools/linq';
-import { EOL, DeepPartial } from '@azure-tools/codegen';
-import { Access, Modifier } from '@azure-tools/codegen-csharp';
-import { Class } from '@azure-tools/codegen-csharp';
-import { Binary } from '../schema/binary';
+import { NewResponse, ParameterLocation } from "@azure-tools/codemodel-v3";
+import {
+  Operation,
+  SchemaResponse,
+  BinaryResponse,
+  Schema as NewSchema,
+  Parameter as NewHttpOperationParameter,
+  Response,
+  BinarySchema,
+  SchemaType,
+} from "@azure-tools/codemodel";
+import { items, values, keys, Dictionary, length } from "@azure-tools/linq";
+import { EOL, DeepPartial } from "@azure-tools/codegen";
+import { Access, Modifier } from "@azure-tools/codegen-csharp";
+import { Class } from "@azure-tools/codegen-csharp";
+import { Binary } from "../schema/binary";
 
-import { Expression, ExpressionOrLiteral, LiteralExpression, StringExpression, toExpression, valueOf } from '@azure-tools/codegen-csharp';
-import { Method } from '@azure-tools/codegen-csharp';
-import { Parameter } from '@azure-tools/codegen-csharp';
-import { Case, DefaultCase, TerminalCase, TerminalDefaultCase } from '@azure-tools/codegen-csharp';
-import { Finally } from '@azure-tools/codegen-csharp';
-import { If, While } from '@azure-tools/codegen-csharp';
-import { Return } from '@azure-tools/codegen-csharp';
-import { OneOrMoreStatements, Statement, Statements } from '@azure-tools/codegen-csharp';
-import { Switch } from '@azure-tools/codegen-csharp';
-import { Try } from '@azure-tools/codegen-csharp';
-import { Using } from '@azure-tools/codegen-csharp';
-import { Local, LocalVariable, Variable } from '@azure-tools/codegen-csharp';
-import { ClientRuntime } from '../clientruntime';
-import { HttpOperation, Schema } from '../code-model';
-import { State } from '../generator';
-import { CallbackParameter, OperationParameter, OperationBodyParameter } from '../operation/parameter';
+import {
+  Expression,
+  ExpressionOrLiteral,
+  LiteralExpression,
+  StringExpression,
+  toExpression,
+  valueOf,
+} from "@azure-tools/codegen-csharp";
+import { Method } from "@azure-tools/codegen-csharp";
+import { Parameter } from "@azure-tools/codegen-csharp";
+import {
+  Case,
+  DefaultCase,
+  TerminalCase,
+  TerminalDefaultCase,
+} from "@azure-tools/codegen-csharp";
+import { Finally } from "@azure-tools/codegen-csharp";
+import { If, While } from "@azure-tools/codegen-csharp";
+import { Return } from "@azure-tools/codegen-csharp";
+import {
+  OneOrMoreStatements,
+  Statement,
+  Statements,
+} from "@azure-tools/codegen-csharp";
+import { Switch } from "@azure-tools/codegen-csharp";
+import { Try } from "@azure-tools/codegen-csharp";
+import { Using } from "@azure-tools/codegen-csharp";
+import { Local, LocalVariable, Variable } from "@azure-tools/codegen-csharp";
+import { ClientRuntime } from "../clientruntime";
+import { HttpOperation, Schema } from "../code-model";
+import { State } from "../generator";
+import {
+  CallbackParameter,
+  OperationParameter,
+  OperationBodyParameter,
+} from "../operation/parameter";
 
-import { isMediaTypeJson, isMediaTypeXml, KnownMediaType, knownMediaType, normalizeMediaType, parseMediaType } from '@azure-tools/codemodel-v3';
-import { ClassType, dotnet, System } from '@azure-tools/codegen-csharp';
-import { Ternery } from '@azure-tools/codegen-csharp';
+import {
+  isMediaTypeJson,
+  isMediaTypeXml,
+  KnownMediaType,
+  knownMediaType,
+  normalizeMediaType,
+  parseMediaType,
+} from "@azure-tools/codemodel-v3";
+import { ClassType, dotnet, System } from "@azure-tools/codegen-csharp";
+import { Ternery } from "@azure-tools/codegen-csharp";
 
-
-function removeEncoding(pp: OperationParameter, paramName: string, kmt: KnownMediaType): string {
-  const up = pp.typeDeclaration.serializeToNode(kmt, pp, paramName, ClientRuntime.SerializationMode.None).value;
-  return pp.param.extensions && pp.param.extensions['x-ms-skip-url-encoding'] ? up.replace(/global::System.Uri.EscapeDataString|System.Uri.EscapeDataString/g, '') : up;
+function removeEncoding(
+  pp: OperationParameter,
+  paramName: string,
+  kmt: KnownMediaType
+): string {
+  const up = pp.typeDeclaration.serializeToNode(
+    kmt,
+    pp,
+    paramName,
+    ClientRuntime.SerializationMode.None
+  ).value;
+  return pp.param.extensions && pp.param.extensions["x-ms-skip-url-encoding"]
+    ? up.replace(
+        /global::System.Uri.EscapeDataString|System.Uri.EscapeDataString/g,
+        ""
+      )
+    : up;
 }
 
-
 export class EventListener {
-  constructor(protected expression: Expression, protected emitSignals: boolean) {
-  }
+  constructor(
+    protected expression: Expression,
+    protected emitSignals: boolean
+  ) {}
 
-  *signalNoCheck(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
+  *signalNoCheck(
+    eventName: Expression,
+    ...additionalParameters: Array<string | Expression>
+  ) {
     if (this.emitSignals) {
-      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params =
+        length(additionalParameters) > 0
+          ? `, ${additionalParameters.joinWith((each) =>
+              typeof each === "string" ? each : each.value
+            )}`
+          : "";
       yield `await ${this.expression.value}.Signal(${eventName}${params});`;
     }
   }
-  *syncSignalNoCheck(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
+  *syncSignalNoCheck(
+    eventName: Expression,
+    ...additionalParameters: Array<string | Expression>
+  ) {
     if (this.emitSignals) {
-      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params =
+        length(additionalParameters) > 0
+          ? `, ${additionalParameters.joinWith((each) =>
+              typeof each === "string" ? each : each.value
+            )}`
+          : "";
       yield `${this.expression.value}.Signal(${eventName}${params}).Wait();`;
     }
   }
-  *signal(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
+  *signal(
+    eventName: Expression,
+    ...additionalParameters: Array<string | Expression>
+  ) {
     if (this.emitSignals) {
-      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params =
+        length(additionalParameters) > 0
+          ? `, ${additionalParameters.joinWith((each) =>
+              typeof each === "string" ? each : each.value
+            )}`
+          : "";
       yield `await ${this.expression.value}.Signal(${eventName}${params}); if( ${this.expression.value}.Token.IsCancellationRequested ) { return; }`;
     } else {
-      yield `if( ${this.expression.value}.CancellationToken.IsCancellationRequested ) { throw ${System.OperationCanceledException.new()}; }`;
+      yield `if( ${
+        this.expression.value
+      }.CancellationToken.IsCancellationRequested ) { throw ${System.OperationCanceledException.new()}; }`;
     }
   }
-  *syncSignal(eventName: Expression, ...additionalParameters: Array<string | Expression>) {
+  *syncSignal(
+    eventName: Expression,
+    ...additionalParameters: Array<string | Expression>
+  ) {
     if (this.emitSignals) {
-      const params = length(additionalParameters) > 0 ? `, ${additionalParameters.joinWith(each => typeof each === 'string' ? each : each.value)}` : '';
+      const params =
+        length(additionalParameters) > 0
+          ? `, ${additionalParameters.joinWith((each) =>
+              typeof each === "string" ? each : each.value
+            )}`
+          : "";
       yield `${this.expression.value}.Signal(${eventName}${params}).Wait(); if( ${this.expression.value}.Token.IsCancellationRequested ) { return; }`;
     } else {
-      yield `if( ${this.expression.value}.CancellationToken.IsCancellationRequested ) { throw ${System.OperationCanceledException.new()} }`;
+      yield `if( ${
+        this.expression.value
+      }.CancellationToken.IsCancellationRequested ) { throw ${System.OperationCanceledException.new()} }`;
     }
-
   }
 }
-
 
 export class OperationMethod extends Method {
   public methodParameters: Array<OperationParameter>;
@@ -87,232 +171,418 @@ export class OperationMethod extends Method {
 
   protected callName: string;
 
-  constructor(public parent: Class, public operation: Operation, public viaIdentity: boolean, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
-    super(viaIdentity ? `${operation.language.csharp?.name}ViaIdentity` : operation.language.csharp?.name || '', System.Threading.Tasks.Task());
+  constructor(
+    public parent: Class,
+    public operation: Operation,
+    public viaIdentity: boolean,
+    protected state: State,
+    public viaJson: boolean = false,
+    objectInitializer?: DeepPartial<OperationMethod>
+  ) {
+    super(
+      viaJson
+        ? `${operation.language.csharp?.name}ViaJsonString`
+        : viaIdentity
+        ? `${operation.language.csharp?.name}ViaIdentity`
+        : operation.language.csharp?.name || "",
+      System.Threading.Tasks.Task()
+    );
     this.apply(objectInitializer);
     this.async = Modifier.Async;
     this.returnsDescription = `A <see cref="${System.Threading.Tasks.Task()}" /> that will be complete when handling of the response is completed.`;
     const $this = this;
 
     this.callName = `${operation.language.csharp?.name}_Call`;
-    this.push(Using('NoSynchronizationContext', ''));
+    this.push(Using("NoSynchronizationContext", ""));
 
     // add parameters
     this.methodParameters = [];
 
-    const identity = new Parameter('viaIdentity', System.String);
+    const identity = new Parameter("viaIdentity", System.String);
     if (this.viaIdentity) {
       this.addParameter(identity);
     }
-    let baseUrl = '';
-    for (let index = 0; index < length(this.operation.parameters) && this.operation.parameters; index++) {
+    let baseUrl = "";
+    for (
+      let index = 0;
+      index < length(this.operation.parameters) && this.operation.parameters;
+      index++
+    ) {
       const value = this.operation.parameters[index];
 
-      if (value.language.default.name === '$host') {
+      if (value.language.default.name === "$host") {
         baseUrl = value.clientDefaultValue;
         continue;
       }
-      const p = new OperationParameter(this, value, this.state.path('parameters', index));
+      const p = new OperationParameter(
+        this,
+        value,
+        this.state.path("parameters", index)
+      );
 
       if (value.language.csharp?.constantValue) {
-        const constTd = state.project.modelsNamespace.NewResolveTypeDeclaration(value.schema, true, state);
-        p.defaultInitializer = constTd.deserializeFromString(KnownMediaType.UriParameter, new StringExpression(`${value.language.csharp.constantValue}`), toExpression(constTd.defaultOfType));
+        const constTd = state.project.modelsNamespace.NewResolveTypeDeclaration(
+          value.schema,
+          true,
+          state
+        );
+        p.defaultInitializer = constTd.deserializeFromString(
+          KnownMediaType.UriParameter,
+          new StringExpression(`${value.language.csharp.constantValue}`),
+          toExpression(constTd.defaultOfType)
+        );
       }
 
       // don't add path parameters  when we're in identity mode
-      if (!this.viaIdentity || value.protocol.http?.in !== ParameterLocation.Path) {
+      if (
+        !this.viaIdentity ||
+        value.protocol.http?.in !== ParameterLocation.Path
+      ) {
         this.addParameter(p);
       } else {
         this.add(function* () {
-          yield '';
+          yield "";
         });
       }
       this.methodParameters.push(p);
     }
 
-    if (baseUrl === '') {
+    if (baseUrl === "") {
       // Some services will make the host as an input parameter
-      baseUrl = this.operation.requests ? this.operation.requests[0].protocol.http?.uri : '';
+      baseUrl = this.operation.requests
+        ? this.operation.requests[0].protocol.http?.uri
+        : "";
     }
 
-    this.description = this.operation.language.csharp?.description || '';
+    this.description = this.operation.language.csharp?.description || "";
 
     // add body paramter if there should be one.
-    if (this.operation.requests && this.operation.requests.length && this.operation.requests[0].parameters && this.operation.requests[0].parameters.length) {
+    if (
+      this.operation.requests &&
+      this.operation.requests.length &&
+      this.operation.requests[0].parameters &&
+      this.operation.requests[0].parameters.length
+    ) {
       // this request does have a request body.
-      const param = this.operation.requests[0].parameters.find((p) => !p.origin || p.origin.indexOf('modelerfour:synthesized') < 0);
+      const param = this.operation.requests[0].parameters.find(
+        (p) => !p.origin || p.origin.indexOf("modelerfour:synthesized") < 0
+      );
       if (param) {
-        this.bodyParameter = new OperationBodyParameter(this, 'body', param.language.default.description, param.schema, param.required ?? false, this.state, {
-          // TODO: temp solution. We need a class like NewKnowMediaType
-          mediaType: knownMediaType(KnownMediaType.Json),
-          contentType: KnownMediaType.Json
-        });
-        this.addParameter(this.bodyParameter);
+        if (!viaJson) {
+          this.bodyParameter = new OperationBodyParameter(
+            this,
+            "body",
+            param.language.default.description,
+            param.schema,
+            param.required ?? false,
+            this.state,
+            {
+              // TODO: temp solution. We need a class like NewKnowMediaType
+              mediaType: knownMediaType(KnownMediaType.Json),
+              contentType: KnownMediaType.Json,
+            }
+          );
+          this.addParameter(this.bodyParameter);
+        } else {
+          this.addParameter(
+            new Parameter("jsonString", System.String, {
+              description: `Json string supplied to the ${operation.language.csharp?.name} operation`,
+            })
+          );
+        }
       }
     }
 
-    for (const response of [...values(this.operation.responses), ...values(this.operation.exceptions)]) {
-      const responseType = (<BinaryResponse>response).binary ? new Binary(new BinarySchema(''), true) : ((<SchemaResponse>response).schema ? state.project.modelsNamespace.NewResolveTypeDeclaration(<NewSchema>((<SchemaResponse>response).schema), true, state) : null);
-      const headerType = response.language.default.headerSchema ? state.project.modelsNamespace.NewResolveTypeDeclaration(<NewSchema>response.language.default.headerSchema, true, state) : null;
-      const newCallbackParameter = new CallbackParameter(response.language.csharp?.name || '', responseType, headerType, this.state, { description: response.language.csharp?.description });
+    for (const response of [
+      ...values(this.operation.responses),
+      ...values(this.operation.exceptions),
+    ]) {
+      const responseType = (<BinaryResponse>response).binary
+        ? new Binary(new BinarySchema(""), true)
+        : (<SchemaResponse>response).schema
+        ? state.project.modelsNamespace.NewResolveTypeDeclaration(
+            <NewSchema>(<SchemaResponse>response).schema,
+            true,
+            state
+          )
+        : null;
+      const headerType = response.language.default.headerSchema
+        ? state.project.modelsNamespace.NewResolveTypeDeclaration(
+            <NewSchema>response.language.default.headerSchema,
+            true,
+            state
+          )
+        : null;
+      const newCallbackParameter = new CallbackParameter(
+        response.language.csharp?.name || "",
+        responseType,
+        headerType,
+        this.state,
+        { description: response.language.csharp?.description }
+      );
       this.addParameter(newCallbackParameter);
       this.callbacks.push(newCallbackParameter);
-
-
     }
 
     // add eventhandler parameter
-    this.contextParameter = this.addParameter(new Parameter('eventListener', ClientRuntime.IEventListener, { description: `an <see cref="${ClientRuntime.IEventListener}" /> instance that will receive events.` }));
+    this.contextParameter = this.addParameter(
+      new Parameter("eventListener", ClientRuntime.IEventListener, {
+        description: `an <see cref="${ClientRuntime.IEventListener}" /> instance that will receive events.`,
+      })
+    );
 
     // add optional parameter for sender
-    this.senderParameter = this.addParameter(new Parameter('sender', ClientRuntime.ISendAsync, { description: `an instance of an ${ClientRuntime.ISendAsync} pipeline to use to make the request.` }));
+    this.senderParameter = this.addParameter(
+      new Parameter("sender", ClientRuntime.ISendAsync, {
+        description: `an instance of an ${ClientRuntime.ISendAsync} pipeline to use to make the request.`,
+      })
+    );
 
-    let rx = this.operation.requests ? this.operation.requests[0].protocol.http?.path : '';
+    let rx = this.operation.requests
+      ? this.operation.requests[0].protocol.http?.path
+      : "";
     const path = rx;
     // For post API, Some URI may contain an action string .e.x '/start' at the end
     // of the URI, for such cases, we will drop the action string if identityCorrection
     // is set in the configuration
-    if (this.operation.requests && this.operation.requests.length && this.operation.requests[0].protocol.http?.method === 'post' && this.state.project.identityCorrection) {
-      const idx = rx.lastIndexOf('/');
+    if (
+      this.operation.requests &&
+      this.operation.requests.length &&
+      this.operation.requests[0].protocol.http?.method === "post" &&
+      this.state.project.identityCorrection
+    ) {
+      const idx = rx.lastIndexOf("/");
       rx = rx.substr(0, idx);
     }
 
-    let url = `/${path.startsWith('/') ? path.substr(1) : path}`;
+    let url = `/${path.startsWith("/") ? path.substr(1) : path}`;
 
+    const serverParams = this.methodParameters.filter(
+      (each) => each.param.protocol.http?.in === ParameterLocation.Uri
+    );
 
-    const serverParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Uri);
-
-    const headerParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Header);
-    const pathParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Path);
-    const queryParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Query);
-    const cookieParams = this.methodParameters.filter(each => each.param.protocol.http?.in === ParameterLocation.Cookie);
+    const headerParams = this.methodParameters.filter(
+      (each) => each.param.protocol.http?.in === ParameterLocation.Header
+    );
+    const pathParams = this.methodParameters.filter(
+      (each) => each.param.protocol.http?.in === ParameterLocation.Path
+    );
+    const queryParams = this.methodParameters.filter(
+      (each) => each.param.protocol.http?.in === ParameterLocation.Query
+    );
+    const cookieParams = this.methodParameters.filter(
+      (each) => each.param.protocol.http?.in === ParameterLocation.Cookie
+    );
 
     // replace any server params in the uri
     for (const pp of serverParams) {
-      url = url.replace(`{${pp.param.language.default.serializedName}}`, `"
+      url = url.replace(
+        `{${pp.param.language.default.serializedName}}`,
+        `"
         + ${pp.name}
-        + "`);
+        + "`
+      );
     }
 
     for (const pp of pathParams) {
-      rx = rx.replace(`{${pp.param.language.default.serializedName}}`, `(?<${pp.param.language.default.serializedName}>[^/]+)`);
+      rx = rx.replace(
+        `{${pp.param.language.default.serializedName}}`,
+        `(?<${pp.param.language.default.serializedName}>[^/]+)`
+      );
 
       if (this.viaIdentity) {
-        url = url.replace(`{${pp.param.language.default.serializedName}}`, `"
+        url = url.replace(
+          `{${pp.param.language.default.serializedName}}`,
+          `"
         + ${pp.name}
-        + "`);
+        + "`
+        );
       } else {
-        url = url.replace(`{${pp.param.language.default.serializedName}}`, `"
-        + ${removeEncoding(pp, '', KnownMediaType.UriParameter)}
-        + "`);
+        url = url.replace(
+          `{${pp.param.language.default.serializedName}}`,
+          `"
+        + ${removeEncoding(pp, "", KnownMediaType.UriParameter)}
+        + "`
+        );
       }
     }
     rx = `"^${rx}$"`;
-    url = url.replace(/\s*\+ ""/gm, '');
+    url = url.replace(/\s*\+ ""/gm, "");
 
     const bp = this.bodyParameter;
 
     if (bp) {
-      this.serializationMode = ClientRuntime.SerializationMode.IncludeCreateOrUpdate;
-      if (operation.language.default.name === 'Patch') {
+      this.serializationMode =
+        ClientRuntime.SerializationMode.IncludeCreateOrUpdate;
+      if (operation.language.default.name === "Patch") {
         this.serializationMode = ClientRuntime.SerializationMode.IncludeUpdate;
       }
       // add optional parameter for json serialization mode
-      this.serializationModeParameter = this.addParameter(new Parameter('serializationMode', ClientRuntime.SerializationMode, { description: `Allows the caller to choose the depth of the serialization. See <see cref="${ClientRuntime.SerializationMode}"/>.`, defaultInitializer: this.serializationMode }));
+      this.serializationModeParameter = this.addParameter(
+        new Parameter("serializationMode", ClientRuntime.SerializationMode, {
+          description: `Allows the caller to choose the depth of the serialization. See <see cref="${ClientRuntime.SerializationMode}"/>.`,
+          defaultInitializer: this.serializationMode,
+        })
+      );
     }
     // add method implementation...
 
     this.add(function* () {
-      const eventListener = new EventListener($this.contextParameter, $this.state.project.emitSignals);
+      const eventListener = new EventListener(
+        $this.contextParameter,
+        $this.state.project.emitSignals
+      );
 
       yield EOL;
 
       if ($this.viaIdentity) {
-        yield '// verify that Identity format is an exact match for uri';
+        yield "// verify that Identity format is an exact match for uri";
         yield EOL;
 
-        const match = Local('_match', `${System.Text.RegularExpressions.Regex.new(rx, 'global::System.Text.RegularExpressions.RegexOptions.IgnoreCase').value}.Match(${identity.value})`);
+        const match = Local(
+          "_match",
+          `${
+            System.Text.RegularExpressions.Regex.new(
+              rx,
+              "global::System.Text.RegularExpressions.RegexOptions.IgnoreCase"
+            ).value
+          }.Match(${identity.value})`
+        );
         yield match.declarationStatement;
-        yield If(`!${match}.Success`, `throw new global::System.Exception("Invalid identity for URI '${path}'");`);
+        yield If(
+          `!${match}.Success`,
+          `throw new global::System.Exception("Invalid identity for URI '${path}'");`
+        );
         yield EOL;
-        yield '// replace URI parameters with values from identity';
+        yield "// replace URI parameters with values from identity";
         for (const pp of pathParams) {
           yield `var ${pp.name} = ${match.value}.Groups["${pp.param.language.default.serializedName}"].Value;`;
         }
       }
 
-      yield '// construct URL';
-      const pathAndQueryV = Local('pathAndQuery', `${System.Text.RegularExpressions.Regex.declaration}.Replace(
+      yield "// construct URL";
+      const pathAndQueryV = Local(
+        "pathAndQuery",
+        `${System.Text.RegularExpressions.Regex.declaration}.Replace(
         "${url}"
-        ${queryParams.length > 0 ? '+ "?"' : ''}${queryParams.joinWith(pp => `
-        + ${removeEncoding(pp, pp.param.language.default.serializedName, KnownMediaType.QueryParameter)}`, `
+        ${queryParams.length > 0 ? '+ "?"' : ""}${queryParams.joinWith(
+          (pp) => `
+        + ${removeEncoding(
+          pp,
+          pp.param.language.default.serializedName,
+          KnownMediaType.QueryParameter
+        )}`,
+          `
         + "&"`
-)}
-        ,"\\\\?&*$|&*$|(\\\\?)&+|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, ''));
+        )}
+        ,"\\\\?&*$|&*$|(\\\\?)&+|(&)&+","$1$2")`.replace(/\s*\+ ""/gm, "")
+      );
       yield pathAndQueryV.declarationStatement;
 
       yield EOL;
 
-      yield eventListener.signal(ClientRuntime.Events.URLCreated, pathAndQueryV.value);
+      yield eventListener.signal(
+        ClientRuntime.Events.URLCreated,
+        pathAndQueryV.value
+      );
       yield EOL;
 
-      yield '// generate request object ';
-      const urlV = new LocalVariable('_url', dotnet.Var, {
-        initializer: System.Uri.new(`$"${baseUrl}{${pathAndQueryV.value}}"`)
+      yield "// generate request object ";
+      const urlV = new LocalVariable("_url", dotnet.Var, {
+        initializer: System.Uri.new(`$"${baseUrl}{${pathAndQueryV.value}}"`),
       });
       yield urlV.declarationStatement;
-      const method = $this.operation.requests ? $this.operation.requests[0].protocol.http?.method : '';
-      yield `var request =  ${System.Net.Http.HttpRequestMessage.new(`${ClientRuntime.fullName}.Method.${method.capitalize()}, ${urlV.value}`)};`;
-      yield eventListener.signal(ClientRuntime.Events.RequestCreated, 'request.RequestUri.PathAndQuery');
+      const method = $this.operation.requests
+        ? $this.operation.requests[0].protocol.http?.method
+        : "";
+      yield `var request =  ${System.Net.Http.HttpRequestMessage.new(
+        `${ClientRuntime.fullName}.Method.${method.capitalize()}, ${urlV.value}`
+      )};`;
+      yield eventListener.signal(
+        ClientRuntime.Events.RequestCreated,
+        "request.RequestUri.PathAndQuery"
+      );
       yield EOL;
 
       if (length(headerParams) > 0) {
-        yield '// add headers parameters';
+        yield "// add headers parameters";
         for (const hp of headerParams) {
-          if (hp.param.language.default.name === 'Content-Length') {
+          if (hp.param.language.default.name === "Content-Length") {
             // content length is set when the request body is set
             continue;
           }
-          yield hp.serializeToContainerMember(KnownMediaType.Header, new LocalVariable('request.Headers', dotnet.Var), hp.param.language.default.serializedName, ClientRuntime.SerializationMode.None);
+          yield hp.serializeToContainerMember(
+            KnownMediaType.Header,
+            new LocalVariable("request.Headers", dotnet.Var),
+            hp.param.language.default.serializedName,
+            ClientRuntime.SerializationMode.None
+          );
         }
         yield EOL;
       }
       yield eventListener.signal(ClientRuntime.Events.HeaderParametersAdded);
 
       if (bp) {
-        yield '// set body content';
-        yield `request.Content = ${bp.serializeToContent(bp.mediaType, new LiteralExpression('serializationMode'))};`;
-        yield `request.Content.Headers.ContentType = ${System.Net.Http.Headers.MediaTypeHeaderValue.Parse(bp.contentType)};`;
+        yield "// set body content";
+        yield `request.Content = ${bp.serializeToContent(
+          bp.mediaType,
+          new LiteralExpression("serializationMode")
+        )};`;
+        yield `request.Content.Headers.ContentType = ${System.Net.Http.Headers.MediaTypeHeaderValue.Parse(
+          bp.contentType
+        )};`;
         yield eventListener.signal(ClientRuntime.Events.BodyContentSet);
       }
 
-      yield '// make the call ';
+      if (viaJson) {
+        yield "// set body content";
+        yield "request.Content = new global::System.Net.Http.StringContent(jsonString, global::System.Text.Encoding.UTF8);";
+        yield 'request.Content.Headers.ContentType = global::System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");';
+        yield eventListener.signal(ClientRuntime.Events.BodyContentSet);
+      }
+
+      yield "// make the call ";
     });
   }
 
   emitCall(returnFromCall: boolean) {
-
     // storage will return from the call for download, etc.
     if (returnFromCall) {
-      this.returnType = System.Threading.Tasks.Task(System.Net.Http.HttpResponseMessage);
+      this.returnType = System.Threading.Tasks.Task(
+        System.Net.Http.HttpResponseMessage
+      );
     }
 
-    this.add(`await this.${this.callName}(request,${this.callbacks.joinWith(each => each.use, ',')},${this.contextParameter.use},${this.senderParameter.use});`);
+    this.add(
+      `await this.${this.callName}(request,${this.callbacks.joinWith(
+        (each) => each.use,
+        ","
+      )},${this.contextParameter.use},${this.senderParameter.use});`
+    );
 
     // remove constant parameters and make them locals instead.
-    this.insert('// Constant Parameters');
+    this.insert("// Constant Parameters");
     for (let i = length(this.parameters); i--; i < 0) {
       const p = this.parameters[i];
-      if (p && p.defaultInitializer && p.name !== 'serializationMode') {
+      if (p && p.defaultInitializer && p.name !== "serializationMode") {
         this.parameters.splice(i, 1);
-        this.insert(new LocalVariable(p.name, dotnet.Var, { initializer: p.defaultInitializer }));
+        this.insert(
+          new LocalVariable(p.name, dotnet.Var, {
+            initializer: p.defaultInitializer,
+          })
+        );
       }
     }
   }
 }
 export class CallMethod extends Method {
   public returnNull = false;
-  constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
+  constructor(
+    protected parent: Class,
+    protected opMethod: OperationMethod,
+    protected state: State,
+    objectInitializer?: DeepPartial<OperationMethod>
+  ) {
     super(`${opMethod.name}_Call`, System.Threading.Tasks.Task());
     this.description = `Actual wire call for <see cref="${opMethod.name}" /> method.`;
     this.returnsDescription = opMethod.returnsDescription;
@@ -320,43 +590,74 @@ export class CallMethod extends Method {
     this.apply(objectInitializer);
     this.access = Access.Internal;
     this.async = Modifier.Async;
-    this.push(Using('NoSynchronizationContext', ''));
+    this.push(Using("NoSynchronizationContext", ""));
 
     const $this = this;
     // add parameters
     // request, listener, sender
-    const reqParameter = this.addParameter(new Parameter('request', System.Net.Http.HttpRequestMessage, { description: 'the prepared HttpRequestMessage to send.' }));
-    opMethod.callbacks.forEach(each => this.addParameter(each));
+    const reqParameter = this.addParameter(
+      new Parameter("request", System.Net.Http.HttpRequestMessage, {
+        description: "the prepared HttpRequestMessage to send.",
+      })
+    );
+    opMethod.callbacks.forEach((each) => this.addParameter(each));
 
     this.addParameter(opMethod.contextParameter);
     this.addParameter(opMethod.senderParameter);
 
     // add statements to this method
     this.add(function* () {
-      const eventListener = new EventListener(opMethod.contextParameter, $this.state.project.emitSignals);
+      const eventListener = new EventListener(
+        opMethod.contextParameter,
+        $this.state.project.emitSignals
+      );
 
-      const response = Local('_response', dotnet.Null, System.Net.Http.HttpResponseMessage);
+      const response = Local(
+        "_response",
+        dotnet.Null,
+        System.Net.Http.HttpResponseMessage
+      );
       yield response;
       yield Try(function* () {
-
         const responder = function* () {
           // TODO: omit generating _contentType var if it will never be used
           // const contentType = new LocalVariable('_contentType', dotnet.Var, { initializer: `_response.Content.Headers.ContentType?.MediaType` });
-          const contentType = Local('_contentType', `${response}.Content.Headers.ContentType?.MediaType`);
+          const contentType = Local(
+            "_contentType",
+            `${response}.Content.Headers.ContentType?.MediaType`
+          );
 
           yield contentType;
 
           // add response handlers
           yield Switch(`${response}.StatusCode`, function* () {
-            const responses = [...values(opMethod.operation.responses), ...values(opMethod.operation.exceptions)].sort(function (a, b) { return (<string>(a.protocol.http?.statusCodes[0])).localeCompare(<string>(b.protocol.http?.statusCodes[0]));});
+            const responses = [
+              ...values(opMethod.operation.responses),
+              ...values(opMethod.operation.exceptions),
+            ].sort(function (a, b) {
+              return (<string>a.protocol.http?.statusCodes[0]).localeCompare(
+                <string>b.protocol.http?.statusCodes[0]
+              );
+            });
             for (const resp of responses) {
-              if (resp.protocol.http?.statusCodes[0] !== 'default') {
+              if (resp.protocol.http?.statusCodes[0] !== "default") {
                 const responseCode = resp.protocol.http?.statusCodes[0];
                 const leadNum = parseInt(responseCode[0]);
                 // will use enum when it can, fall back to casting int when it can't
-                yield Case(System.Net.HttpStatusCode[responseCode] ? System.Net.HttpStatusCode[responseCode].value : `${System.Net.HttpStatusCode.declaration} n when((int)n >= ${leadNum * 100} && (int)n < ${leadNum * 100 + 100})`, $this.responsesEmitter($this, opMethod, [resp], eventListener));
+                yield Case(
+                  System.Net.HttpStatusCode[responseCode]
+                    ? System.Net.HttpStatusCode[responseCode].value
+                    : `${
+                        System.Net.HttpStatusCode.declaration
+                      } n when((int)n >= ${leadNum * 100} && (int)n < ${
+                        leadNum * 100 + 100
+                      })`,
+                  $this.responsesEmitter($this, opMethod, [resp], eventListener)
+                );
               } else {
-                yield DefaultCase($this.responsesEmitter($this, opMethod, [resp], eventListener));
+                yield DefaultCase(
+                  $this.responsesEmitter($this, opMethod, [resp], eventListener)
+                );
               }
             }
 
@@ -372,54 +673,82 @@ export class CallMethod extends Method {
 
         // try statements
         const sendTask = Local(
-          'sendTask',
+          "sendTask",
           new LiteralExpression(
             `${opMethod.senderParameter.value}.SendAsync(${reqParameter.use}, ${opMethod.contextParameter.value})`
           )
         );
         yield sendTask;
         // delay sending BeforeCall event until URI has been replaced by HTTP pipeline
-        yield eventListener.signal(ClientRuntime.Events.BeforeCall, reqParameter.use);
+        yield eventListener.signal(
+          ClientRuntime.Events.BeforeCall,
+          reqParameter.use
+        );
 
         if ($this.opMethod.operation.language.csharp?.lro) {
-          yield eventListener.signal(ClientRuntime.Events.Progress, new LiteralExpression('"intentional placeholder"'), new LiteralExpression('0'));
+          yield eventListener.signal(
+            ClientRuntime.Events.Progress,
+            new LiteralExpression('"intentional placeholder"'),
+            new LiteralExpression("0")
+          );
         }
 
         yield `${response.value} = await ${sendTask.value};`;
-        yield eventListener.signal(ClientRuntime.Events.ResponseCreated, response.value);
-        const EOL = 'EOL';
+        yield eventListener.signal(
+          ClientRuntime.Events.ResponseCreated,
+          response.value
+        );
+        const EOL = "EOL";
         // LRO processing (if appropriate)
         if ($this.opMethod.operation.language.csharp?.lro) {
-          yield '// this operation supports x-ms-long-running-operation';
-          const originalUri = Local('_originalUri', new LiteralExpression(`${reqParameter.use}.RequestUri.AbsoluteUri`));
+          yield "// this operation supports x-ms-long-running-operation";
+          const originalUri = Local(
+            "_originalUri",
+            new LiteralExpression(`${reqParameter.use}.RequestUri.AbsoluteUri`)
+          );
           yield originalUri;
 
-          yield `// declared final-state-via: ${$this.opMethod.operation.language.csharp.lro['final-state-via']}`;
-          const fsv = $this.opMethod.operation.language.csharp.lro['final-state-via'];
+          yield `// declared final-state-via: ${$this.opMethod.operation.language.csharp.lro["final-state-via"]}`;
+          const fsv =
+            $this.opMethod.operation.language.csharp.lro["final-state-via"];
           let finalUri: LocalVariable;
 
           switch (fsv) {
-            case 'original-uri':
+            case "original-uri":
               // perform a final GET on the original URI.
               finalUri = originalUri;
               break;
 
-            case 'location':
+            case "location":
               // perform a final GET on the uri in Location header
-              finalUri = Local('_finalUri', response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+              finalUri = Local(
+                "_finalUri",
+                response.invokeMethod(
+                  "GetFirstHeader",
+                  new StringExpression("Location")
+                )
+              );
               yield finalUri;
               break;
-            case 'azure-asyncoperation':
-            case 'azure-async-operation':
+            case "azure-asyncoperation":
+            case "azure-async-operation":
               //depending on the type of request, do the appropriate behavior
-              switch ($this.opMethod.operation.requests?.[0].protocol.http?.method.toLowerCase()) {
-                case 'post':
-                case 'delete':
-                  finalUri = Local('_finalUri', response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
+              switch (
+                $this.opMethod.operation.requests?.[0].protocol.http?.method.toLowerCase()
+              ) {
+                case "post":
+                case "delete":
+                  finalUri = Local(
+                    "_finalUri",
+                    response.invokeMethod(
+                      "GetFirstHeader",
+                      new StringExpression("Azure-AsyncOperation")
+                    )
+                  );
                   yield finalUri;
                   break;
-                case 'patch':
-                case 'put':
+                case "patch":
+                case "put":
                   // perform a final GET on the original URI.
                   finalUri = originalUri;
                   break;
@@ -429,74 +758,136 @@ export class CallMethod extends Method {
             default:
               // depending on the type of request, fall back to the appropriate behavior
               if ($this.opMethod.operation.requests) {
-                switch ($this.opMethod.operation.requests[0].protocol.http?.method.toLowerCase()) {
-                  case 'post':
-                  case 'delete':
-                    finalUri = Local('_finalUri', response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+                switch (
+                  $this.opMethod.operation.requests[0].protocol.http?.method.toLowerCase()
+                ) {
+                  case "post":
+                  case "delete":
+                    finalUri = Local(
+                      "_finalUri",
+                      response.invokeMethod(
+                        "GetFirstHeader",
+                        new StringExpression("Location")
+                      )
+                    );
                     yield finalUri;
                     break;
-                  case 'patch':
-                  case 'put':
+                  case "patch":
+                  case "put":
                     // perform a final GET on the original URI.
                     finalUri = originalUri;
                     break;
                 }
               }
               break;
-
           }
 
-          const asyncOperation = Local('asyncOperation', response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
+          const asyncOperation = Local(
+            "asyncOperation",
+            response.invokeMethod(
+              "GetFirstHeader",
+              new StringExpression("Azure-AsyncOperation")
+            )
+          );
           yield asyncOperation;
-          const location = Local('location', response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
+          const location = Local(
+            "location",
+            response.invokeMethod(
+              "GetFirstHeader",
+              new StringExpression("Location")
+            )
+          );
           yield location;
 
-          yield While(new LiteralExpression(`${reqParameter.use}.Method == System.Net.Http.HttpMethod.Put && ${response.value}.StatusCode == ${System.Net.HttpStatusCode[200].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `), function* () {
-            yield '// delay before making the next polling request';
-            yield eventListener.signal(ClientRuntime.Events.DelayBeforePolling, response.value);
+          yield While(
+            new LiteralExpression(
+              `${reqParameter.use}.Method == System.Net.Http.HttpMethod.Put && ${response.value}.StatusCode == ${System.Net.HttpStatusCode[200].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `
+            ),
+            function* () {
+              yield "// delay before making the next polling request";
+              yield eventListener.signal(
+                ClientRuntime.Events.DelayBeforePolling,
+                response.value
+              );
 
-            yield EOL;
-            yield '// while we wait, let\'s grab the headers and get ready to poll. ';
-            yield 'if (!System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Azure-AsyncOperation"))) {';
-            yield '    ' + asyncOperation.assign(response.invokeMethod('GetFirstHeader', new StringExpression('Azure-AsyncOperation')));
-            yield '}';
-            yield 'if (!global::System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Location"))) {';
-            yield '    ' + location.assign(response.invokeMethod('GetFirstHeader', new StringExpression('Location')));
-            yield '}';
-            const uriLocal = Local('_uri', Ternery(
-              System.String.IsNullOrEmpty(asyncOperation),
-              Ternery(System.String.IsNullOrEmpty(location),
-                originalUri,
-                location),
-              asyncOperation));
-            yield uriLocal;
+              yield EOL;
+              yield "// while we wait, let's grab the headers and get ready to poll. ";
+              yield 'if (!System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Azure-AsyncOperation"))) {';
+              yield "    " +
+                asyncOperation.assign(
+                  response.invokeMethod(
+                    "GetFirstHeader",
+                    new StringExpression("Azure-AsyncOperation")
+                  )
+                );
+              yield "}";
+              yield 'if (!global::System.String.IsNullOrEmpty(_response.GetFirstHeader(@"Location"))) {';
+              yield "    " +
+                location.assign(
+                  response.invokeMethod(
+                    "GetFirstHeader",
+                    new StringExpression("Location")
+                  )
+                );
+              yield "}";
+              const uriLocal = Local(
+                "_uri",
+                Ternery(
+                  System.String.IsNullOrEmpty(asyncOperation),
+                  Ternery(
+                    System.String.IsNullOrEmpty(location),
+                    originalUri,
+                    location
+                  ),
+                  asyncOperation
+                )
+              );
+              yield uriLocal;
 
-            yield `${reqParameter.use} = ${reqParameter.use}.CloneAndDispose(${System.Uri.new(uriLocal)}, ${ClientRuntime.Method.Get});`;
+              yield `${reqParameter.use} = ${
+                reqParameter.use
+              }.CloneAndDispose(${System.Uri.new(uriLocal)}, ${
+                ClientRuntime.Method.Get
+              });`;
 
-            yield EOL;
-            yield '// and let\'s look at the current response body and see if we have some information we can give back to the listener';
-            const content = Local('content', new LiteralExpression(`await ${response.value}.Content.ReadAsStringAsync()`));
-            yield content;
+              yield EOL;
+              yield "// and let's look at the current response body and see if we have some information we can give back to the listener";
+              const content = Local(
+                "content",
+                new LiteralExpression(
+                  `await ${response.value}.Content.ReadAsStringAsync()`
+                )
+              );
+              yield content;
 
-            yield EOL;
-            yield '// drop the old response';
-            yield `${response.value}?.Dispose();`;
+              yield EOL;
+              yield "// drop the old response";
+              yield `${response.value}?.Dispose();`;
 
-            yield EOL;
-            yield '// make the polling call';
-            yield `${response.value} = await ${opMethod.senderParameter}.SendAsync(${reqParameter.value}, ${opMethod.contextParameter});`;
-            yield eventListener.signal(ClientRuntime.Events.Polling, response.value);
+              yield EOL;
+              yield "// make the polling call";
+              yield `${response.value} = await ${opMethod.senderParameter}.SendAsync(${reqParameter.value}, ${opMethod.contextParameter});`;
+              yield eventListener.signal(
+                ClientRuntime.Events.Polling,
+                response.value
+              );
 
-            yield EOL;
-            yield `
+              yield EOL;
+              yield `
 // if we got back an OK, take a peek inside and see if it's done
 if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
 {
     var error = false;
     try {
-        if( ${ClientRuntime.JsonNode.Parse(toExpression(`await ${response.value}.Content.ReadAsStringAsync()`))} is ${ClientRuntime.JsonObject} json)
+        if( ${ClientRuntime.JsonNode.Parse(
+          toExpression(`await ${response.value}.Content.ReadAsStringAsync()`)
+        )} is ${ClientRuntime.JsonObject} json)
         {
-            var state = json.Property("properties")?.PropertyT<${ClientRuntime.JsonString}>("provisioningState") ?? json.PropertyT<${ClientRuntime.JsonString}>("status");
+            var state = json.Property("properties")?.PropertyT<${
+              ClientRuntime.JsonString
+            }>("provisioningState") ?? json.PropertyT<${
+                ClientRuntime.JsonString
+              }>("status");
             if( state is null )
             {
                 // the body doesn't contain any information that has the state of the LRO
@@ -516,7 +907,9 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
 
               default:
                 // need to keep polling!
-                ${response.value}.StatusCode = ${System.Net.HttpStatusCode.Created};
+                ${response.value}.StatusCode = ${
+                System.Net.HttpStatusCode.Created
+              };
                 continue;
             }
         }
@@ -525,76 +918,134 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
         // we really don't want to do anything special.
     }
     if (error) {
-        throw new ${ClientRuntime.fullName}.UndeclaredResponseException(${response.value});
+        throw new ${ClientRuntime.fullName}.UndeclaredResponseException(${
+                response.value
+              });
     }
 }`;
 
-            yield EOL;
-            yield '// check for terminal status code';
-            yield If(new LiteralExpression(`${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `), 'continue;');
+              yield EOL;
+              yield "// check for terminal status code";
+              yield If(
+                new LiteralExpression(
+                  `${response.value}.StatusCode == ${System.Net.HttpStatusCode[201].value} || ${response.value}.StatusCode == ${System.Net.HttpStatusCode[202].value} `
+                ),
+                "continue;"
+              );
 
-            yield '// we are done polling, do a request on final target?';
+              yield "// we are done polling, do a request on final target?";
 
-            switch (fsv) {
-              case 'original-uri':
-              case 'azure-asyncoperation':
-              case 'azure-async-operation':
-              case 'location':
-                // perform a final GET on the specified final URI.
-                yield $this.finalGet(eventListener, finalUri, reqParameter, response);
-                break;
+              switch (fsv) {
+                case "original-uri":
+                case "azure-asyncoperation":
+                case "azure-async-operation":
+                case "location":
+                  // perform a final GET on the specified final URI.
+                  yield $this.finalGet(
+                    eventListener,
+                    finalUri,
+                    reqParameter,
+                    response
+                  );
+                  break;
 
-              default:
-                yield If(`!string.IsNullOrWhiteSpace(${finalUri})`, function* () {
-                  yield $this.finalGet(eventListener, finalUri, reqParameter, response);
-                });
-                break;
+                default:
+                  yield If(
+                    `!string.IsNullOrWhiteSpace(${finalUri})`,
+                    function* () {
+                      yield $this.finalGet(
+                        eventListener,
+                        finalUri,
+                        reqParameter,
+                        response
+                      );
+                    }
+                  );
+                  break;
+              }
             }
-          });
+          );
         }
-        yield eventListener.signal(ClientRuntime.Events.Progress, new LiteralExpression('"intentional placeholder"'), new LiteralExpression('100'));
+        yield eventListener.signal(
+          ClientRuntime.Events.Progress,
+          new LiteralExpression('"intentional placeholder"'),
+          new LiteralExpression("100")
+        );
         yield responder();
       });
 
       yield Finally(function* () {
-        yield '// finally statements';
-        yield eventListener.signalNoCheck(ClientRuntime.Events.Finally, 'request', '_response');
+        yield "// finally statements";
+        yield eventListener.signalNoCheck(
+          ClientRuntime.Events.Finally,
+          "request",
+          "_response"
+        );
         yield `${response.value}?.Dispose();`;
         yield `${reqParameter.use}?.Dispose();`;
       });
 
       if ($this.returnNull) {
-        yield Return('result');
-        $this.insert(new LocalVariable('result', System.Net.Http.HttpResponseMessage, { initializer: dotnet.Null }));
+        yield Return("result");
+        $this.insert(
+          new LocalVariable("result", System.Net.Http.HttpResponseMessage, {
+            initializer: dotnet.Null,
+          })
+        );
       }
     });
 
     this.opMethod.emitCall($this.returnNull);
   }
 
-  private * finalGet(eventListener: EventListener, finalLocation: ExpressionOrLiteral, reqParameter: Variable, response: Variable) {
-    yield '// create a new request with the final uri';
-    yield reqParameter.assign(`${valueOf(reqParameter)}.CloneAndDispose(${System.Uri.new(finalLocation)}, ${ClientRuntime.Method.Get})`);
+  private *finalGet(
+    eventListener: EventListener,
+    finalLocation: ExpressionOrLiteral,
+    reqParameter: Variable,
+    response: Variable
+  ) {
+    yield "// create a new request with the final uri";
+    yield reqParameter.assign(
+      `${valueOf(reqParameter)}.CloneAndDispose(${System.Uri.new(
+        finalLocation
+      )}, ${ClientRuntime.Method.Get})`
+    );
 
     yield EOL;
-    yield '// drop the old response';
+    yield "// drop the old response";
     yield `${response.value}?.Dispose();`;
 
     yield EOL;
-    yield '// make the final call';
-    yield response.assign(`await ${this.opMethod.senderParameter}.SendAsync(${valueOf(reqParameter)},  ${this.opMethod.contextParameter})`);
+    yield "// make the final call";
+    yield response.assign(
+      `await ${this.opMethod.senderParameter}.SendAsync(${valueOf(
+        reqParameter
+      )},  ${this.opMethod.contextParameter})`
+    );
     yield eventListener.signal(ClientRuntime.Events.Polling, response.value);
 
     // make sure we're not polling anymore.
-    yield 'break;';
+    yield "break;";
   }
 
-  private * responsesEmitter($this: CallMethod, opMethod: OperationMethod, responses: Array<Response>, eventListener: EventListener) {
+  private *responsesEmitter(
+    $this: CallMethod,
+    opMethod: OperationMethod,
+    responses: Array<Response>,
+    eventListener: EventListener
+  ) {
     if (length(responses) > 1) {
-      yield Switch('_contentType', function* () {
+      yield Switch("_contentType", function* () {
         for (const eachResponse of values(responses)) {
-          const mimetype = length(eachResponse.protocol.http?.mediaTypes) > 0 ? eachResponse.protocol.http?.mimeTypes[0] : '';
-          const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === eachResponse.language.csharp?.name);
+          const mimetype =
+            length(eachResponse.protocol.http?.mediaTypes) > 0
+              ? eachResponse.protocol.http?.mimeTypes[0]
+              : "";
+          const callbackParameter = <CallbackParameter>(
+            values(opMethod.callbacks).first(
+              (each) => each.name === eachResponse.language.csharp?.name
+            )
+          );
 
           let count = length(eachResponse.protocol.http?.mediaTypes);
           for (const mt of values(eachResponse.protocol.http?.mediaTypes)) {
@@ -602,9 +1053,19 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
             const mediaType = normalizeMediaType(<string>mt);
             if (mediaType) {
               if (count === 0) {
-                yield Case(new StringExpression(mediaType).toString(), $this.NewResponseHandler(mimetype, eachResponse, callbackParameter));
+                yield Case(
+                  new StringExpression(mediaType).toString(),
+                  $this.NewResponseHandler(
+                    mimetype,
+                    eachResponse,
+                    callbackParameter
+                  )
+                );
               } else {
-                yield TerminalCase(new StringExpression(mediaType).toString(), '');
+                yield TerminalCase(
+                  new StringExpression(mediaType).toString(),
+                  ""
+                );
               }
             }
           }
@@ -612,21 +1073,39 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
       });
     } else {
       const response = responses[0];
-      const callbackParameter = <CallbackParameter>values(opMethod.callbacks).first(each => each.name === response.language.csharp?.name);
+      const callbackParameter = <CallbackParameter>(
+        values(opMethod.callbacks).first(
+          (each) => each.name === response.language.csharp?.name
+        )
+      );
       // all mimeTypes per for this response code.
-      yield eventListener.signal(ClientRuntime.Events.BeforeResponseDispatch, '_response');
-      yield $this.NewResponseHandler(<string>values(response.protocol.http?.mediaTypes).first() || '', response, callbackParameter);
+      yield eventListener.signal(
+        ClientRuntime.Events.BeforeResponseDispatch,
+        "_response"
+      );
+      yield $this.NewResponseHandler(
+        <string>values(response.protocol.http?.mediaTypes).first() || "",
+        response,
+        callbackParameter
+      );
     }
   }
 
-  private * responseHandlerForNormalPipeline(mimetype: string, eachResponse: NewResponse, callbackParameter: CallbackParameter) {
+  private *responseHandlerForNormalPipeline(
+    mimetype: string,
+    eachResponse: NewResponse,
+    callbackParameter: CallbackParameter
+  ) {
     const callbackParameters = new Array<ExpressionOrLiteral>();
 
     if (callbackParameter.responseType) {
       // hande the body response
-      const r = callbackParameter.responseType.deserializeFromResponse(knownMediaType(mimetype), toExpression('_response'), toExpression('null'));
+      const r = callbackParameter.responseType.deserializeFromResponse(
+        knownMediaType(mimetype),
+        toExpression("_response"),
+        toExpression("null")
+      );
       if (r) {
-
         callbackParameters.push(r);
       }
 
@@ -638,23 +1117,36 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
 
     if (callbackParameter.headerType) {
       // header model deserialization...
-      const r = callbackParameter.headerType.deserializeFromResponse(KnownMediaType.Header, toExpression('_response'), toExpression('null'));
+      const r = callbackParameter.headerType.deserializeFromResponse(
+        KnownMediaType.Header,
+        toExpression("_response"),
+        toExpression("null")
+      );
       if (r) {
         callbackParameters.push(r);
       }
     }
     // make the callback with the appropriate parameters
-    yield `await ${eachResponse.details.csharp.name}(_response${callbackParameters.length === 0 ? '' : ','}${callbackParameters.joinWith(valueOf)});`;
+    yield `await ${eachResponse.details.csharp.name}(_response${
+      callbackParameters.length === 0 ? "" : ","
+    }${callbackParameters.joinWith(valueOf)});`;
   }
 
-  private * NewResponseHandlerForNormalPipeline(mimetype: string, eachResponse: Response, callbackParameter: CallbackParameter) {
+  private *NewResponseHandlerForNormalPipeline(
+    mimetype: string,
+    eachResponse: Response,
+    callbackParameter: CallbackParameter
+  ) {
     const callbackParameters = new Array<ExpressionOrLiteral>();
 
     if (callbackParameter.responseType) {
       // hande the body response
-      const r = callbackParameter.responseType.deserializeFromResponse(knownMediaType(mimetype), toExpression('_response'), toExpression('null'));
+      const r = callbackParameter.responseType.deserializeFromResponse(
+        knownMediaType(mimetype),
+        toExpression("_response"),
+        toExpression("null")
+      );
       if (r) {
-
         callbackParameters.push(r);
       }
 
@@ -666,32 +1158,58 @@ if( ${response.value}.StatusCode == ${System.Net.HttpStatusCode.OK})
 
     if (callbackParameter.headerType) {
       // header model deserialization...
-      const r = callbackParameter.headerType.deserializeFromResponse(KnownMediaType.Header, toExpression('_response'), toExpression('null'));
+      const r = callbackParameter.headerType.deserializeFromResponse(
+        KnownMediaType.Header,
+        toExpression("_response"),
+        toExpression("null")
+      );
       if (r) {
         callbackParameters.push(r);
       }
     }
     // make the callback with the appropriate parameters
-    yield `await ${eachResponse.language.csharp?.name}(_response${callbackParameters.length === 0 ? '' : ','}${callbackParameters.joinWith(valueOf)});`;
+    yield `await ${eachResponse.language.csharp?.name}(_response${
+      callbackParameters.length === 0 ? "" : ","
+    }${callbackParameters.joinWith(valueOf)});`;
   }
 
-  private responseHandler(mimetype: string, eachResponse: NewResponse, callbackParameter: CallbackParameter) {
-    return this.responseHandlerForNormalPipeline(mimetype, eachResponse, callbackParameter);
+  private responseHandler(
+    mimetype: string,
+    eachResponse: NewResponse,
+    callbackParameter: CallbackParameter
+  ) {
+    return this.responseHandlerForNormalPipeline(
+      mimetype,
+      eachResponse,
+      callbackParameter
+    );
   }
-  private NewResponseHandler(mimetype: string, eachResponse: Response, callbackParameter: CallbackParameter) {
-    return this.NewResponseHandlerForNormalPipeline(mimetype, eachResponse, callbackParameter);
+  private NewResponseHandler(
+    mimetype: string,
+    eachResponse: Response,
+    callbackParameter: CallbackParameter
+  ) {
+    return this.NewResponseHandlerForNormalPipeline(
+      mimetype,
+      eachResponse,
+      callbackParameter
+    );
   }
 }
 export class ValidationMethod extends Method {
-
-  constructor(protected parent: Class, protected opMethod: OperationMethod, protected state: State, objectInitializer?: DeepPartial<OperationMethod>) {
+  constructor(
+    protected parent: Class,
+    protected opMethod: OperationMethod,
+    protected state: State,
+    objectInitializer?: DeepPartial<OperationMethod>
+  ) {
     super(`${opMethod.name}_Validate`, System.Threading.Tasks.Task());
     this.apply(objectInitializer);
     this.description = `Validation method for <see cref="${opMethod.name}" /> method. Call this like the actual call, but you will get validation events back.`;
     this.returnsDescription = opMethod.returnsDescription;
     this.access = Access.Internal;
     this.async = Modifier.Async;
-    this.push(Using('NoSynchronizationContext', ''));
+    this.push(Using("NoSynchronizationContext", ""));
 
     // add the method parameters
     for (const parameter of opMethod.methodParameters) {
@@ -718,8 +1236,12 @@ export class ValidationMethod extends Method {
 
       // spit out body parameter validation too
       if (opMethod.bodyParameter) {
-        yield opMethod.bodyParameter.validatePresenceStatement(opMethod.contextParameter);
-        yield opMethod.bodyParameter.validationStatement(opMethod.contextParameter);
+        yield opMethod.bodyParameter.validatePresenceStatement(
+          opMethod.contextParameter
+        );
+        yield opMethod.bodyParameter.validationStatement(
+          opMethod.contextParameter
+        );
       }
     });
   }

--- a/powershell/utils/http-operation.ts
+++ b/powershell/utils/http-operation.ts
@@ -1,7 +1,7 @@
-// /*---------------------------------------------------------------------------------------------
-//  *  Copyright (c) Microsoft Corporation. All rights reserved.
-//  *  Licensed under the MIT License. See License.txt in the project root for license information.
-//  *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
 
 // import { Components, Example, ExternalDocumentation, ImplementationDetails, ImplementationLocation, IOperation, IOperationBase, IParameter, LanguageDetails, Link, ParameterDetails, ResponseDetails, SecurityRequirement, Server } from './components';
 // import { Extensions } from './extensions';
@@ -10,13 +10,17 @@
 // import { DeepPartial } from '@azure-tools/codegen';
 // import { Dictionary } from '@azure-tools/linq';
 // import { uid } from './uid';
+import {
+  Operation,
+  Parameter as NewHttpOperationParameter,
+} from "@azure-tools/codemodel";
 
 // export interface HttpOperationDetails extends ImplementationDetails {
 // }
 
-// /** 
-//  * An encoding attribute is introduced to give you control over the serialization of parts of multipart request bodies. 
-//  * This attribute is only applicable to multipart and application/x-www-form-urlencoded request bodies. 
+// /**
+//  * An encoding attribute is introduced to give you control over the serialization of parts of multipart request bodies.
+//  * This attribute is only applicable to multipart and application/x-www-form-urlencoded request bodies.
 // */
 // export class Encoding extends Extensions implements Encoding {
 //   public headers = new Array<Header>();
@@ -68,11 +72,11 @@
 // }
 
 export enum ParameterLocation {
-  Uri = 'uri',
-  Query = 'query',
-  Header = 'header',
-  Cookie = 'cookie',
-  Path = 'path',
+  Uri = "uri",
+  Query = "query",
+  Header = "header",
+  Cookie = "cookie",
+  Path = "path",
 }
 
 // export enum EncodingStyle {
@@ -298,3 +302,20 @@ export enum ParameterLocation {
 //     this.apply(initializer);
 //   }
 // }
+
+export function hasValidBodyParameters(
+  operation: Operation
+): NewHttpOperationParameter | undefined {
+  if (
+    operation.requests &&
+    operation.requests.length > 0 &&
+    operation.requests[0].parameters &&
+    operation.requests[0].parameters.length > 0
+  ) {
+    const param = operation.requests[0].parameters.find(
+      (p) => !p.origin || p.origin.indexOf("modelerfour:synthesized") < 0
+    );
+    return param;
+  }
+  return undefined;
+}


### PR DESCRIPTION
If use configure `support-json-input` as true, will generate two parameter sets:
1. Accept raw json string as parameter `-JsonString`, will send the content as http request body.
2. Accept a file path as parameter `-JsonFilePath` will read the content in the file, will send the content as http request body.