### PR TITLE
v4 - remove discriminator parameter in auxiliary cmdlet

### DIFF
--- a/powershell/llcsharp/csharp-declarations.ts
+++ b/powershell/llcsharp/csharp-declarations.ts
@@ -9,5 +9,6 @@ import { ClassType, Namespace, TypeDeclaration } from '@azure-tools/codegen-csha
 const rest = new Namespace('Microsoft.Rest');
 
 export const PropertyOriginAttribute: TypeDeclaration = new ClassType(rest, 'Origin');
+export const ConstantAttribute: TypeDeclaration = new ClassType(rest, 'Constant');
 export const DoNotFormatAttribute: TypeDeclaration = new ClassType(rest, 'DoNotFormat');
 export const FormatTableAttribute: TypeDeclaration = new ClassType(rest, 'FormatTable');

--- a/powershell/resources/psruntime/BuildTime/PsAttributes.cs
+++ b/powershell/resources/psruntime/BuildTime/PsAttributes.cs
@@ -110,6 +110,11 @@ namespace Microsoft.Rest
     }
 
     [AttributeUsage(AttributeTargets.Property)]
+    public class ConstantAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
     public class FormatTableAttribute : Attribute
     {
         public int Index { get; set; } = -1;


### PR DESCRIPTION
Discriminator is fixed when we create an instance of a child class, so the parameter is useless in auxiliary cmdlet.