### PR TITLE
Implement sanitizer handler for autorest

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -501,9 +501,13 @@ export class CmdletClass extends Class {
       else {
         yield `var telemetryInfo = ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetTelemetryInfo?.Invoke(__correlationId);`;
         yield If('telemetryInfo != null', function* () {
+          yield 'telemetryInfo.TryGetValue("ShowSecretsWarning", out var showSecretsWarning);';
           yield 'telemetryInfo.TryGetValue("SanitizedProperties", out var sanitizedProperties);';
           yield 'telemetryInfo.TryGetValue("InvocationName", out var invocationName);';
-          yield If('!string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName ?? "Unknown"} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+          yield If('showSecretsWarning == "true"', function* () {
+            yield If('string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName} may compromise security by showing secrets. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+            yield Else('WriteWarning($"The output of cmdlet {invocationName} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+          });
         });
       }
     });

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -417,7 +417,9 @@ export class CmdletClass extends Class {
 
     this.NewImplementProcessRecordAsync(this.operation);
 
-    this.NewImplementWriteObject();
+    if (this.state.project.azure) {
+      this.NewImplementWriteObject();
+    }
 
     this.debugMode = await this.state.getValue('debug', false);
 
@@ -496,13 +498,14 @@ export class CmdletClass extends Class {
       if (!$this.state.project.azure) {
         yield $this.eventListener.syncSignal(Events.CmdletEndProcessing);
       }
-
-      yield `var telemetryInfo = ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetTelemetryInfo?.Invoke(__correlationId);`;
-      yield If('telemetryInfo != null', function* () {
-        yield 'telemetryInfo.TryGetValue("SanitizedProperties", out var sanitizedProperties);';
-        yield 'telemetryInfo.TryGetValue("InvocationName", out var invocationName);';
-        yield If('!string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName ?? "Unknown"} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
-      });
+      else {
+        yield `var telemetryInfo = ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetTelemetryInfo?.Invoke(__correlationId);`;
+        yield If('telemetryInfo != null', function* () {
+          yield 'telemetryInfo.TryGetValue("SanitizedProperties", out var sanitizedProperties);';
+          yield 'telemetryInfo.TryGetValue("InvocationName", out var invocationName);';
+          yield If('!string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName ?? "Unknown"} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+        });
+      }
     });
 
     // debugging

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -254,6 +254,15 @@ export class NewModuleClass extends Class {
       PSCmdlet, /* pscmdlet */
     )));
 
+    const sanitizerDelegate = new Alias('SanitizerDelegate', System.Action(
+      dotnet.Object, /* sendToPipeline */
+      dotnet.String  /* telemetryId */
+    ));
+    const getTelemetryInfoDelegate = new Alias('GetTelemetryInfoDelegate', System.Func(
+      dotnet.String /* telemetryId */,
+      /* returns */ System.Collections.Generic.Dictionary(System.String, System.String)
+    ));
+
     const tokenAudienceConverterDelegate = new Alias('TokenAudienceConverterDelegate',
       System.Func(
         dotnet.String,
@@ -293,6 +302,10 @@ export class NewModuleClass extends Class {
     const AddAuthorizeRequestHandler = new Property('AddAuthorizeRequestHandler', authorizeRequestDelegate, { description: 'The delegate to call before each new request to add authorization.' });
     this.add(new Property('GetTelemetryId', getTelemetryIdDelegate, { description: 'The delegate to get the telemetry Id.' }));
     this.add(new Property('Telemetry', telemetryDelegate, { description: 'The delegate for creating a telemetry.' }));
+    const SanitizeOutput = this.add(new Property('SanitizeOutput', sanitizerDelegate, { description: 'The delegate to call in WriteObject to sanitize the output object.' }));
+    namespace.add(sanitizerDelegate);
+    const GetTelemetryInfo = this.add(new Property('GetTelemetryInfo', getTelemetryInfoDelegate, { description: 'The delegate to get the telemetry info.' }));
+    namespace.add(getTelemetryInfoDelegate);
     if (isDataPlane) {
       this.add(AddRequestUserAgentHandler);
       this.add(AddPatchRequestUriHandler);


### PR DESCRIPTION
This pull request primarily focuses on enhancing the telemetry and output sanitization in the `CmdletClass` and `NewModuleClass` within the `powershell/cmdlets/class.ts` and `powershell/module/module-class.ts` files respectively. The changes include the addition of a new method `NewImplementWriteObject`, inclusion of telemetry information, and sanitizing the output object.

Telemetry and Output Sanitization in `CmdletClass`:

* [`powershell/cmdlets/class.ts`]: Added a new method `NewImplementWriteObject` that includes two new `WriteObject` methods to sanitize the output before sending it to the pipeline.
* [`powershell/cmdlets/class.ts`]: Added telemetry information to the `CmdletClass` that includes sanitized properties and invocation name.

Telemetry and Output Sanitization in `NewModuleClass`:

* [`powershell/module/module-class.ts`]: Added `SanitizerDelegate` and `GetTelemetryInfoDelegate` to the `NewModuleClass` to sanitize the output object and get telemetry info respectively.

Other Changes:

* [`powershell/generators/psm1.ts`]: Added delegation to sanitize the output object and get the telemetry info in the `generatePsm1` function.