### PR TITLE
Add Start-TestSleep to avoid waiting during playback mode

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportTestStub.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportTestStub.cs
@@ -56,6 +56,31 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         return -join ((48..57) + (97..122) | Get-Random -Count $len | % {[char]$_})
     }
 }
+function Start-TestSleep {
+    [CmdletBinding(DefaultParameterSetName = 'SleepBySeconds')]
+    param(
+        [parameter(Mandatory = $true, Position = 0, ParameterSetName = 'SleepBySeconds')]
+        [ValidateRange(0.0, 2147483.0)]
+        [double] $Seconds,
+
+        [parameter(Mandatory = $true, ParameterSetName = 'SleepByMilliseconds')]
+        [ValidateRange('NonNegative')]
+        [Alias('ms')]
+        [int] $Milliseconds
+    )
+
+    if ($TestMode -ne 'playback') {
+        switch ($PSCmdlet.ParameterSetName) {
+            'SleepBySeconds' {
+                Start-Sleep -Seconds $Seconds
+            }
+            'SleepByMilliseconds' {
+                Start-Sleep -Milliseconds $Milliseconds
+            }
+        }
+    }
+}
+
 $env = @{}
 if ($UsePreviousConfigForRecord) {
     $previousEnv = Get-Content (Join-Path $PSScriptRoot 'env.json') | ConvertFrom-Json


### PR DESCRIPTION
Currently part of the test cases invokes Start-Sleep to wait for a specific period of time until the required resources are ready. However, in the scenario test, it is absolutely not necessary during playback mode. It has increased the total amount of test execution time in the CI. In this PR, we introduce a new function called `Start-TestSleep` to avoid the unnecessary wait time.