### PR TITLE
tsp - use schema description if property comment is not specified

### DIFF
--- a/packages/typespec-powershell/src/utils/modelUtils.ts
+++ b/packages/typespec-powershell/src/utils/modelUtils.ts
@@ -936,7 +936,7 @@ function getSchemaForModel(
       (<Schema>propSchema).language.default.name = (<Schema>propSchema).language.default.name || name;
     }
     // ToDo: need to confirm there is no duplicated properties.
-    const property = new Property(name, getDoc(program, prop) || "", propSchema || new ObjectSchema(name, ""));
+    const property = new Property(name, getDoc(program, prop) || propSchema.language.default.description || "", propSchema || new ObjectSchema(name, ""));
     if (!prop.optional) {
       property.required = true;
     }


### PR DESCRIPTION
This pull request makes a small improvement to how property descriptions are assigned in the `getSchemaForModel` function. Now, if documentation for a property is missing, it falls back to using the property's schema description instead of leaving it blank.