### PR TITLE
Fix missing a space in command description

### DIFF
--- a/powershell/plugins/create-commands-v2.ts
+++ b/powershell/plugins/create-commands-v2.ts
@@ -396,7 +396,7 @@ export /* @internal */ class Inferrer {
     // positive test case: The operation to create or update the extension.
     // negative test case: Starts an UpdateRun 
     const createOrUpdateRegex = /((create or update)|(creates or updates)|(create)|(update)|(creates)|(updates))([^a-zA-Z0-9])/gi;
-    operation.language.default.description = operation.language.default.description.replace(createOrUpdateRegex, `${variant.action.capitalize()}`);
+    operation.language.default.description = operation.language.default.description.replace(createOrUpdateRegex, `${variant.action.toLowerCase()} `);
     const op = await this.addCommandOperation(vname, parameters, operation, variant, state, preOperations, commandType);
 
     // if this has a body with it, let's add that parameter


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/fbb3b5d7-1a1c-4ea2-8bd5-f8674658f493)
