### PR TITLE
Fixed two issues related to x-ms-azure-resource and constructor without parameters

### DIFF
--- a/powershell/resources/templates/model.ejs
+++ b/powershell/resources/templates/model.ejs
@@ -58,7 +58,7 @@ if (p.property.schema.type == 'sealed-choice' || p.property.schema.type == 'choi
 <%});-%>
         public <%- model.language.default.name%>(<%-model.language.default.constructorParametersDeclaration%>)
 <%# If there is only one direct parent, will implement it as parent%>
-<% var publicVirtualProperties = project.helper.GetAllPublicVirtualProperties(model.language.default.virtualProperties);
+<% var publicVirtualProperties = (model.extensions && model.extensions["x-ms-azure-resource"]) ? project.helper.GetAllPublicVirtualPropertiesWithoutInherited(model.language.default.virtualProperties) : project.helper.GetAllPublicVirtualProperties(model.language.default.virtualProperties);
 if (model.language.default.baseConstructorCall) {
         publicVirtualProperties = project.helper.GetAllPublicVirtualPropertiesWithoutInherited(model.language.default.virtualProperties);
 -%>

--- a/powershell/sdk/utility.ts
+++ b/powershell/sdk/utility.ts
@@ -21,7 +21,7 @@ export class Helper {
 
   public HasConstantProperty(schema: Schema): boolean {
     const virtualProperties = this.GetAllPublicVirtualProperties(schema.language.default.virtualProperties);
-    return virtualProperties.filter(p => p.required && (p.property.schema.type === SchemaType.Constant || this.IsConstantProperty(p))).length > 0;
+    return virtualProperties.filter(p => p.required && (p.property.schema.type === SchemaType.Constant || this.IsConstantProperty(p) || (p.property.schema.type === SchemaType.Object && this.HasConstantProperty(p.property.schema)))).length > 0;
   }
 
   public GetCsharpType(schema: Schema): string {


### PR DESCRIPTION
1. If x-ms-azure-resource is set, will inherent from Microsoft.Rest.Azure.IResource and other parents will be ignored
2. For member with const properties, need to new it in the constructor without parameters.