### PR TITLE
Fix the UX metadata issue caused by missing Categories attribute

### DIFF
--- a/powershell/resources/assets/generate-portal-ux.ps1
+++ b/powershell/resources/assets/generate-portal-ux.ps1
@@ -32,7 +32,7 @@ $moduleInfo = Get-Module -Name $moduleName
 $parameterSetsInfo = Get-Module -Name "$moduleName.private"
 
 $buildinFunctions = @("Export-CmdletSurface", "Export-ExampleStub", "Export-FormatPs1xml", "Export-HelpMarkdown", "Export-ModelSurface", "Export-ProxyCmdlet", "Export-Psd1", "Export-TestStub", "Get-CommonParameter", "Get-ModuleGuid", "Get-ScriptCmdlet")
-$skipParameterList = ("Confirm", "Verbose", "Debug", "ErrorAction", "WarningAction", "InformationAction", "ErrorVariable", "WarningVariable", "InformationVariable", "OutVariable", "OutBuffer", "PipelineVariable", "WhatIf")
+$skipParameterList = @("Confirm", "Verbose", "Debug", "ErrorAction", "WarningAction", "InformationAction", "ErrorVariable", "WarningVariable", "InformationVariable", "OutVariable", "OutBuffer", "PipelineVariable", "WhatIf")
 
 function Test-FunctionSupported()
 {


### PR DESCRIPTION
Currently, the Categories attribute of body parameter may miss in some situation, this will cause to generate a wrong UX metadata element for that cmdlet. This fix is to skip the wrong cmdlets.