### PR TITLE
v4 - support setting cmdlet name for model cmdlet

### DIFF
--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -76,6 +76,10 @@ export interface PsRequiredModule {
   version: string;
 }
 
+interface ModelCmdletDirective {
+  'model-name': string;
+  'cmdlet-name'?: string
+}
 export class NewPSSwitch extends Boolean {
   get declaration(): string {
     return `global::System.Management.Automation.SwitchParameter${this.isRequired ? '' : '?'}`;
@@ -159,7 +163,8 @@ export class Project extends codeDomProject {
   public schemaDefinitionResolver!: SchemaDefinitionResolver;
   public moduleVersion!: string;
   public profiles!: Array<string>;
-  public modelCmdlets!: Array<string>;
+  public modelCmdlets!: Array<ModelCmdletDirective>;
+  public modelCmdletsInPS!: string;
   public inputHandlers!: Array<string>;
 
   public prefix!: string;
@@ -259,9 +264,10 @@ export class Project extends codeDomProject {
     directives = values(<any>allDirectives).toArray();
     for (const directive of directives.filter((each) => each['model-cmdlet'])) {
       this.modelCmdlets = this.modelCmdlets.concat(
-        <ConcatArray<string>>values(directive['model-cmdlet']).toArray()
+        <ConcatArray<ModelCmdletDirective>>values(directive['model-cmdlet']).toArray()
       );
     }
+    this.modelCmdletsInPS = this.modelCmdlets.map(each => `@{modelName="${each['model-name']}"; cmdletName="${each['cmdlet-name'] || ''}"}`).join(', ') || '';
     // input handlers
     this.inputHandlers = await this.state.getValue('input-handlers', []);
     // Flags

--- a/powershell/resources/assets/build-module.ps1
+++ b/powershell/resources/assets/build-module.ps1
@@ -119,7 +119,7 @@ $examplesFolder = Join-Path $PSScriptRoot '${$lib.path.relative($project.baseFol
 $null = New-Item -ItemType Directory -Force -Path $examplesFolder
 
 Write-Host -ForegroundColor Green 'Creating cmdlets for specified models...'
-$modelCmdlets = @(${$project.modelCmdlets.map(each => `'` + each + `'`).join(', ')})
+$modelCmdlets = @(${$project.modelCmdletsInPS})
 if ($modelCmdlets.Count -gt 0) {
   . (Join-Path $PSScriptRoot 'create-model-cmdlets.ps1')
   CreateModelCmdlet($modelCmdlets)


### PR DESCRIPTION
Directive for model-cmdlet changed from
```
- model-cmdlet
  - xxx
```
to
```
- model-cmdlet
  - model-name: xxx
     model-cmdlet: yyy
```