### PR TITLE
Add new warning message when output is plain text instead of object.

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -670,9 +670,13 @@ export class CmdletClass extends Class {
         else {
           yield `var telemetryInfo = ${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetTelemetryInfo?.Invoke(__correlationId);`;
           yield If('telemetryInfo != null', function* () {
+            yield 'telemetryInfo.TryGetValue("ShowSecretsWarning", out var showSecretsWarning);';
             yield 'telemetryInfo.TryGetValue("SanitizedProperties", out var sanitizedProperties);';
             yield 'telemetryInfo.TryGetValue("InvocationName", out var invocationName);';
-            yield If('!string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName ?? "Unknown"} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+            yield If('showSecretsWarning == "true"', function* () {
+              yield If('string.IsNullOrEmpty(sanitizedProperties)', 'WriteWarning($"The output of cmdlet {invocationName} may compromise security by showing secrets. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+              yield Else('WriteWarning($"The output of cmdlet {invocationName} may compromise security by showing the following secrets: {sanitizedProperties}. Learn more at https://go.microsoft.com/fwlink/?linkid=2258844");');
+            });
           });
         }
       });


### PR DESCRIPTION
This pull request includes changes to the `CmdletClass` in the `powershell/cmdlets/class.ts` file. The changes primarily focus on improving the handling of telemetry information and warnings related to the display of secrets.

Key changes:

* [`powershell/cmdlets/class.ts`]: Added a new line to retrieve the `ShowSecretsWarning` value from `telemetryInfo`. This value is then used to control whether a warning about displaying secrets is shown. The conditional statement for displaying the warning has been updated to check the `ShowSecretsWarning` value instead of checking if `sanitizedProperties` is not null or empty. If `ShowSecretsWarning` is "true", it checks if `sanitizedProperties` is null or empty. If it is, a general warning about showing secrets is displayed. Otherwise, a detailed warning about showing specific secrets is displayed.