### PR TITLE
Fixed an asjob related issue #1494

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1515,7 +1515,7 @@ export class CmdletClass extends Class {
               yield `global::System.IO.File.WriteAllBytes(${paths.value}[0],${result.value});`;
             }
 
-            yield If('true == MyInvocation?.BoundParameters?.ContainsKey("PassThru")', function* () {
+            yield If('true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru")', function* () {
               // no return type. Let's just return ... true?
               yield 'WriteObject(true);';
             });
@@ -1555,14 +1555,14 @@ export class CmdletClass extends Class {
             });
 
 
-            yield If('true == MyInvocation?.BoundParameters?.ContainsKey("PassThru")', function* () {
+            yield If('true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru")', function* () {
               // no return type. Let's just return ... true?
               yield 'WriteObject(true);';
             });
             return;
           }
         }
-        yield If('true == MyInvocation?.BoundParameters?.ContainsKey("PassThru")', function* () {
+        yield If('true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru")', function* () {
           // no return type. Let's just return ... true?
           yield 'WriteObject(true);';
         });

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationEvidence_Delete.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationEvidence_Delete.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationEvidence_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationEvidence_DeleteViaIdentity.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -493,7 +493,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationEvidence_DeleteViaIdentityReport.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationEvidence_DeleteViaIdentityReport.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationReport_Delete.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationReport_Delete.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationReport_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationReport_DeleteViaIdentity.cs
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -554,7 +554,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationScopingConfiguration_Delete.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationScopingConfiguration_Delete.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationScopingConfiguration_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationScopingConfiguration_DeleteViaIdentity.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationScopingConfiguration_DeleteViaIdentityReport.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationScopingConfiguration_DeleteViaIdentityReport.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationWebhook_Delete.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationWebhook_Delete.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationWebhook_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationWebhook_DeleteViaIdentity.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -493,7 +493,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationWebhook_DeleteViaIdentityReport.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/cmdlets/RemoveAzAppComplianceAutomationWebhook_DeleteViaIdentityReport.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/cmdlets/RemoveAzAstroOrganization_Delete.cs
+++ b/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/cmdlets/RemoveAzAstroOrganization_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/cmdlets/RemoveAzAstroOrganization_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/cmdlets/RemoveAzAstroOrganization_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/cmdlets/RemoveAzComputeFleet_Delete.cs
+++ b/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/cmdlets/RemoveAzComputeFleet_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/cmdlets/RemoveAzComputeFleet_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/cmdlets/RemoveAzComputeFleet_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeInstance_Delete.cs
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeInstance_DeleteViaIdentity.cs
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeStorageInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeStorageInstance_Delete.cs
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeStorageInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/cmdlets/RemoveAzAzureLargeInstanceAzureLargeStorageInstance_DeleteViaIdentity.cs
@@ -476,7 +476,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningAccount_Delete.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningAccount_Delete.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -584,7 +584,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningAccount_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningAccount_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningCertificateProfile_Delete.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningCertificateProfile_Delete.cs
@@ -575,7 +575,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -599,7 +599,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningCertificateProfile_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningCertificateProfile_DeleteViaIdentity.cs
@@ -542,7 +542,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningCertificateProfile_DeleteViaIdentityCodeSigningAccount.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RemoveAzCodeSigningCertificateProfile_DeleteViaIdentityCodeSigningAccount.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -581,7 +581,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_Revoke.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_Revoke.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeExpanded.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeExpanded.cs
@@ -555,7 +555,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentity.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentityCodeSigningAccount.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentityCodeSigningAccount.cs
@@ -493,7 +493,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentityCodeSigningAccountExpanded.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentityCodeSigningAccountExpanded.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentityExpanded.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaIdentityExpanded.cs
@@ -526,7 +526,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaJsonFilePath.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaJsonFilePath.cs
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaJsonString.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/cmdlets/RevokeAzCodeSigningCertificateProfileCertificate_RevokeViaJsonString.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAssetEndpointProfile_Delete.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAssetEndpointProfile_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAssetEndpointProfile_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAssetEndpointProfile_DeleteViaIdentity.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAsset_Delete.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAsset_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAsset_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/cmdlets/RemoveAzDeviceRegistryAsset_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_Promote.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_Promote.cs
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteExpanded.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteExpanded.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaIdentity.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaIdentityExpanded.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaIdentityExpanded.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaJsonFilePath.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaJsonFilePath.cs
@@ -570,7 +570,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaJsonString.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/InvokeAzMongoClusterPromoteMongoCluster_PromoteViaJsonString.cs
@@ -567,7 +567,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoClusterFirewallRule_Delete.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoClusterFirewallRule_Delete.cs
@@ -576,7 +576,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -600,7 +600,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoClusterFirewallRule_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoClusterFirewallRule_DeleteViaIdentity.cs
@@ -542,7 +542,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoClusterFirewallRule_DeleteViaIdentityMongoCluster.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoClusterFirewallRule_DeleteViaIdentityMongoCluster.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoCluster_Delete.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoCluster_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoCluster_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/cmdlets/RemoveAzMongoCluster_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/cmdlets/RemoveAzHealthDataAiServicesDeidService_Delete.cs
+++ b/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/cmdlets/RemoveAzHealthDataAiServicesDeidService_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/cmdlets/RemoveAzHealthDataAiServicesDeidService_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/cmdlets/RemoveAzHealthDataAiServicesDeidService_DeleteViaIdentity.cs
@@ -540,7 +540,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaOrganization_Delete.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaOrganization_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaOrganization_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaOrganization_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaServerlessRuntime_Delete.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaServerlessRuntime_Delete.cs
@@ -576,7 +576,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -600,7 +600,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaServerlessRuntime_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaServerlessRuntime_DeleteViaIdentity.cs
@@ -542,7 +542,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaServerlessRuntime_DeleteViaIdentityOrganization.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/RemoveAzInformaticaServerlessRuntime_DeleteViaIdentityOrganization.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/StartAzInformaticaServerlessRuntimeFailedServerlessRuntime_Start.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/StartAzInformaticaServerlessRuntimeFailedServerlessRuntime_Start.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/StartAzInformaticaServerlessRuntimeFailedServerlessRuntime_StartViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/StartAzInformaticaServerlessRuntimeFailedServerlessRuntime_StartViaIdentity.cs
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/StartAzInformaticaServerlessRuntimeFailedServerlessRuntime_StartViaIdentityOrganization.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/cmdlets/StartAzInformaticaServerlessRuntimeFailedServerlessRuntime_StartViaIdentityOrganization.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeBgpPeer_Delete.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeBgpPeer_Delete.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeBgpPeer_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeBgpPeer_DeleteViaIdentity.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeLoadBalancer_Delete.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeLoadBalancer_Delete.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeLoadBalancer_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeLoadBalancer_DeleteViaIdentity.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeService_Delete.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeService_Delete.cs
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeService_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeService_DeleteViaIdentity.cs
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeStorageClass_Delete.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeStorageClass_Delete.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeStorageClass_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/cmdlets/RemoveAzContainerOrchestratorRuntimeStorageClass_DeleteViaIdentity.cs
@@ -537,7 +537,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Cmdlet
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/cmdlets/RemoveAzLambdaTestOrganization_Delete.cs
+++ b/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/cmdlets/RemoveAzLambdaTestOrganization_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/cmdlets/RemoveAzLambdaTestOrganization_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/cmdlets/RemoveAzLambdaTestOrganization_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/cmdlets/RemoveAzWeightsBiasesInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/cmdlets/RemoveAzWeightsBiasesInstance_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/cmdlets/RemoveAzWeightsBiasesInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/cmdlets/RemoveAzWeightsBiasesInstance_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/cmdlets/RemoveAzDevOpsInfrastructurePool_Delete.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/cmdlets/RemoveAzDevOpsInfrastructurePool_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/cmdlets/RemoveAzDevOpsInfrastructurePool_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/cmdlets/RemoveAzDevOpsInfrastructurePool_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/cmdlets/RemoveAzNeonPostgresOrganization_Delete.cs
+++ b/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/cmdlets/RemoveAzNeonPostgresOrganization_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/cmdlets/RemoveAzNeonPostgresOrganization_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/cmdlets/RemoveAzNeonPostgresOrganization_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_Rotate.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_Rotate.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateExpanded.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaIdentity.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaIdentityExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaIdentityExpanded.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaJsonFilePath.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaJsonFilePath.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaJsonString.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/InvokeAzNetworkAnalyticsRotateDataProductKey_RotateViaJsonString.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_Remove.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_Remove.cs
@@ -496,7 +496,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveExpanded.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaIdentity.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaIdentityExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaIdentityExpanded.cs
@@ -546,7 +546,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaJsonFilePath.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaJsonFilePath.cs
@@ -499,7 +499,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaJsonString.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProductUserRole_RemoveViaJsonString.cs
@@ -497,7 +497,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProduct_Delete.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProduct_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProduct_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataProduct_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_Delete.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_Delete.cs
@@ -590,7 +590,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -614,7 +614,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteExpanded.cs
@@ -579,7 +579,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentity.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -581,7 +581,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentityDataProduct.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentityDataProduct.cs
@@ -572,7 +572,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -596,7 +596,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentityDataProductExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentityDataProductExpanded.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentityExpanded.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaIdentityExpanded.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -573,7 +573,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaJsonFilePath.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaJsonFilePath.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -618,7 +618,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaJsonString.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataTypeData_DeleteViaJsonString.cs
@@ -592,7 +592,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -616,7 +616,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataType_Delete.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataType_Delete.cs
@@ -576,7 +576,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -600,7 +600,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataType_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataType_DeleteViaIdentity.cs
@@ -542,7 +542,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -566,7 +566,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataType_DeleteViaIdentityDataProduct.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/cmdlets/RemoveAzNetworkAnalyticsDataType_DeleteViaIdentityDataProduct.cs
@@ -558,7 +558,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/cmdlets/RemoveAzPineconeOrganization_Delete.cs
+++ b/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/cmdlets/RemoveAzPineconeOrganization_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/cmdlets/RemoveAzPineconeOrganization_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/cmdlets/RemoveAzPineconeOrganization_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/cmdlets/RemoveAzQumuloFileSystem_Delete.cs
+++ b/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/cmdlets/RemoveAzQumuloFileSystem_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/cmdlets/RemoveAzQumuloFileSystem_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/cmdlets/RemoveAzQumuloFileSystem_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereCatalog_Delete.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereCatalog_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereCatalog_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereCatalog_DeleteViaIdentity.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_Delete.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_Delete.cs
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -618,7 +618,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_DeleteViaIdentity.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -573,7 +573,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_DeleteViaIdentityCatalog.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_DeleteViaIdentityCatalog.cs
@@ -573,7 +573,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -597,7 +597,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_DeleteViaIdentityProduct.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereDeviceGroup_DeleteViaIdentityProduct.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -586,7 +586,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereProduct_Delete.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereProduct_Delete.cs
@@ -578,7 +578,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -602,7 +602,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereProduct_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereProduct_DeleteViaIdentity.cs
@@ -544,7 +544,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereProduct_DeleteViaIdentityCatalog.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/cmdlets/RemoveAzSphereProduct_DeleteViaIdentityCatalog.cs
@@ -557,7 +557,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -581,7 +581,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyContainerGroupPool_Delete.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyContainerGroupPool_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyContainerGroupPool_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyContainerGroupPool_DeleteViaIdentity.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyVirtualMachinePool_Delete.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyVirtualMachinePool_Delete.cs
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyVirtualMachinePool_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/cmdlets/RemoveAzStandbyPoolStandbyVirtualMachinePool_DeleteViaIdentity.cs
@@ -541,7 +541,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapApplicationServerInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapApplicationServerInstance_Delete.cs
@@ -581,7 +581,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -605,7 +605,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapApplicationServerInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapApplicationServerInstance_DeleteViaIdentity.cs
@@ -548,7 +548,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -572,7 +572,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapApplicationServerInstance_DeleteViaIdentitySapVirtualInstance.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapApplicationServerInstance_DeleteViaIdentitySapVirtualInstance.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -584,7 +584,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapCentralServerInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapCentralServerInstance_Delete.cs
@@ -583,7 +583,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -607,7 +607,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapCentralServerInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapCentralServerInstance_DeleteViaIdentity.cs
@@ -549,7 +549,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -573,7 +573,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapCentralServerInstance_DeleteViaIdentitySapVirtualInstance.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapCentralServerInstance_DeleteViaIdentitySapVirtualInstance.cs
@@ -563,7 +563,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -587,7 +587,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapDatabaseInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapDatabaseInstance_Delete.cs
@@ -580,7 +580,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapDatabaseInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapDatabaseInstance_DeleteViaIdentity.cs
@@ -548,7 +548,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -572,7 +572,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapDatabaseInstance_DeleteViaIdentitySapVirtualInstance.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapDatabaseInstance_DeleteViaIdentitySapVirtualInstance.cs
@@ -562,7 +562,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -586,7 +586,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapVirtualInstance_Delete.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapVirtualInstance_Delete.cs
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -588,7 +588,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapVirtualInstance_DeleteViaIdentity.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/cmdlets/RemoveAzSapVirtualInstanceSapVirtualInstance_DeleteViaIdentity.cs
@@ -544,7 +544,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onNoContent - response for 204 / application/json
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Cmdlets
                     return ;
                 }
                 // onOk - response for 200 /
-                if (true == MyInvocation?.BoundParameters?.ContainsKey("PassThru"))
+                if (true == InvocationInformation?.BoundParameters?.ContainsKey("PassThru"))
                 {
                     WriteObject(true);
                 }


### PR DESCRIPTION
This pull request updates references from `MyInvocation` to `InvocationInformation` when checking for the `"PassThru"` parameter in the `CmdletClass` class. This change ensures consistency and correctness in how bound parameters are accessed within the PowerShell cmdlet code.

Parameter checking improvements:

* Updated conditional checks to use `InvocationInformation?.BoundParameters?.ContainsKey("PassThru")` instead of `MyInvocation?.BoundParameters?.ContainsKey("PassThru")` in multiple locations within `powershell/cmdlets/class.ts`. [[1]](diffhunk://#diff-d3177b21f23d6f098dd6943741c221a13c2924648ce0d9cfc3803b75bc50f1a7L1518-R1518) [[2]](diffhunk://#diff-d3177b21f23d6f098dd6943741c221a13c2924648ce0d9cfc3803b75bc50f1a7L1558-R1565)