### PR TITLE
Implement sanitizer handler for autorest modules

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -509,7 +509,9 @@ export class CmdletClass extends Class {
 
     this.NewImplementProcessRecordAsync();
 
-    this.NewImplementWriteObject();
+    if (this.state.project.azure) {
+      this.NewImplementWriteObject();
+    }
 
     this.debugMode = await this.state.getValue('debug', false);
 
@@ -665,13 +667,14 @@ export class CmdletClass extends Class {
         if (!$this.state.project.azure) {
           yield $this.eventListener.syncSignal(Events.CmdletEndProcessing);
         }
-
-        yield `var telemetryInfo = ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetTelemetryInfo?.Invoke(__correlationId);`;
-        yield If('telemetryInfo != null', function* () {
-          yield 'telemetryInfo.TryGetValue("SanitizedProperties", out var sanitizedProperties);';
-          yield 'telemetryInfo.TryGetValue("InvocationName", out var invocationName);';
-          yield If('!string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName ?? "Unknown"} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
-        });
+        else {
+          yield `var telemetryInfo = ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetTelemetryInfo?.Invoke(__correlationId);`;
+          yield If('telemetryInfo != null', function* () {
+            yield 'telemetryInfo.TryGetValue("SanitizedProperties", out var sanitizedProperties);';
+            yield 'telemetryInfo.TryGetValue("InvocationName", out var invocationName);';
+            yield If('!string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName ?? "Unknown"} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+          });
+        }
       });
 
     // debugging

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -270,6 +270,15 @@ export class NewModuleClass extends Class {
       PSCmdlet, /* pscmdlet */
     )));
 
+    const sanitizerDelegate = new Alias('SanitizerDelegate', System.Action(
+      dotnet.Object, /* sendToPipeline */
+      dotnet.String  /* telemetryId */
+    ));
+    const getTelemetryInfoDelegate = new Alias('GetTelemetryInfoDelegate', System.Func(
+      dotnet.String /* telemetryId */,
+      /* returns */ System.Collections.Generic.Dictionary(System.String, System.String)
+    ));
+
     const tokenAudienceConverterDelegate = new Alias('TokenAudienceConverterDelegate',
       System.Func(
         dotnet.String,
@@ -288,6 +297,7 @@ export class NewModuleClass extends Class {
         tokenAudienceConverterDelegate.fullDefinition,
         System.Collections.Generic.IDictionary(dotnet.String, dotnet.Object)
       ));
+
     if (isDataPlane) {
       namespace.add(tokenAudienceConverterDelegate);
       namespace.add(authorizeRequestDelegate);
@@ -309,6 +319,10 @@ export class NewModuleClass extends Class {
     const AddAuthorizeRequestHandler = new Property('AddAuthorizeRequestHandler', authorizeRequestDelegate, { description: 'The delegate to call before each new request to add authorization.' });
     this.add(new Property('GetTelemetryId', getTelemetryIdDelegate, { description: 'The delegate to get the telemetry Id.' }));
     this.add(new Property('Telemetry', telemetryDelegate, { description: 'The delegate for creating a telemetry.' }));
+    const SanitizeOutput = this.add(new Property('SanitizeOutput', sanitizerDelegate, { description: 'The delegate to call in WriteObject to sanitize the output object.' }));
+    namespace.add(sanitizerDelegate);
+    const GetTelemetryInfo = this.add(new Property('GetTelemetryInfo', getTelemetryInfoDelegate, { description: 'The delegate to get the telemetry info.' }));
+    namespace.add(getTelemetryInfoDelegate);
     if (isDataPlane) {
       this.add(AddRequestUserAgentHandler);
       this.add(AddPatchRequestUriHandler);


### PR DESCRIPTION
This pull request introduces several changes to the PowerShell cmdlets and module classes in the `powershell/cmdlets/class.ts`, `powershell/generators/psm1.ts`, and `powershell/module/module-class.ts` files. The changes mainly focus on implementing telemetry and output sanitization features. The most significant changes include the addition of a new `NewImplementWriteObject` method, the introduction of new delegates for sanitizing output and getting telemetry information, and the inclusion of these delegates in the `CmdletClass` and `NewModuleClass`.

Telemetry and Output Sanitization:

* [`powershell/cmdlets/class.ts`]: Added a new method `NewImplementWriteObject` to sanitize output objects and write them to the pipeline. This method includes two overloads for handling single objects and collections.
* [`powershell/cmdlets/class.ts`]: Added code to retrieve telemetry information and display a warning if the cmdlet output may compromise security.
* [`powershell/generators/psm1.ts`]: Added delegates for sanitizing output and getting telemetry information to the module instance.

New Delegates:

* [`powershell/module/module-class.ts`]: Introduced new delegates `SanitizerDelegate` and `GetTelemetryInfoDelegate` for sanitizing output and getting telemetry information, respectively.
