### PR TITLE
tsp - Add description for array body and path parameter if missing

### DIFF
--- a/packages/typespec-powershell/src/convertor/convertor.ts
+++ b/packages/typespec-powershell/src/convertor/convertor.ts
@@ -420,7 +420,7 @@ function createParameter(psContext: SdkContext, parameter: HttpOperationParamete
   } else {
     // always create the parameter
     const paramSchema = parameter.param.sourceProperty ? getSchemaForType(psContext, parameter.param.sourceProperty) : getSchemaForType(psContext, parameter.param);
-    const newParameter = new Parameter(parameter.name, getDoc(psContext.program, parameter.param) || "", paramSchema);
+    const newParameter = new Parameter(parameter.name, getDoc(psContext.program, parameter.param) || paramSchema.description || "", paramSchema);
     newParameter.language.default.serializedName = parameter.name;
     newParameter.protocol.http = newParameter.protocol.http ?? new Protocol();
     newParameter.protocol.http.in = parameter.type;

--- a/packages/typespec-powershell/src/utils/modelUtils.ts
+++ b/packages/typespec-powershell/src/utils/modelUtils.ts
@@ -1227,7 +1227,9 @@ function getSchemaForArrayModel(
     //   }),
     //   description: getDoc(program, type)
     // };
-    schema = new ArraySchema("", "", getSchemaForType(dpgContext, indexer.value!));
+    schema = new ArraySchema("", getDoc(program, type) || (indexer.value && "name" in indexer.value && typeof indexer.value.name === "string"
+      ? "Array of " + indexer.value.name
+      : ""), getSchemaForType(dpgContext, indexer.value!));
     // circle reference, resolve it later
     if (!getSchemaForType(dpgContext, indexer.value!)) {
       schema.delayType = indexer.value!;


### PR DESCRIPTION
This pull request improves how parameter and array schema descriptions are generated in the TypeSpec PowerShell converter, leading to more informative and user-friendly documentation output. The main changes focus on enhancing the fallback logic for descriptions when explicit documentation is missing.

**Improvements to description generation:**

* In `convertor.ts`, the logic for creating a parameter description now falls back to the schema's description if explicit documentation is unavailable, ensuring that parameters always have a meaningful description.
* In `modelUtils.ts`, array schema descriptions now use available documentation or, if missing, generate a description like "Array of [type name]", making array types clearer in generated docs.