### PR TITLE
tsp - Use clientname as property name if it is specified

### DIFF
--- a/packages/typespec-powershell/src/utils/modelUtils.ts
+++ b/packages/typespec-powershell/src/utils/modelUtils.ts
@@ -936,6 +936,7 @@ function getSchemaForModel(
     };
   }
   for (const [propName, prop] of model.properties) {
+    const clientName = getClientNameOverride(dpgContext, prop, "powershell");
     const encodedName = resolveEncodedName(program, prop, "application/json");
     const restApiName = getWireName(dpgContext, prop);
     const name = encodedName ?? restApiName ?? propName;
@@ -968,6 +969,10 @@ function getSchemaForModel(
     }
     // ToDo: need to confirm there is no duplicated properties.
     const property = new Property(name, getDoc(program, prop) || propSchema.language.default.description || "", propSchema || new ObjectSchema(name, ""));
+    if (clientName) {
+      // Use the client name as the property name if it is specified
+      property.language.default.name = clientName;
+    }
     if (!prop.optional) {
       property.required = true;
     }


### PR DESCRIPTION
This pull request updates the logic for generating model schemas in PowerShell by improving how property names are determined and allowing for client-specific naming overrides. The changes ensure that if a client name override is specified for a property, it will be used as the property's name in the generated schema.

Enhancements to property naming in model schema generation:

* Added retrieval of a client name override for each property using `getClientNameOverride`, specifically for PowerShell, in the `getSchemaForModel` function.
* Updated the property creation logic to use the client name as the property's name if it is specified, ensuring client-specific naming is respected in the schema.