### PR TITLE
Expanded parameters should be optional if the entire body parameter is optional

### DIFF
--- a/powershell/plugins/plugin-create-inline-properties.ts
+++ b/powershell/plugins/plugin-create-inline-properties.ts
@@ -381,7 +381,7 @@ function createVirtualParameters(operation: CommandOperation) {
             name: virtualProperty.name,
             description: virtualProperty.property.language.default.description,
             nameOptions: virtualProperty.nameOptions,
-            required: shouldBeRequired(operation, virtualProperty),
+            required: parameter.required ? shouldBeRequired(operation, virtualProperty) : false,
             schema: virtualProperty.property.schema,
             origin: virtualProperty,
             alias: []


### PR DESCRIPTION
Fixed https://github.com/Azure/autorest.powershell/issues/1290