### PR TITLE
Remove complex interface information from help markdown

### DIFF
--- a/powershell/resources/assets/build-module.ps1
+++ b/powershell/resources/assets/build-module.ps1
@@ -136,7 +136,8 @@ if($NoDocs) {
     $null = Get-ChildItem -Path $docsFolder -Recurse -Exclude 'README.md' | Remove-Item -Recurse -ErrorAction SilentlyContinue
   }
   $null = New-Item -ItemType Directory -Force -Path $docsFolder
-  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ModuleDescription $moduleDescription -DocsFolder $docsFolder -ExamplesFolder $examplesFolder -ModuleGuid $guid
+  $addComplexInterfaceInfo = ![System.Convert]::ToBoolean('${$project.azure}')
+  Export-ProxyCmdlet -ModuleName $moduleName -ModulePath $modulePaths -ExportsFolder $exportsFolder -InternalFolder $internalFolder -ModuleDescription $moduleDescription -DocsFolder $docsFolder -ExamplesFolder $examplesFolder -ModuleGuid $guid -AddComplexInterfaceInfo:$addComplexInterfaceInfo
 }
 
 Write-Host -ForegroundColor Green 'Creating format.ps1xml...'

--- a/powershell/resources/assets/generate-help.ps1
+++ b/powershell/resources/assets/generate-help.ps1
@@ -55,8 +55,8 @@ foreach($directory in $directories)
   $docsPath = Join-Path $docsFolder $directory.Name
   $null = New-Item -ItemType Directory -Force -Path $docsPath -ErrorAction SilentlyContinue
   $examplesPath = Join-Path $examplesFolder $directory.Name
-
-  Export-HelpMarkdown -ModuleInfo $moduleInfo -FunctionInfo $cmdletFunctionInfo -HelpInfo $cmdletHelpInfo -DocsFolder $docsPath -ExamplesFolder $examplesPath
+  $addComplexInterfaceInfo = ![System.Convert]::ToBoolean('${$project.azure}')
+  Export-HelpMarkdown -ModuleInfo $moduleInfo -FunctionInfo $cmdletFunctionInfo -HelpInfo $cmdletHelpInfo -DocsFolder $docsPath -ExamplesFolder $examplesPath -AddComplexInterfaceInfo:$addComplexInterfaceInfo
   Write-Host -ForegroundColor Green "Created documentation in '$docsPath'"
 }
 

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportHelpMarkdown.cs
@@ -33,6 +33,9 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
     [ValidateNotNullOrEmpty]
     public string ExamplesFolder { get; set; }
 
+    [Parameter()]
+    public SwitchParameter AddComplexInterfaceInfo { get; set; }
+
     protected override void ProcessRecord()
     {
       try
@@ -41,7 +44,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         var variantGroups = FunctionInfo.Select(fi => fi.BaseObject).Cast<FunctionInfo>()
             .Join(helpInfos, fi => fi.Name, phi => phi.CmdletName, (fi, phi) => fi.ToVariants(phi))
             .Select(va => new VariantGroup(ModuleInfo.Name, va.First().CmdletName, va, String.Empty));
-        WriteMarkdowns(variantGroups, ModuleInfo.ToModuleInfo(), DocsFolder, ExamplesFolder);
+        WriteMarkdowns(variantGroups, ModuleInfo.ToModuleInfo(), DocsFolder, ExamplesFolder, AddComplexInterfaceInfo.IsPresent);
       }
       catch (Exception ee)
       {

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         [Parameter(Mandatory = true, ParameterSetName = "NoDocs")]
         public SwitchParameter ExcludeDocs { get; set; }
 
+        [Parameter(ParameterSetName = "Docs")]
+        public SwitchParameter AddComplexInterfaceInfo { get; set; }
+
         protected override void ProcessRecord()
         {
             try
@@ -152,7 +155,7 @@ ${$project.pwshCommentHeaderForCsharp}
                         var isValidProfile = !String.IsNullOrEmpty(profileName) && profileName != NoProfiles;
                         var docsFolder = isValidProfile ? Path.Combine(DocsFolder, profileName) : DocsFolder;
                         var examplesFolder = isValidProfile ? Path.Combine(ExamplesFolder, profileName) : ExamplesFolder;
-                        WriteMarkdowns(variantGroupsByProfile, moduleInfo, docsFolder, examplesFolder);
+                        WriteMarkdowns(variantGroupsByProfile, moduleInfo, docsFolder, examplesFolder, AddComplexInterfaceInfo.IsPresent);
                     }
                 }
             }

--- a/powershell/resources/psruntime/BuildTime/MarkdownRenderer.cs
+++ b/powershell/resources/psruntime/BuildTime/MarkdownRenderer.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 {
     internal static class MarkdownRenderer
     {
-        public static void WriteMarkdowns(IEnumerable<VariantGroup> variantGroups, PsModuleHelpInfo moduleHelpInfo, string docsFolder, string examplesFolder)
+        public static void WriteMarkdowns(IEnumerable<VariantGroup> variantGroups, PsModuleHelpInfo moduleHelpInfo, string docsFolder, string examplesFolder, bool AddComplexInterfaceInfo = true)
         {
             Directory.CreateDirectory(docsFolder);
             var markdownInfos = variantGroups.Where(vg => !vg.IsInternal).Select(vg => new MarkdownHelpInfo(vg, examplesFolder)).OrderBy(mhi => mhi.CmdletName).ToArray();
@@ -69,18 +69,26 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
                 }
 
                 sb.Append($"## NOTES{Environment.NewLine}{Environment.NewLine}");
-                sb.Append($"ALIASES{Environment.NewLine}{Environment.NewLine}");
+                if (markdownInfo.Aliases.Any())
+                {
+                    sb.Append($"ALIASES{Environment.NewLine}{Environment.NewLine}");
+                }
                 foreach (var alias in markdownInfo.Aliases)
                 {
                     sb.Append($"{alias}{Environment.NewLine}{Environment.NewLine}");
                 }
-                if (markdownInfo.ComplexInterfaceInfos.Any())
+
+                if (AddComplexInterfaceInfo)
                 {
-                    sb.Append($"{ComplexParameterHeader}{Environment.NewLine}");
-                }
-                foreach (var complexInterfaceInfo in markdownInfo.ComplexInterfaceInfos)
-                {
-                    sb.Append($"{complexInterfaceInfo.ToNoteOutput(includeDashes: true, includeBackticks: true)}{Environment.NewLine}{Environment.NewLine}");
+                    if (markdownInfo.ComplexInterfaceInfos.Any())
+                    {
+                        sb.Append($"{ComplexParameterHeader}{Environment.NewLine}");
+                    }
+                    foreach (var complexInterfaceInfo in markdownInfo.ComplexInterfaceInfos)
+                    {
+                        sb.Append($"{complexInterfaceInfo.ToNoteOutput(includeDashes: true, includeBackticks: true)}{Environment.NewLine}{Environment.NewLine}");
+                    }
+
                 }
 
                 sb.Append($"## RELATED LINKS{Environment.NewLine}{Environment.NewLine}");


### PR DESCRIPTION
Fixing #832 

Before:
![image](https://github.com/Azure/autorest.powershell/assets/19869716/72214d27-ea88-4080-9ab3-b34d16de9549)
After：
![image](https://github.com/Azure/autorest.powershell/assets/19869716/67b8d787-9827-47c4-a7fc-295d45b7fb46)
