### PR TITLE
Fix export file format

### DIFF
--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportFormatPs1xml.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportFormatPs1xml.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
 
     private static readonly bool IsAzure = Convert.ToBoolean(@"${$project.azure}");
 
-    private static string SelectedBySuffix = @"${$project.autoSwitchView? "#Multiple" : ""}";
+    private static string SelectedBySuffix = @"${$project.autoSwitchView? ""#Multiple"" : """"}";
     
     protected override void ProcessRecord()
     {


### PR DESCRIPTION
The TempTypeSpecFiles/ directory contains intermediate template files with ${...} placeholders (not valid C#). When using -SkipCleanTemp, these files are retained and incorrectly included in compilation, causing CS1040 errors.


<img width="1192" height="199" alt="image" src="https://github.com/user-attachments/assets/97dfcd1d-b7a5-4561-a0f3-bce19eb0e62d" />
