### PR TITLE
v4 - stop getting next page if nextlink is an empty string

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -978,7 +978,7 @@ export class CmdletClass extends Class {
                       }));
                       const nextLinkName = `${result.value}.${nl.name}`;
                       yield `_nextLink = ${nextLinkName};`;
-                      const nextLinkCondition = $this.clientsidePagination ? '_nextLink != null && this.PagingParameters.First > 0' : '_nextLink != null';
+                      const nextLinkCondition = $this.clientsidePagination ? '!String.IsNullOrEmpty(_nextLink) && this.PagingParameters.First > 0' : '!String.IsNullOrEmpty(_nextLink)';
                       yield (If('_isFirst', function* () {
                         yield '_isFirst = false;';
                         yield (While(nextLinkCondition,


### PR DESCRIPTION
Sometimes service will return an empty string instead of null, which it should be. And this enhancement is added for the case like this.
Related issue is https://github.com/Azure/autorest.powershell/issues/982.