### PR TITLE
Change default values for azure  case

### DIFF
--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -270,10 +270,7 @@ export class Project extends codeDomProject {
     this.inputHandlers = await this.state.getValue('input-handlers', []);
     // Flags
     this.azure = this.model.language.default.isAzure;
-    this.addToString = await this.state.getValue(
-      'nested-object-to-string',
-      false
-    );
+    this.addToString = await this.state.getValue('nested-object-to-string', this.azure ? true : false);
     // Names
     this.prefix = this.model.language.default.prefix;
     this.serviceName = this.model.language.default.serviceName;

--- a/powershell/llcsharp/project.ts
+++ b/powershell/llcsharp/project.ts
@@ -46,10 +46,10 @@ export class Project extends codeDomProject {
     this.apifolder = await this.state.getValue('api-folder', '');
     this.runtimefolder = await this.state.getValue('runtime-folder', 'runtime');
     this.azure = await this.state.getValue('azure', false) || await this.state.getValue('azure-arm', false);
-    this.identityCorrection = await this.state.getValue('identity-correction-for-post', false);
-    this.resourceGroupAppend = await this.state.getValue('resourcegroup-append', false);
+    this.identityCorrection = await this.state.getValue('identity-correction-for-post', this.azure ? true : false);
+    this.resourceGroupAppend = await this.state.getValue('resourcegroup-append', this.azure ? true : false);
     this.license = await this.state.getValue('header-text', '');
-    this.exportPropertiesForDict = await this.state.getValue('export-properties-for-dict', true);
+    this.exportPropertiesForDict = await this.state.getValue('export-properties-for-dict', this.azure ? true : false);
     this.formats = await this.state.getValue('formats', {});
 
 


### PR DESCRIPTION
We need to set up default directives and configuration if module is under Azure PowerShell. For instance:

resourcegroup-append should be true
identity-correction-for-post: true
export-properties-for-dict: true
nested-object-to-string：true