### PR TITLE
Add retry support in v4

### DIFF
--- a/powershell/llcsharp/project.ts
+++ b/powershell/llcsharp/project.ts
@@ -25,7 +25,7 @@ export class Project extends codeDomProject {
   public exportPropertiesForDict!: boolean;
   public projectNamespace!: string;
   public overrides!: Dictionary<string>;
-  protected state!: State;
+  public state!: State;
 
   apifolder!: string;
   runtimefolder!: string;

--- a/powershell/llcsharp/project.ts
+++ b/powershell/llcsharp/project.ts
@@ -21,6 +21,7 @@ export class Project extends codeDomProject {
   public xmlSerialization = false;
   public defaultPipeline = true;
   public emitSignals = true;
+  public enableApiRetry = true;
   public exportPropertiesForDict!: boolean;
   public projectNamespace!: string;
   public overrides!: Dictionary<string>;
@@ -51,6 +52,7 @@ export class Project extends codeDomProject {
     this.license = await this.state.getValue('header-text', '');
     this.exportPropertiesForDict = await this.state.getValue('export-properties-for-dict', true);
     this.formats = await this.state.getValue('formats', {});
+    this.enableApiRetry = await this.state.getValue('enable-api-retry', true);
 
 
     // add project namespace


### PR DESCRIPTION
There are two kinds of retries.

1. Retry on error
Default retry time is 3, but can be overridden by env variable PS_HTTP_MAX_RETRIES and AZURE_PS_HTTP_MAX_RETRIES (most high priority)
3. retry on 429 with retry-after
Default retry time will be max(int), but can be overridden by env variable PS_HTTP_MAX_RETRIES_FOR_429 and AZURE_PS_HTTP_MAX_RETRIES_FOR_429 (most high priority)