### PR TITLE
Fix missing question mark

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1913,7 +1913,7 @@ export class CmdletClass extends Class {
 
           }
 
-          const desc = (vParam.description || '.').replace(/[\r?\n]/gm, '');
+          const desc = (vParam.description || '.').replace(/[\r\n]/gm, '');
           cmdletParameter.description = desc;
 
           // check if this parameter is a byte array, which would indicate that it should really be a file input


### PR DESCRIPTION
Link to issue: https://github.com/Azure/autorest.powershell/issues/1363

Regular expression issue, removed unexpected question mark in doc.
This PR removed question mark match in autorest powershell.
Tested in `Workloads/SAPVirtualInstance`, the generated doc in azure-powershell kept the question mark. 
And the only change between latest published version and this version is the question mark.
