### PR TITLE
[Change Safety] Generator: emit GetDynamicParametersValue delegate + IDynamicParameters on write cmdlets (Stages C+D)

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -11,11 +11,11 @@ import { getAllProperties as NewGetAllProperties, getAllPublicVirtualProperties 
 import { escapeString, docComment, serialize, pascalCase, DeepPartial, camelCase } from '@azure-tools/codegen';
 import { items, values, Dictionary, length } from '@azure-tools/linq';
 import {
-  Access, Attribute, BackedProperty, Catch, Class, ClassType, Constructor, dotnet, Else, Expression, Finally, ForEach, If, LambdaProperty, LiteralExpression, LocalVariable, Method, Modifier, Namespace, OneOrMoreStatements, Parameter, Property, Return, Statements, BlockStatement, StringExpression,
+  Access, Attribute, BackedProperty, Catch, Class, ClassType, Constructor, dotnet, Else, Expression, Finally, ForEach, If, LambdaMethod, LambdaProperty, LiteralExpression, LocalVariable, Method, Modifier, Namespace, OneOrMoreStatements, Parameter, Property, Return, Statements, BlockStatement, StringExpression,
   Switch, System, TerminalCase, toExpression, Try, Using, valueOf, Field, IsNull, Or, ExpressionOrLiteral, TerminalDefaultCase, xmlize, TypeDeclaration, And, IsNotNull, PartialMethod, Case, While, LiteralStatement, Not, ElseIf
 } from '@azure-tools/codegen-csharp';
 import { ClientRuntime, EventListener, Schema, ArrayOf, EnumImplementation } from '../llcsharp/exports';
-import { NullableBoolean, Alias, ArgumentCompleterAttribute, PSArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, ExternalDocsAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute, HttpPathAttribute, NotSuggestDefaultParameterSetAttribute } from '../internal/powershell-declarations';
+import { NullableBoolean, Alias, ArgumentCompleterAttribute, PSArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, IDynamicParameters, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, ExternalDocsAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute, HttpPathAttribute, NotSuggestDefaultParameterSetAttribute } from '../internal/powershell-declarations';
 import { State } from '../internal/state';
 import { Channel } from '@autorest/extension-base';
 import { IParameter } from '@azure-tools/codemodel-v3/dist/code-model/components';
@@ -459,6 +459,9 @@ export class CmdletClass extends Class {
 
     // implement part of the IContext
     this.implementIContext();
+
+    // implement IDynamicParameters for write-verb cmdlets (Change Safety)
+    this.implementIDynamicParameters();
 
     // add constructors
     this.implementConstructors();
@@ -1621,6 +1624,23 @@ export class CmdletClass extends Class {
     const extensibleParametersProp = new Property('ExtensibleParameters', System.Collections.Generic.IDictionary(System.String, System.Object), { description: 'Accessor for extensibleParameters.' });
     extensibleParametersProp.get = toExpression(`${extensibleParameters.value} `);
     this.add(extensibleParametersProp);
+  }
+  private implementIDynamicParameters() {
+    // Change Safety: only write-verb cmdlets (PUT/POST/DELETE/PATCH) participate in dynamic parameter discovery.
+    // The correlation id field only exists for azure projects, so gate on that as well.
+    if (!this.state.project.azure) {
+      return;
+    }
+    const httpMethod = (this.apiCall.requests?.[0]?.protocol.http?.method ?? '').toLowerCase();
+    if (!['put', 'post', 'delete', 'patch'].includes(httpMethod)) {
+      return;
+    }
+    const $this = this;
+    this.interfaces.push(IDynamicParameters);
+    this.add(new LambdaMethod('GetDynamicParameters', dotnet.Object, new LiteralExpression(`${$this.state.project.serviceNamespace.moduleClass.declaration}.Instance.GetDynamicParameters(this.${$this.invocationInfo.value}, ${$this.correlationId.value})`), {
+      description: 'Gets the Change Safety dynamic parameters from a common module.',
+      returnsDescription: 'The RuntimeDefinedParameterDictionary of Change Safety parameters, or null.'
+    }));
   }
   private implementIEventListener() {
     const $this = this;

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -118,6 +118,9 @@ ${requestHandler}
   # Gets shared parameter values
   $instance.GetParameterValue = $VTable.GetParameterValue
 
+  # Delegate to get the Change Safety dynamic parameters
+  $instance.GetDynamicParametersValue = $VTable.GetDynamicParametersValue
+
   # Allows shared module to listen to events from this module
   $instance.EventListener = $VTable.EventListener
 

--- a/powershell/internal/powershell-declarations.ts
+++ b/powershell/internal/powershell-declarations.ts
@@ -32,6 +32,7 @@ export const ErrorRecord: TypeDeclaration = new ClassType(sma, 'ErrorRecord');
 export const SwitchParameter: TypeDeclaration = new ClassType(sma, 'SwitchParameter');
 export const NullableBoolean: TypeDeclaration = new ClassType(new Namespace('System'), 'Boolean?');
 export const IArgumentCompleter: IInterface = { allProperties: [], declaration: 'System.Management.Automation.IArgumentCompleter' };
+export const IDynamicParameters: IInterface = { allProperties: [], declaration: 'System.Management.Automation.IDynamicParameters' };
 export const CompletionResult: TypeDeclaration = new ClassType(sma, 'CompletionResult');
 export const CommandAst: TypeDeclaration = new ClassType(`${sma}.Language`, 'CommandAst');
 export const CompletionResultType: TypeDeclaration = new ClassType(sma, 'CompletionResultType');

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -239,6 +239,13 @@ export class NewModuleClass extends Class {
       dotnet.String, /* parameterName */
       /* returns */ dotnet.Object)));
 
+    const getDynamicParametersDelegate = namespace.add(new Alias('GetDynamicParametersDelegate', System.Func(
+      dotnet.String, /* resourceId */
+      dotnet.String, /* moduleName */
+      InvocationInfo, /* invocationInfo */
+      dotnet.String, /* correlationId */
+      /* returns */ dotnet.Object)));
+
     const moduleLoadPipelineDelegate = namespace.add(new Alias('ModuleLoadPipelineDelegate', System.Action(
       dotnet.String, /* resourceId */
       dotnet.String, /* moduleName */
@@ -331,6 +338,7 @@ export class NewModuleClass extends Class {
       this.add(OnNewRequest);
     }
     const GetParameterValue = this.add(new Property('GetParameterValue', getParameterDelegate, { description: 'The delegate to call to get parameter data from a common module.' }));
+    const GetDynamicParametersValue = this.add(new Property('GetDynamicParametersValue', getDynamicParametersDelegate, { description: 'The delegate to call to get the Change Safety dynamic parameters from a common module.' }));
     const EventListener = this.add(new Property('EventListener', eventListenerDelegate, { description: 'A delegate that gets called for each signalled event' }));
     const ArgumentCompleter = this.add(new Property('ArgumentCompleter', argumentCompleterDelegate, { description: 'Gets completion data for azure specific fields' }));
     const ProfileName = this.add(new Property('ProfileName', System.String, { description: 'The name of the currently selected Azure profile' }));
@@ -344,6 +352,13 @@ export class NewModuleClass extends Class {
       parameters: [this.pInvocationInfo, this.pCorrelationId, this.pParameterName],
       description: 'Gets parameters from a common module.',
       returnsDescription: 'The parameter value from the common module. (Note: this should be type converted on the way back)'
+    }));
+
+    /* get Change Safety dynamic parameters method (calls azAccounts) */
+    this.add(new LambdaMethod('GetDynamicParameters', dotnet.Object, new LiteralExpression(`${GetDynamicParametersValue.value}?.Invoke( ${moduleResourceId.value}, ${moduleIdentity.value}, ${$this.pInvocationInfo.value}, ${$this.pCorrelationId.value} )`), {
+      parameters: [this.pInvocationInfo, this.pCorrelationId],
+      description: 'Gets the Change Safety dynamic parameters from a common module.',
+      returnsDescription: 'The RuntimeDefinedParameterDictionary of Change Safety parameters, or null.'
     }));
 
     /* signal method (calls azAccounts) */


### PR DESCRIPTION
## Summary
Generator support for bringing the Change Safety feature (`-AcquirePolicyToken` / `-ChangeReference`) to AutoRest-generated cmdlets. Two commits:

- **Stage C** (`powershell/module/module-class.ts`, `powershell/generators/psm1.ts`): the generated `Module.cs` gains a `GetDynamicParametersValue` VTable delegate property plus a `GetDynamicParameters(invocationInfo, correlationId)` wrapper method (mirroring the existing `GetParameterValue`/`GetParameter` pattern), and the generated `.psm1` wires `$instance.GetDynamicParametersValue = $VTable.GetDynamicParametersValue`. Inert until a cmdlet calls it (Stage D).
- **Stage D** (`powershell/cmdlets/class.ts`, `powershell/internal/powershell-declarations.ts`): generated **write-verb** cmdlets (HTTP PUT/POST/DELETE/PATCH) implement `System.Management.Automation.IDynamicParameters` and emit `GetDynamicParameters() => Module.Instance.GetDynamicParameters(this.InvocationInformation, __correlationId)`. Read-verb cmdlets (GET/HEAD) get a **zero diff**. Emit is gated to azure projects (where the VTable / `__correlationId` exist).

## Why / dependencies
AutoRest cmdlets don't inherit `AzurePSCmdlet`, so Change Safety is injected via the `Register-AzModule` VTable — the same mechanism as auth/telemetry/completers. This generator change is consumed by modules at **regeneration** time.

- Pairs with Az.Accounts PR Azure/azure-powershell#29840 (adds the `GetDynamicParametersValue` VTable delegate + `ContextAdapter` implementation + the `AcquirePolicyToken` pipeline step).
- Which in turn depends on the shared extraction Azure/azure-powershell-common#454 (`PolicyTokenAcquirer` + `ChangeSafetyParameters`).

## Verification
Built the generator, ESLint clean, unit tests pass. Smoke-generation of an azure spec confirms: a write cmdlet (`New-*`) implements `IDynamicParameters` and emits the wrapper call; a `Get-*` cmdlet has no such member (zero diff). The generated `Module.cs` exposes `GetDynamicParametersValue` + the `GetDynamicParameters` wrapper, and the `.psm1` wires the delegate.

## Rollout
Ships as a `@autorest/powershell` release; azure-powershell adopts it per-module at regeneration (pilot module first, then batched) — no module changes here.
