### PR TITLE
tsp - Added suppport for rfc7231 and fixed an issue related to operationId

### DIFF
--- a/packages/typespec-powershell/src/convertor/convertor.ts
+++ b/packages/typespec-powershell/src/convertor/convertor.ts
@@ -137,11 +137,11 @@ function getOperationGroups(program: Program, client: SdkClient, psContext: SdkC
       continue;
     }
     const operationId = resolveOperationId(psContext, op);
-    let group = operationGroupsMap.get(operationId.split("_")[0] || "");
+    let group = operationGroupsMap.get(operationId.includes('_') ? operationId.split("_")[0] : "");
     if (!group) {
       group = new OperationGroup("");
-      group.language.default.name = group.$key = operationId.split("_")[0] || "";
-      operationGroupsMap.set(operationId.split("_")[0] || "", group);
+      group.language.default.name = group.$key = operationId.includes('_') ? operationId.split("_")[0] : "";
+      operationGroupsMap.set(operationId.includes('_') ? operationId.split("_")[0] : "", group);
     }
     addOperation(psContext, op, group, model, emitterOptions);
   }


### PR DESCRIPTION
This pull request introduces improvements and fixes to the schema generation and operation grouping logic in the TypeSpec PowerShell converter. The most significant changes enhance the handling of date-time encodings in schemas and improve the robustness of operation group mapping.

Schema generation improvements:

* Enhanced `getSchemaForType` to correctly handle model properties with date-time encodings, such as `rfc1123` and `rfc7231`, by setting a specific `format` in the schema when these encodings are detected. This ensures that the generated schema accurately reflects date-time encoding requirements.
* Updated the `mergeFormatAndEncoding` function to map specific encodings (like `rfc3339`, `unixTimestamp`, and `rfc7231`) to their appropriate schema formats, improving compatibility with downstream consumers.

Operation group mapping fix:

* Improved the logic in `getOperationGroups` to handle operation IDs without underscores more robustly, preventing issues when grouping operations that do not follow the expected naming convention.

Minor code quality improvement:

* Added a blank line for better readability in `getSchemaForType`.