### PR TITLE
v4 - add directive to suppress shouldprocess, fixed #704

### DIFF
--- a/powershell/utils/command-operation.ts
+++ b/powershell/utils/command-operation.ts
@@ -88,3 +88,16 @@ export interface CommandComponents extends Components<CommandOperation, IParamet
 
 export class CommandComponents extends Components<CommandOperation, IParameter> {
 }
+
+export function isWritableCmdlet(operation: CommandOperation): boolean {
+  if (operation.callGraph[0].requests) {
+    switch (operation.callGraph[0].requests[0]?.protocol.http?.method.toLowerCase()) {
+      case 'put':
+      case 'post':
+      case 'delete':
+      case 'patch':
+        return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
This directive is especially useful for some post APIs like listkey or checksomething, which actually does not require shouldprocess for generated cmdlets
```
  - where:
      verb: Get
    set:
      suppress-should-process: true
```