### PR TITLE
tsp - Use 'powershell' for @clientname decorator

### DIFF
--- a/packages/typespec-powershell/src/convertor/convertor.ts
+++ b/packages/typespec-powershell/src/convertor/convertor.ts
@@ -196,7 +196,7 @@ function resolveOperationId(psContext: SdkContext, op: HttpOperation): string {
 }
 
 function getClientName(context: SdkContext, type: Type & { name: string }) {
-  const clientName = getClientNameOverride(context, type);
+  const clientName = getClientNameOverride(context, type, "powershell");
   return clientName ?? type.name;
 }
 

--- a/packages/typespec-powershell/src/utils/modelUtils.ts
+++ b/packages/typespec-powershell/src/utils/modelUtils.ts
@@ -743,7 +743,7 @@ function getSchemaForModel(
   }
 
   const program = dpgContext.program;
-  const overridedModelName = getClientNameOverride(dpgContext, model) ??
+  const overridedModelName = getClientNameOverride(dpgContext, model, "powershell") ??
     getFriendlyName(program, model) ?? getWireName(dpgContext, model);
 
   const fullNamespaceName =

--- a/tests-upgrade/tests-emitter/EmitterTest.ps1
+++ b/tests-upgrade/tests-emitter/EmitterTest.ps1
@@ -50,7 +50,8 @@ function GenerateModuleWithEmitter {
         [TestEmitterModel]
         $TestEmitter
     )
-    $result = (tsp compile ./ --emit $script:PowerShellEmitter) | Out-String
+    $tspFile = if (Test-Path "./client.tsp") { "./client.tsp" } else { "./" }
+    $result = (tsp compile $tspFile --emit $script:PowerShellEmitter) | Out-String
     Write-Debug "$($TestEmitter.TestName) generated powershell debug information"
     Write-Debug $result
 


### PR DESCRIPTION
This pull request introduces targeted improvements to the PowerShell emitter and related utilities. The main changes focus on ensuring that the correct client name overrides are applied for PowerShell, and updating test logic to better handle file selection during compilation.

**PowerShell-specific client name handling:**

* Updated both `getClientName` in `convertor.ts` and `getSchemaForModel` in `modelUtils.ts` to pass `"powershell"` as the override context, ensuring client name overrides are correctly applied for PowerShell scenarios. [[1]](diffhunk://#diff-deb3e8830d245343a9d4842c064b793ef5938fe39609ef552059d14b9b6a4be9L199-R199) [[2]](diffhunk://#diff-b14ca573b6245afb541400cac7bdbdd353e48bfdc0ff8254d5574da138dc0f07L746-R746)

**Test robustness improvements:**

* Modified the `GenerateModuleWithEmitter` function in `EmitterTest.ps1` to check for the existence of `client.tsp` and use it if available, otherwise defaulting to the current directory, making test compilation more flexible and robust.