### PR TITLE
do not append action for post viaidentity

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1017,7 +1017,7 @@ export class CmdletClass extends Class {
           }
         });
         //add child resource to path for list operation
-        if ($this.operation.variant.startsWith('List') && pathParamsInIdentitySerializedName?.[pathParamsInIdentitySerializedName.length - 1]) {
+        if ($this.operation.variant.startsWith('List') && $this.operation.callGraph[0].requests?.[0].protocol.http?.method.toLowerCase() !== 'post' && pathParamsInIdentitySerializedName?.[pathParamsInIdentitySerializedName.length - 1]) {
           const childResourceName = getChildResourceNameFromPath(path, pathParamsInIdentitySerializedName?.[pathParamsInIdentitySerializedName.length - 1]);
           if (pathParams && pathParams.length > 0) {
             pathParams += `/${childResourceName}`;


### PR DESCRIPTION
fixing #1198 

API ```List=>POST:"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}/listAllTrafficFilters"```
was treated as list operation, thus the list viaidentity cmdlet append action 'listAllTrafficFilters' for identity '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Elastic/monitors/{monitorName}'
```
if (MonitorInputObject?.Id != null)
{
    this.MonitorInputObject.Id += "/listAllTrafficFilters";
    await this.Client.AllTrafficFiltersListViaIdentity(MonitorInputObject.Id, onOk, onDefault, this, Pipeline);
}
```
Add check for list operations, if it's post API, append nothing to the identity.