### PR TITLE
Throw error if current operation is mi operation but cannot be replaced by get+put

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4453,7 +4453,7 @@ packages:
     dev: false
 
   file:projects/powershell.tgz:
-    resolution: {integrity: sha512-/cTXzGUZTDhTv00X96g/ev5R8DhTdsQMIKOfHnwTU5XV+VHjonfZkNAE/F4J6Nx+PlUMQDOpu2l8WODdTfbxZQ==, tarball: file:projects/powershell.tgz}
+    resolution: {integrity: sha512-g+2G98k1uy6WYWIz2YpqovxGt8rcL0RxWA6Zx8iROMAxurDEnhto1UzalzXAuGu7QSqy7suBvPQGATb0Y77W9A==, tarball: file:projects/powershell.tgz}
     name: '@rush-temp/powershell'
     version: 0.0.0
     dependencies:
@@ -4489,7 +4489,7 @@ packages:
     dev: false
 
   file:projects/typespec-powershell.tgz:
-    resolution: {integrity: sha512-faeQhGWL+GN07n8p4riwDBWlZLNc36hqf6Gu5LVK1mJow5IiBe+mgUSDkrOn48dfTPRY1mJx7jn52w1HE4O5Tg==, tarball: file:projects/typespec-powershell.tgz}
+    resolution: {integrity: sha512-FEyIs94S0ytHp2gxuA2ZcEN7YOzvAPKpxNgNDEOEb3aK5brakvfUK/qW8UZaFgd2zA6+pPehphG/XlHsvshnDw==, tarball: file:projects/typespec-powershell.tgz}
     name: '@rush-temp/typespec-powershell'
     version: 0.0.0
     dependencies:

--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -169,7 +169,13 @@ export /* @internal */ class Inferrer {
     };
     const disableGetPut = await this.state.getValue('disable-getput', false);
     const disableTransformIdentityType = await this.state.getValue('disable-transform-identity-type', false);
-    const suppressReplacePatchByGetPutError = await this.state.getValue('suppress-replace-patch-by-getput-error', false);
+    const disableTransformIdentityTypeForOperation = await this.state.getValue('disable-transform-identity-type-for-operation', []);
+    const optsToExclude = new Array<string>();
+    if (disableTransformIdentityTypeForOperation) {
+      for (const item of values(disableTransformIdentityTypeForOperation)) {
+        optsToExclude.push(item);
+      }
+    }
     this.state.message({ Channel: Channel.Debug, Text: 'detecting high level commands...' });
     for (const operationGroup of values(model.operationGroups)) {
       let hasPatch = false;
@@ -207,10 +213,10 @@ export /* @internal */ class Inferrer {
             || !hasPatch && putOperation && this.IsManagedIdentityOperation(putOperation))) {
           await this.addVariants(putOperation.parameters, putOperation, this.createCommandVariant('create', [operationGroup.$key], [], this.state.model), '', this.state, [getOperation], CommandType.ManagedIdentityUpdate);
         } else if (!disableTransformIdentityType && !supportsCombineGetPutOperation && hasPatch && patchOperation && this.IsManagedIdentityOperation(patchOperation)) {
-          if (!suppressReplacePatchByGetPutError) {
-            const replacePatchByGetPutErrorMessage = `operation ${patchOperation.operationId} can not be replaced by its get+put operations for support transforming IdentityType. See https://github.com/Azure/azure-powershell/blob/main/documentation/development-docs/design-guidelines/managed-identity-best-practices.md#frequently-asked-question to mitigate this issue.`;
-            this.state.message({ Channel: Channel.Error, Text: replacePatchByGetPutErrorMessage });
-            throw new Error(replacePatchByGetPutErrorMessage);
+          if (!optsToExclude.includes(patchOperation.operationId ?? '')) {
+            const transformIdentityTypeErrorMessage = `Parameter IdentityType in operation '${patchOperation.operationId}' can not be transformed as the best practice design. See https://github.com/Azure/azure-powershell/blob/main/documentation/development-docs/design-guidelines/managed-identity-best-practices.md#frequently-asked-question to mitigate this issue.`;
+            this.state.message({ Channel: Channel.Error, Text: transformIdentityTypeErrorMessage });
+            throw new Error(transformIdentityTypeErrorMessage);
           }
           // bez: add patch operation back and disable transforming identity type
           for (const variant of await this.inferCommandNames(patchOperation, operationGroup.$key, this.state)) {
@@ -227,10 +233,10 @@ export /* @internal */ class Inferrer {
           await this.addVariants(putOperation.parameters, putOperation, this.createCommandVariant('create', [operationGroup.$key], [], this.state.model), '', this.state, [getOperation], CommandType.GetPut);
         }
       } else if (this.isAzure && !disableTransformIdentityType && patchOperation && this.IsManagedIdentityOperation(patchOperation)) {
-        if (!suppressReplacePatchByGetPutError) {
-          const replacePatchByGetPutErrorMessage = `operation ${patchOperation.operationId} can not be replaced by its get+put operations for support transforming IdentityType. See https://github.com/Azure/azure-powershell/blob/main/documentation/development-docs/design-guidelines/managed-identity-best-practices.md#frequently-asked-question to mitigate this issue.`;
-          this.state.message({ Channel: Channel.Error, Text: replacePatchByGetPutErrorMessage });
-          throw new Error(replacePatchByGetPutErrorMessage);
+        if (!optsToExclude.includes(patchOperation.operationId ?? '')) {
+          const transformIdentityTypeErrorMessage = `Parameter IdentityType in operation '${patchOperation.operationId}' can not be transformed as the best practice design. See https://github.com/Azure/azure-powershell/blob/main/documentation/development-docs/design-guidelines/managed-identity-best-practices.md#frequently-asked-question to mitigate this issue.`;
+          this.state.message({ Channel: Channel.Error, Text: transformIdentityTypeErrorMessage });
+          throw new Error(transformIdentityTypeErrorMessage);
         }
 
         // bez: add variants back and disable transforming identity type as no put or get


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/7d12f448-53f5-4668-9e41-4e9f80a36238)
Developer needs to customize that operation and suppress error by disable-transform-identity-type-for-operation` in directive