### PR TITLE
[Change Safety] Generator: emit inline IDynamicParameters (-AcquirePolicyToken/-ChangeReference) on write cmdlets (Stage D)

### DIFF
--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1630,6 +1630,11 @@ export class CmdletClass extends Class {
     // write-verb cmdlets (PUT/POST/DELETE/PATCH) expose the opt-in Change Safety parameters.
     // The parameter values are read by the module-level HTTP pipeline step (in Az.Accounts)
     // from the cmdlet's BoundParameters, so no runtime-wired delegate is required here.
+    // Opt-in per module via `change-safety: true` in the module readme (default off), so the
+    // 180+ module rollout is deliberate rather than triggered by any unrelated regeneration.
+    if (!this.state.project.changeSafety) {
+      return;
+    }
     if (!this.state.project.azure) {
       return;
     }

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1627,12 +1627,12 @@ export class CmdletClass extends Class {
   }
   private implementChangeSafetyParameters() {
     // Change Safety (codegen-owned static parameters): only azure management-plane (ARM)
-    // write-verb cmdlets (PUT/POST/DELETE/PATCH) expose the opt-in Change Safety parameters.
-    // The parameter values are read by the module-level HTTP pipeline step (in Az.Accounts)
-    // from the cmdlet's BoundParameters, so no runtime-wired delegate is required here.
-    // Opt-in per module via `change-safety: true` in the module readme (default off), so the
-    // 180+ module rollout is deliberate rather than triggered by any unrelated regeneration.
-    if (!this.state.project.changeSafety) {
+    // write cmdlets expose the opt-in Change Safety parameters. The parameter values are read
+    // by the module-level HTTP pipeline step (in Az.Accounts) from the cmdlet's BoundParameters,
+    // so no runtime-wired delegate is required here.
+    // Opt-in per module via `enable-change-safety: true` in the module readme (default off), so
+    // the 180+ module rollout is deliberate rather than triggered by any unrelated regeneration.
+    if (!this.state.project.enableChangeSafety) {
       return;
     }
     if (!this.state.project.azure) {
@@ -1644,8 +1644,15 @@ export class CmdletClass extends Class {
     if (this.state.project.endpointResourceIdKeyName) {
       return;
     }
-    const httpMethod = (this.apiCall.requests?.[0]?.protocol.http?.method ?? '').toLowerCase();
-    if (!['put', 'post', 'delete', 'patch'].includes(httpMethod)) {
+    // Gate on the PowerShell verb rather than sniffing the HTTP method off requests[0]. A cmdlet's
+    // callGraph can contain multiple operations (e.g. a GetPut Update = GET + PUT) and a single
+    // operation can carry multiple requests, so requests[0] is not a reliable signal for whether
+    // the cmdlet mutates. The verb encodes the mutating intent computed across the whole call graph
+    // and, unlike the raw HTTP method, correctly treats POST "list"-style operations (surfaced as
+    // Get) as reads.
+    const verb = (this.operation.details.csharp.verb ?? '').toLowerCase();
+    const readOnlyVerbs = ['get', 'test', 'find', 'search', 'measure', 'show', 'ping', 'trace', 'resolve', 'read'];
+    if (readOnlyVerbs.includes(verb)) {
       return;
     }
 

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -460,6 +460,9 @@ export class CmdletClass extends Class {
     // implement part of the IContext
     this.implementIContext();
 
+    // Change Safety: emit codegen-owned static parameters on write-verb cmdlets
+    this.implementChangeSafetyParameters();
+
     // add constructors
     this.implementConstructors();
 
@@ -1621,6 +1624,28 @@ export class CmdletClass extends Class {
     const extensibleParametersProp = new Property('ExtensibleParameters', System.Collections.Generic.IDictionary(System.String, System.Object), { description: 'Accessor for extensibleParameters.' });
     extensibleParametersProp.get = toExpression(`${extensibleParameters.value} `);
     this.add(extensibleParametersProp);
+  }
+  private implementChangeSafetyParameters() {
+    // Change Safety (codegen-owned static parameters): only azure write-verb cmdlets
+    // (PUT/POST/DELETE/PATCH) expose the opt-in Change Safety parameters. The parameter
+    // values are read by the module-level HTTP pipeline step (in Az.Accounts) from the
+    // cmdlet's BoundParameters, so no runtime-wired delegate is required here.
+    if (!this.state.project.azure) {
+      return;
+    }
+    const httpMethod = (this.apiCall.requests?.[0]?.protocol.http?.method ?? '').toLowerCase();
+    if (!['put', 'post', 'delete', 'patch'].includes(httpMethod)) {
+      return;
+    }
+
+    const acquirePolicyToken = this.add(new Property('AcquirePolicyToken', SwitchParameter, { attributes: [], description: 'Acquire a policy evaluation token for this change and include it on the write request.' }));
+    acquirePolicyToken.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Acquire a policy evaluation token for this change and include it on the write request."'] }));
+    acquirePolicyToken.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
+
+    const changeReference = this.add(new Property('ChangeReference', dotnet.String, { attributes: [], description: 'A caller-supplied reference that correlates this change with an external change-management record.' }));
+    changeReference.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "A caller-supplied reference that correlates this change with an external change-management record."'] }));
+    changeReference.add(new Attribute(ValidateNotNull));
+    changeReference.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
   }
   private implementIEventListener() {
     const $this = this;

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -15,7 +15,7 @@ import {
   Switch, System, TerminalCase, toExpression, Try, Using, valueOf, Field, IsNull, Or, ExpressionOrLiteral, TerminalDefaultCase, xmlize, TypeDeclaration, And, IsNotNull, PartialMethod, Case, While, LiteralStatement, Not, ElseIf
 } from '@azure-tools/codegen-csharp';
 import { ClientRuntime, EventListener, Schema, ArrayOf, EnumImplementation } from '../llcsharp/exports';
-import { NullableBoolean, Alias, ArgumentCompleterAttribute, PSArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, ExternalDocsAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute, HttpPathAttribute, NotSuggestDefaultParameterSetAttribute } from '../internal/powershell-declarations';
+import { NullableBoolean, Alias, ArgumentCompleterAttribute, PSArgumentCompleterAttribute, AsyncCommandRuntime, AsyncJob, CmdletAttribute, ErrorCategory, ErrorRecord, Events, IDynamicParameters, InvocationInfo, OutputTypeAttribute, ParameterAttribute, PSCmdlet, PSCredential, SwitchParameter, ValidateNotNull, verbEnum, GeneratedAttribute, DescriptionAttribute, ExternalDocsAttribute, CategoryAttribute, ParameterCategory, ProfileAttribute, PSObject, InternalExportAttribute, ExportAsAttribute, DefaultRunspace, RunspaceFactory, AllowEmptyCollectionAttribute, DoNotExportAttribute, HttpPathAttribute, NotSuggestDefaultParameterSetAttribute } from '../internal/powershell-declarations';
 import { State } from '../internal/state';
 import { Channel } from '@autorest/extension-base';
 import { IParameter } from '@azure-tools/codemodel-v3/dist/code-model/components';
@@ -460,7 +460,7 @@ export class CmdletClass extends Class {
     // implement part of the IContext
     this.implementIContext();
 
-    // Change Safety: emit codegen-owned static parameters on write-verb cmdlets
+    // Change Safety: emit codegen-owned inline dynamic parameters on write-verb cmdlets
     this.implementChangeSafetyParameters();
 
     // add constructors
@@ -1626,10 +1626,12 @@ export class CmdletClass extends Class {
     this.add(extensibleParametersProp);
   }
   private implementChangeSafetyParameters() {
-    // Change Safety (codegen-owned static parameters): only azure management-plane (ARM)
-    // write cmdlets expose the opt-in Change Safety parameters. The parameter values are read
-    // by the module-level HTTP pipeline step (in Az.Accounts) from the cmdlet's BoundParameters,
-    // so no runtime-wired delegate is required here.
+    // Change Safety (codegen-owned inline dynamic parameters): only azure management-plane (ARM)
+    // write cmdlets expose the opt-in Change Safety parameters. They are surfaced via an inline
+    // IDynamicParameters implementation (the same dynamic-parameter mechanism SDK cmdlets use),
+    // emitted directly in the generated cmdlet -- no runtime-wired VTable delegate. PowerShell
+    // binds the returned parameters into BoundParameters, where the module-level HTTP pipeline
+    // step (in Az.Accounts) reads them.
     // Opt-in per module via `enable-change-safety: true` in the module readme (default off), so
     // the 180+ module rollout is deliberate rather than triggered by any unrelated regeneration.
     if (!this.state.project.enableChangeSafety) {
@@ -1656,14 +1658,22 @@ export class CmdletClass extends Class {
       return;
     }
 
-    const acquirePolicyToken = this.add(new Property('AcquirePolicyToken', SwitchParameter, { attributes: [], description: 'Acquire an Azure Policy token automatically for this resource operation.' }));
-    acquirePolicyToken.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Acquire an Azure Policy token automatically for this resource operation."'] }));
-    acquirePolicyToken.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
-
-    const changeReference = this.add(new Property('ChangeReference', dotnet.String, { attributes: [], description: 'The change reference resource ID for this resource operation.' }));
-    changeReference.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "The change reference resource ID for this resource operation."'] }));
-    changeReference.add(new Attribute(ValidateNotNull));
-    changeReference.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
+    // Emit an inline IDynamicParameters implementation. GetDynamicParameters builds the
+    // RuntimeDefinedParameterDictionary locally with names + help text that mirror
+    // azure-powershell-common's ChangeSafetyParameters (there is no compile-time link across repos;
+    // a contract pin test in Accounts.Test keeps these literals in sync). This matches how SDK
+    // cmdlets surface -AcquirePolicyToken / -ChangeReference, so the two are indistinguishable.
+    this.interfaces.push(IDynamicParameters);
+    const getDynamicParameters = this.add(new Method('GetDynamicParameters', dotnet.Object, {
+      description: 'Returns the Change Safety dynamic parameters (-AcquirePolicyToken / -ChangeReference) for this write cmdlet.',
+      returnsDescription: 'A <see cref="System.Management.Automation.RuntimeDefinedParameterDictionary" /> containing the Change Safety parameters.'
+    }));
+    getDynamicParameters.add(function* () {
+      yield 'var parameters = new global::System.Management.Automation.RuntimeDefinedParameterDictionary();';
+      yield 'parameters.Add("AcquirePolicyToken", new global::System.Management.Automation.RuntimeDefinedParameter("AcquirePolicyToken", typeof(global::System.Management.Automation.SwitchParameter), new global::System.Collections.ObjectModel.Collection<global::System.Attribute> { new global::System.Management.Automation.ParameterAttribute { HelpMessage = "Acquire an Azure Policy token automatically for this resource operation.", ParameterSetName = global::System.Management.Automation.ParameterAttribute.AllParameterSets } }));';
+      yield 'parameters.Add("ChangeReference", new global::System.Management.Automation.RuntimeDefinedParameter("ChangeReference", typeof(string), new global::System.Collections.ObjectModel.Collection<global::System.Attribute> { new global::System.Management.Automation.ParameterAttribute { HelpMessage = "The change reference resource ID for this resource operation.", ParameterSetName = global::System.Management.Automation.ParameterAttribute.AllParameterSets } }));';
+      yield 'return parameters;';
+    });
   }
   private implementIEventListener() {
     const $this = this;

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1626,11 +1626,17 @@ export class CmdletClass extends Class {
     this.add(extensibleParametersProp);
   }
   private implementChangeSafetyParameters() {
-    // Change Safety (codegen-owned static parameters): only azure write-verb cmdlets
-    // (PUT/POST/DELETE/PATCH) expose the opt-in Change Safety parameters. The parameter
-    // values are read by the module-level HTTP pipeline step (in Az.Accounts) from the
-    // cmdlet's BoundParameters, so no runtime-wired delegate is required here.
+    // Change Safety (codegen-owned static parameters): only azure management-plane (ARM)
+    // write-verb cmdlets (PUT/POST/DELETE/PATCH) expose the opt-in Change Safety parameters.
+    // The parameter values are read by the module-level HTTP pipeline step (in Az.Accounts)
+    // from the cmdlet's BoundParameters, so no runtime-wired delegate is required here.
     if (!this.state.project.azure) {
+      return;
+    }
+    // Change Safety is a management-plane concept; skip data-plane modules, which target a
+    // custom service endpoint (identified by an endpoint-resource-id-key-name). This matches
+    // the data-plane detection used in module-class.ts (isDataPlane).
+    if (this.state.project.endpointResourceIdKeyName) {
       return;
     }
     const httpMethod = (this.apiCall.requests?.[0]?.protocol.http?.method ?? '').toLowerCase();

--- a/powershell/cmdlets/class.ts
+++ b/powershell/cmdlets/class.ts
@@ -1644,12 +1644,12 @@ export class CmdletClass extends Class {
       return;
     }
 
-    const acquirePolicyToken = this.add(new Property('AcquirePolicyToken', SwitchParameter, { attributes: [], description: 'Acquire a policy evaluation token for this change and include it on the write request.' }));
-    acquirePolicyToken.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Acquire a policy evaluation token for this change and include it on the write request."'] }));
+    const acquirePolicyToken = this.add(new Property('AcquirePolicyToken', SwitchParameter, { attributes: [], description: 'Acquire an Azure Policy token automatically for this resource operation.' }));
+    acquirePolicyToken.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "Acquire an Azure Policy token automatically for this resource operation."'] }));
     acquirePolicyToken.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
 
-    const changeReference = this.add(new Property('ChangeReference', dotnet.String, { attributes: [], description: 'A caller-supplied reference that correlates this change with an external change-management record.' }));
-    changeReference.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "A caller-supplied reference that correlates this change with an external change-management record."'] }));
+    const changeReference = this.add(new Property('ChangeReference', dotnet.String, { attributes: [], description: 'The change reference resource ID for this resource operation.' }));
+    changeReference.add(new Attribute(ParameterAttribute, { parameters: ['Mandatory = false', 'HelpMessage = "The change reference resource ID for this resource operation."'] }));
     changeReference.add(new Attribute(ValidateNotNull));
     changeReference.add(new Attribute(CategoryAttribute, { parameters: [`${ParameterCategory}.Azure`] }));
   }

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -47,10 +47,7 @@ export async function generatePsm1(project: Project) {
     const localModulesPath = relative(project.baseFolder, project.dependencyModuleFolder);
     let requestHandler = `
   # Tweaks the pipeline per call
-  $instance.OnNewRequest = $VTable.OnNewRequest
-
-  # Tweaks the pipeline per call (Change Safety policy-token step)
-  $instance.PolicyTokenHandler = $VTable.PolicyTokenHandler`;
+  $instance.OnNewRequest = $VTable.OnNewRequest`;
     if (project.endpointResourceIdKeyName) {
       // for data plane, we should append different functions instead.
       requestHandler = `
@@ -63,6 +60,10 @@ export async function generatePsm1(project: Project) {
   # Tweaks the pipeline per call
   $instance.AddAuthorizeRequestHandler = $VTable.AddAuthorizeRequestHandler
     `;
+    } else {
+      requestHandler += `
+  # Tweaks the pipeline per call (Change Safety policy-token step)
+  $instance.PolicyTokenHandler = $VTable.PolicyTokenHandler`;
     }
     azureInitialize = `
   # ----------------------------------------------------------------------------------

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -47,14 +47,10 @@ export async function generatePsm1(project: Project) {
     const localModulesPath = relative(project.baseFolder, project.dependencyModuleFolder);
     let requestHandler = `
   # Tweaks the pipeline per call
-  $instance.OnNewRequest = $VTable.OnNewRequest`;
-    if (project.enableChangeSafety) {
-      // Change Safety: policy-token step, invoked after OnNewRequest
-      requestHandler += `
+  $instance.OnNewRequest = $VTable.OnNewRequest
 
   # Tweaks the pipeline per call (Change Safety policy-token step)
   $instance.PolicyTokenHandler = $VTable.PolicyTokenHandler`;
-    }
     if (project.endpointResourceIdKeyName) {
       // for data plane, we should append different functions instead.
       requestHandler = `

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -63,7 +63,7 @@ export async function generatePsm1(project: Project) {
     } else {
       requestHandler += `
   # Tweaks the pipeline per call (Change Safety policy-token step)
-  $instance.PolicyTokenHandler = $VTable.PolicyTokenHandler`;
+  $instance.AddChangeSafetyPolicyTokenHandler = $VTable.AddChangeSafetyPolicyTokenHandler`;
     }
     azureInitialize = `
   # ----------------------------------------------------------------------------------

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -60,7 +60,7 @@ export async function generatePsm1(project: Project) {
   # Tweaks the pipeline per call
   $instance.AddAuthorizeRequestHandler = $VTable.AddAuthorizeRequestHandler
     `;
-    } else {
+    } else if (project.enableChangeSafety) {
       requestHandler += `
   # Tweaks the pipeline per call (Change Safety policy-token step)
   $instance.AddChangeSafetyPolicyTokenHandler = $VTable.AddChangeSafetyPolicyTokenHandler`;

--- a/powershell/generators/psm1.ts
+++ b/powershell/generators/psm1.ts
@@ -48,6 +48,13 @@ export async function generatePsm1(project: Project) {
     let requestHandler = `
   # Tweaks the pipeline per call
   $instance.OnNewRequest = $VTable.OnNewRequest`;
+    if (project.enableChangeSafety) {
+      // Change Safety: policy-token step, invoked after OnNewRequest
+      requestHandler += `
+
+  # Tweaks the pipeline per call (Change Safety policy-token step)
+  $instance.PolicyTokenHandler = $VTable.PolicyTokenHandler`;
+    }
     if (project.endpointResourceIdKeyName) {
       // for data plane, we should append different functions instead.
       requestHandler = `

--- a/powershell/internal/powershell-declarations.ts
+++ b/powershell/internal/powershell-declarations.ts
@@ -32,6 +32,7 @@ export const ErrorRecord: TypeDeclaration = new ClassType(sma, 'ErrorRecord');
 export const SwitchParameter: TypeDeclaration = new ClassType(sma, 'SwitchParameter');
 export const NullableBoolean: TypeDeclaration = new ClassType(new Namespace('System'), 'Boolean?');
 export const IArgumentCompleter: IInterface = { allProperties: [], declaration: 'System.Management.Automation.IArgumentCompleter' };
+export const IDynamicParameters: IInterface = { allProperties: [], declaration: 'System.Management.Automation.IDynamicParameters' };
 export const CompletionResult: TypeDeclaration = new ClassType(sma, 'CompletionResult');
 export const CommandAst: TypeDeclaration = new ClassType(`${sma}.Language`, 'CommandAst');
 export const CompletionResultType: TypeDeclaration = new ClassType(sma, 'CompletionResultType');

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -128,7 +128,7 @@ export class Project extends codeDomProject {
   public modelCmdletFolder!: string;
   public endpointResourceIdKeyName!: string;
   public endpointSuffixKeyName!: string;
-  public changeSafety!: boolean;
+  public enableChangeSafety!: boolean;
 
   public customFolder!: string;
   public utilsFolder!: string;
@@ -338,7 +338,7 @@ export class Project extends codeDomProject {
     // Change Safety: opt-in per module. When true, azure management-plane write-verb cmdlets get the
     // -AcquirePolicyToken / -ChangeReference parameters. Default false so the rollout is controlled
     // (a module opts in, alongside bumping its Az.Accounts minimum), not organic on every regeneration.
-    this.changeSafety = await this.state.getValue('change-safety', false);
+    this.enableChangeSafety = await this.state.getValue('enable-change-safety', false);
 
     // File paths
     this.csproj = await this.state.getValue('csproj');

--- a/powershell/internal/project.ts
+++ b/powershell/internal/project.ts
@@ -128,6 +128,7 @@ export class Project extends codeDomProject {
   public modelCmdletFolder!: string;
   public endpointResourceIdKeyName!: string;
   public endpointSuffixKeyName!: string;
+  public changeSafety!: boolean;
 
   public customFolder!: string;
   public utilsFolder!: string;
@@ -333,6 +334,11 @@ export class Project extends codeDomProject {
 
     // configuration for whether to use fixed array in generated code of model, default is false
     this.fixedArray = await this.state.getValue('fixed-array', false);
+
+    // Change Safety: opt-in per module. When true, azure management-plane write-verb cmdlets get the
+    // -AcquirePolicyToken / -ChangeReference parameters. Default false so the rollout is controlled
+    // (a module opts in, alongside bumping its Az.Accounts minimum), not organic on every regeneration.
+    this.changeSafety = await this.state.getValue('change-safety', false);
 
     // File paths
     this.csproj = await this.state.getValue('csproj');

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -310,7 +310,7 @@ export class NewModuleClass extends Class {
     }
 
     namespace.add(newRequestPipelineDelegate);
-    if (!isDataPlane) {
+    if (!isDataPlane && this.state.project.enableChangeSafety) {
       namespace.add(changeSafetyPolicyTokenDelegate);
     }
 
@@ -338,7 +338,9 @@ export class NewModuleClass extends Class {
       this.add(AddAuthorizeRequestHandler);
     } else {
       this.add(OnNewRequest);
-      this.add(AddChangeSafetyPolicyTokenHandler);
+      if (this.state.project.enableChangeSafety) {
+        this.add(AddChangeSafetyPolicyTokenHandler);
+      }
     }
     const GetParameterValue = this.add(new Property('GetParameterValue', getParameterDelegate, { description: 'The delegate to call to get parameter data from a common module.' }));
     const EventListener = this.add(new Property('EventListener', eventListenerDelegate, { description: 'A delegate that gets called for each signalled event' }));

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -253,7 +253,7 @@ export class NewModuleClass extends Class {
       pipelineChangeDelegate.fullDefinition)); /* appendStep */
 
     // Change Safety: dedicated append-only delegate for the policy-token pipeline step.
-    const acquirePolicyTokenDelegate = new Alias('AcquirePolicyTokenDelegate', System.Action(
+    const changeSafetyPolicyTokenDelegate = new Alias('ChangeSafetyPolicyTokenDelegate', System.Action(
       InvocationInfo,  /* invocationInfo */
       pipelineChangeDelegate.fullDefinition)); /* appendStep */
 
@@ -311,7 +311,7 @@ export class NewModuleClass extends Class {
 
     namespace.add(newRequestPipelineDelegate);
     if (!isDataPlane) {
-      namespace.add(acquirePolicyTokenDelegate);
+      namespace.add(changeSafetyPolicyTokenDelegate);
     }
 
     const incomingSignalDelegate = namespace.add(new Alias('SignalDelegate', this.incomingSignalFunc));
@@ -322,7 +322,7 @@ export class NewModuleClass extends Class {
     /* AzAccounts VTable properties  */
     const OnModuleLoad = this.add(new Property('OnModuleLoad', moduleLoadPipelineDelegate, { description: 'The delegate to call when this module is loaded (supporting a commmon module).' }));
     const OnNewRequest = new Property('OnNewRequest', newRequestPipelineDelegate, { description: 'The delegate to call before each new request (supporting a commmon module).' });
-    const PolicyTokenHandler = new Property('PolicyTokenHandler', acquirePolicyTokenDelegate, { description: 'Change Safety: delegate called after OnNewRequest to (conditionally) add the policy-token pipeline step.' });
+    const AddChangeSafetyPolicyTokenHandler = new Property('AddChangeSafetyPolicyTokenHandler', changeSafetyPolicyTokenDelegate, { description: 'Change Safety: delegate called after OnNewRequest to (conditionally) add the policy-token pipeline step.' });
     const AddRequestUserAgentHandler = new Property('AddRequestUserAgentHandler', newRequestPipelineDelegate, { description: 'The delegate to call before each new request to add request user agent.' });
     const AddPatchRequestUriHandler = new Property('AddPatchRequestUriHandler', newRequestPipelineDelegate, { description: 'The delegate to call before each new request to patch request uri.' });
     const AddAuthorizeRequestHandler = new Property('AddAuthorizeRequestHandler', authorizeRequestDelegate, { description: 'The delegate to call before each new request to add authorization.' });
@@ -338,7 +338,7 @@ export class NewModuleClass extends Class {
       this.add(AddAuthorizeRequestHandler);
     } else {
       this.add(OnNewRequest);
-      this.add(PolicyTokenHandler);
+      this.add(AddChangeSafetyPolicyTokenHandler);
     }
     const GetParameterValue = this.add(new Property('GetParameterValue', getParameterDelegate, { description: 'The delegate to call to get parameter data from a common module.' }));
     const EventListener = this.add(new Property('EventListener', eventListenerDelegate, { description: 'A delegate that gets called for each signalled event' }));
@@ -413,7 +413,7 @@ export class NewModuleClass extends Class {
       } else {
         yield `${OnNewRequest.value}?.Invoke( ${$this.pInvocationInfo.use}, ${$this.pCorrelationId},${$this.pProcessRecordId}, (step)=> { ${pip}.Prepend(step); } , (step)=> { ${pip}.Append(step); } );`;
         if ($this.state.project.enableChangeSafety) {
-          yield `${PolicyTokenHandler.value}?.Invoke( ${$this.pInvocationInfo.use}, (step)=> { ${pip}.Append(step); } );`;
+          yield `${AddChangeSafetyPolicyTokenHandler.value}?.Invoke( ${$this.pInvocationInfo.use}, (step)=> { ${pip}.Append(step); } );`;
         }
       }
       yield Return(pip);

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -252,6 +252,11 @@ export class NewModuleClass extends Class {
       pipelineChangeDelegate.fullDefinition,    /* prependStep */
       pipelineChangeDelegate.fullDefinition)); /* appendStep */
 
+    // Change Safety: dedicated append-only delegate for the policy-token pipeline step.
+    const acquirePolicyTokenDelegate = new Alias('AcquirePolicyTokenDelegate', System.Action(
+      InvocationInfo,  /* invocationInfo */
+      pipelineChangeDelegate.fullDefinition)); /* appendStep */
+
     const argumentCompleterDelegate = namespace.add(new Alias('ArgumentCompleterDelegate', System.Func(
       dotnet.String, /* completerName */
       InvocationInfo, /* invocationInfo */
@@ -305,6 +310,9 @@ export class NewModuleClass extends Class {
     }
 
     namespace.add(newRequestPipelineDelegate);
+    if (this.state.project.enableChangeSafety) {
+      namespace.add(acquirePolicyTokenDelegate);
+    }
 
     const incomingSignalDelegate = namespace.add(new Alias('SignalDelegate', this.incomingSignalFunc));
     const eventListenerDelegate = namespace.add(new Alias('EventListenerDelegate', this.eventListenerFunc));
@@ -314,6 +322,7 @@ export class NewModuleClass extends Class {
     /* AzAccounts VTable properties  */
     const OnModuleLoad = this.add(new Property('OnModuleLoad', moduleLoadPipelineDelegate, { description: 'The delegate to call when this module is loaded (supporting a commmon module).' }));
     const OnNewRequest = new Property('OnNewRequest', newRequestPipelineDelegate, { description: 'The delegate to call before each new request (supporting a commmon module).' });
+    const PolicyTokenHandler = new Property('PolicyTokenHandler', acquirePolicyTokenDelegate, { description: 'Change Safety: delegate called after OnNewRequest to (conditionally) add the policy-token pipeline step.' });
     const AddRequestUserAgentHandler = new Property('AddRequestUserAgentHandler', newRequestPipelineDelegate, { description: 'The delegate to call before each new request to add request user agent.' });
     const AddPatchRequestUriHandler = new Property('AddPatchRequestUriHandler', newRequestPipelineDelegate, { description: 'The delegate to call before each new request to patch request uri.' });
     const AddAuthorizeRequestHandler = new Property('AddAuthorizeRequestHandler', authorizeRequestDelegate, { description: 'The delegate to call before each new request to add authorization.' });
@@ -329,6 +338,9 @@ export class NewModuleClass extends Class {
       this.add(AddAuthorizeRequestHandler);
     } else {
       this.add(OnNewRequest);
+      if (this.state.project.enableChangeSafety) {
+        this.add(PolicyTokenHandler);
+      }
     }
     const GetParameterValue = this.add(new Property('GetParameterValue', getParameterDelegate, { description: 'The delegate to call to get parameter data from a common module.' }));
     const EventListener = this.add(new Property('EventListener', eventListenerDelegate, { description: 'A delegate that gets called for each signalled event' }));
@@ -402,6 +414,9 @@ export class NewModuleClass extends Class {
         yield `${AddAuthorizeRequestHandler.value}?.Invoke( ${$this.pInvocationInfo.use}, ${fendpointResourceIdKeyName},${fEndpointSuffixKeyName}, (step)=> { ${pip}.Prepend(step); } , (step)=> { ${pip}.Append(step); }, ${fTokenAudienceConverter}, ${$this.pExtensibleParameters} );`;
       } else {
         yield `${OnNewRequest.value}?.Invoke( ${$this.pInvocationInfo.use}, ${$this.pCorrelationId},${$this.pProcessRecordId}, (step)=> { ${pip}.Prepend(step); } , (step)=> { ${pip}.Append(step); } );`;
+        if ($this.state.project.enableChangeSafety) {
+          yield `${PolicyTokenHandler.value}?.Invoke( ${$this.pInvocationInfo.use}, (step)=> { ${pip}.Append(step); } );`;
+        }
       }
       yield Return(pip);
     });

--- a/powershell/module/module-class.ts
+++ b/powershell/module/module-class.ts
@@ -310,7 +310,7 @@ export class NewModuleClass extends Class {
     }
 
     namespace.add(newRequestPipelineDelegate);
-    if (this.state.project.enableChangeSafety) {
+    if (!isDataPlane) {
       namespace.add(acquirePolicyTokenDelegate);
     }
 
@@ -338,9 +338,7 @@ export class NewModuleClass extends Class {
       this.add(AddAuthorizeRequestHandler);
     } else {
       this.add(OnNewRequest);
-      if (this.state.project.enableChangeSafety) {
-        this.add(PolicyTokenHandler);
-      }
+      this.add(PolicyTokenHandler);
     }
     const GetParameterValue = this.add(new Property('GetParameterValue', getParameterDelegate, { description: 'The delegate to call to get parameter data from a common module.' }));
     const EventListener = this.add(new Property('EventListener', eventListenerDelegate, { description: 'A delegate that gets called for each signalled event' }));

--- a/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -128,6 +128,7 @@ ${$project.pwshCommentHeaderForCsharp}
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
+++ b/powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Rest.ClientRuntime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Runtime.Pow
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Runtime.Pow
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Runtime.Pow
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/AppComplianceAutomation.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AppComplianceAutomation.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Astronomer.Astro.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Astro.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/AzureAI.Assets/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/AzureAI.Assets/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MachineLearningServices.Runtime.Pow
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/AzureAI.Assets/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/AzureAI.Assets/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MachineLearningServices.Runtime.Pow
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MachineLearningServices.Runtime.Pow
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/AzureAI.Assets/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/AzureAI.Assets/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MachineLearningServices.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/AzureFleet.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeFleet.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Runtime.PowerShe
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Runtime.PowerShe
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Runtime.PowerShe
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/AzureLargeInstance.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.AzureLargeInstance.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Chaos.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Chaos.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Chaos.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Chaos.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Chaos.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Chaos.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Chaos.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/CodeSigning.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.CodeSigning.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/ComputeSchedule.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/ComputeSchedule.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeSchedule.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/ComputeSchedule.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/ComputeSchedule.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeSchedule.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeSchedule.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/ComputeSchedule.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/ComputeSchedule.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ComputeSchedule.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Dashboard.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Dashboard.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Dashboard.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Dashboard.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Dashboard.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Dashboard.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Dashboard.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DataBox.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/DataBox.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DataBox.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/DataBox.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/DataBox.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DataBox.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DataBox.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DataProtection.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/DataProtection.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DataProtection.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/DataProtection.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/DataProtection.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DataProtection.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DataProtection.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DataReplication.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/DataReplication.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServicesDataReplication.Run
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/DataReplication.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/DataReplication.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServicesDataReplication.Run
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServicesDataReplication.Run
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DeviceProvisioningServices.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/DeviceProvisioningServices.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceProvisioningServices.Runtime.
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/DeviceProvisioningServices.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/DeviceProvisioningServices.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceProvisioningServices.Runtime.
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceProvisioningServices.Runtime.
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/DeviceRegistry.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DeviceRegistry.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/DocumentDB.MongoCluster.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MongoCluster.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/EdgeZones.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/EdgeZones.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.EdgeZones.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/EdgeZones.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/EdgeZones.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.EdgeZones.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.EdgeZones.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/EdgeZones.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/EdgeZones.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.EdgeZones.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/ElasticSan.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/ElasticSan.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ElasticSan.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/ElasticSan.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/ElasticSan.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ElasticSan.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ElasticSan.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Fleet.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Fleet.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerServiceFleet.Runtime.Power
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Fleet.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Fleet.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerServiceFleet.Runtime.Power
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerServiceFleet.Runtime.Power
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/HardwareSecurityModules.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/HardwareSecurityModules.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Hsm.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/HardwareSecurityModules.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/HardwareSecurityModules.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Hsm.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Hsm.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Runtime.PowerS
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Runtime.PowerS
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Runtime.PowerS
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/HealthDataAIServices.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HealthDataAIServices.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Help.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Help.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Help.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Help.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Help.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Help.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Help.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/HybridKubernetes.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/HybridKubernetes.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HybridKubernetes.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/HybridKubernetes.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/HybridKubernetes.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HybridKubernetes.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.HybridKubernetes.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Informatica.DataManagement.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Informatica.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/KeyVault.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/KeyVault.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.KeyVault.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/KeyVault.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/KeyVault.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.KeyVault.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.KeyVault.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Runtim
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Runtim
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Runtim
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/KubernetesRuntime.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ContainerOrchestratorRuntime.Runtim
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/LambdaTest.HyperExecute.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.LambdaTest.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Liftr.WeightsAndBiases.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.WeightsBiases.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Microsoft.AVS.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.AVS.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.VMware.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Microsoft.AVS.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.AVS.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.VMware.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.VMware.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Microsoft.AVS.Management.brown/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.AVS.Management.brown/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.VMware.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Microsoft.DBforMySQL.FlexibleServers.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DBforMySQL.FlexibleServers.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MySql.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Microsoft.DBforMySQL.FlexibleServers.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DBforMySQL.FlexibleServers.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MySql.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.MySql.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Runtime.PowerS
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Runtime.PowerS
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Runtime.PowerS
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.DevOpsInfrastructure.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.DevOpsInfrastructure.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Microsoft.RecoveryServices.RecoveryServicesBackup.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.RecoveryServices.RecoveryServicesBackup.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServicesBackup.Runtime.Powe
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Microsoft.RecoveryServices.RecoveryServicesBackup.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Microsoft.RecoveryServices.RecoveryServicesBackup.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServicesBackup.Runtime.Powe
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServicesBackup.Runtime.Powe
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Neon.Postgres.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NeonPostgres.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/NetworkAnalytics.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.NetworkAnalytics.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Oracle.Database.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Oracle.Database.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.OracleDatabase.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Oracle.Database.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Oracle.Database.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.OracleDatabase.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.OracleDatabase.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Pinecone.VectorDb.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Pinecone.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Qumulo.Storage.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Qumulo.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/RecoveryServices.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/RecoveryServices.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServices.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/RecoveryServices.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/RecoveryServices.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServices.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.RecoveryServices.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/ServiceFabricManagedClusters.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/ServiceFabricManagedClusters.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ServiceFabricManagedClusters.Runtim
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/ServiceFabricManagedClusters.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/ServiceFabricManagedClusters.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ServiceFabricManagedClusters.Runtim
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.ServiceFabricManagedClusters.Runtim
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Sphere.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Sphere.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.Sphere.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/StandbyPool.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StandbyPool.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/StorageAction.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/StorageAction.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageAction.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/StorageAction.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/StorageAction.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageAction.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageAction.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/StorageAction.Management.brown/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/StorageAction.Management.brown/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageAction.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {

--- a/tests-upgrade/tests-emitter/StorageMover.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/StorageMover.Management.brown/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageMover.Runtime.PowerShell
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/StorageMover.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/StorageMover.Management.brown/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageMover.Runtime.PowerShell
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.StorageMover.Runtime.PowerShell
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/runtime/BuildTime/Cmdlets/ExportProxyCmdlet.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Runtime.PowerShe
                     }
                     sb.Append($"){Environment.NewLine}{Environment.NewLine}");
 
+                    sb.Append(variantGroup.ToDynamicParamOutput());
                     sb.Append(variantGroup.ToBeginOutput());
                     sb.Append(variantGroup.ToProcessOutput());
                     sb.Append(variantGroup.ToEndOutput());

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/runtime/BuildTime/Models/PsProxyOutputs.cs
@@ -199,6 +199,59 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Runtime.PowerShe
         }
     }
 
+    internal class DynamicParamOutput : BaseOutput
+    {
+        public DynamicParamOutput(VariantGroup variantGroup) : base(variantGroup)
+        {
+        }
+
+        // Change Safety: only emit a dynamicparam block when a wrapped (private) cmdlet actually declares
+        // dynamic parameters via IDynamicParameters. For every other cmdlet this emits nothing (zero diff),
+        // so it is a no-op that just forwards the private cmdlet's runtime parameters through the proxy.
+        private bool HasDynamicParameters() => VariantGroup.Variants.Any(v =>
+        {
+            var implementingType = (v.Info as CmdletInfo)?.ImplementingType;
+            return implementingType != null && typeof(IDynamicParameters).IsAssignableFrom(implementingType);
+        });
+
+        private string GetParameterSetToCmdletMapping()
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"{Indent}$mapping = @{{");
+            foreach (var variant in VariantGroup.Variants)
+            {
+                sb.AppendLine($@"{Indent}{Indent}{variant.VariantName} = '{variant.PrivateModuleName}\{variant.PrivateCmdletName}';");
+            }
+            sb.Append($"{Indent}}}");
+            return sb.ToString();
+        }
+
+        public override string ToString() => !HasDynamicParameters() ? String.Empty : $@"dynamicparam {{
+{Indent}$parameterSet = $PSCmdlet.ParameterSetName
+{GetParameterSetToCmdletMapping()}
+{Indent}if (-not $mapping.ContainsKey($parameterSet)) {{ $parameterSet = @($mapping.Keys)[0] }}
+{Indent}try {{
+{Indent}{Indent}$targetCmd = $ExecutionContext.InvokeCommand.GetCommand(($mapping[$parameterSet]), [System.Management.Automation.CommandTypes]::Cmdlet, $PSBoundParameters)
+{Indent}{Indent}$dynamicParams = @($targetCmd.Parameters.GetEnumerator() | Microsoft.PowerShell.Core\Where-Object {{ $_.Value.IsDynamic }})
+{Indent}{Indent}if ($dynamicParams.Length -gt 0) {{
+{Indent}{Indent}{Indent}$paramDictionary = [System.Management.Automation.RuntimeDefinedParameterDictionary]::new()
+{Indent}{Indent}{Indent}foreach ($param in $dynamicParams) {{
+{Indent}{Indent}{Indent}{Indent}$param = $param.Value
+{Indent}{Indent}{Indent}{Indent}if (-not $MyInvocation.MyCommand.Parameters.ContainsKey($param.Name)) {{
+{Indent}{Indent}{Indent}{Indent}{Indent}$dynParam = [System.Management.Automation.RuntimeDefinedParameter]::new($param.Name, $param.ParameterType, $param.Attributes)
+{Indent}{Indent}{Indent}{Indent}{Indent}$paramDictionary.Add($param.Name, $dynParam)
+{Indent}{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}}}
+{Indent}{Indent}{Indent}return $paramDictionary
+{Indent}{Indent}}}
+{Indent}}} catch {{
+{Indent}{Indent}throw
+{Indent}}}
+}}
+
+";
+    }
+
     internal class BeginOutput : BaseOutput
     {
         public BeginOutput(VariantGroup variantGroup) : base(variantGroup)
@@ -639,6 +692,8 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Runtime.PowerShe
         public static ParameterTypeOutput ToParameterTypeOutput(this Type parameterType) => new ParameterTypeOutput(parameterType);
 
         public static ParameterNameOutput ToParameterNameOutput(this string parameterName, bool isLast) => new ParameterNameOutput(parameterName, isLast);
+
+        public static DynamicParamOutput ToDynamicParamOutput(this VariantGroup variantGroup) => new DynamicParamOutput(variantGroup);
 
         public static BeginOutput ToBeginOutput(this VariantGroup variantGroup) => new BeginOutput(variantGroup);
 

--- a/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/runtime/Context.cs
+++ b/tests-upgrade/tests-emitter/Workloads.SAPVirtualInstance.Management/target/generated/runtime/Context.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.PowerShell.Cmdlets.SAPVirtualInstance.Runtime
     /// The IContext Interface defines the communication mechanism for input customization.
     /// </summary>
     /// <remarks>
-    /// In the context, we will have client, pipeline, PSBoundParamters, default EventListener, Cancellation.
+    /// In the context, we will have client, pipeline, PSBoundParameters, default EventListener, Cancellation.
     /// </remarks>
     public interface IContext
     {


### PR DESCRIPTION
## Summary
Generator half of Change Safety for AutoRest **management-plane** modules, **opt-in** per module via an `enable-change-safety` config flag. Adds `-AcquirePolicyToken` and `-ChangeReference` to write-verb cmdlets and wires the pipeline step that acquires a policy token and stamps the `x-ms-policy-external-evaluations` header on write requests. Az.Accounts (Azure/azure-powershell#29840) fills the pipeline slot.

## What it does
1. **Parameter surfacing.** `implementChangeSafetyParameters()` in `cmdlets/class.ts` adds an inline `IDynamicParameters.GetDynamicParameters()` to generated write cmdlets, emitting `-AcquirePolicyToken` (`SwitchParameter`) and `-ChangeReference` (`string`) — the same dynamic-parameter mechanism SDK cmdlets use. Names + help text are reused verbatim from azure-powershell-common's `ChangeSafetyParameters` (a contract pin test in `Accounts.Test` keeps them in sync).
2. **Proxy forwarding.** The public proxy function wraps the private cmdlet with a static `param()` block, so `DynamicParamOutput` (`resources/psruntime/BuildTime/Models/PsProxyOutputs.cs`) emits a `dynamicparam` block that forwards the wrapped cmdlet's dynamic parameters — self-gated on the wrapped cmdlet implementing `IDynamicParameters`. `ExportProxyCmdlet.cs` inserts it between the proxy `param()` block and `begin{}`.
3. **Pipeline hook.** `module/module-class.ts` declares the `ChangeSafetyPolicyTokenDelegate` alias + `AddChangeSafetyPolicyTokenHandler` VTable property and invokes it in `CreatePipeline` right after `OnNewRequest`; `generators/psm1.ts` maps it in the `.psm1`.

`internal/project.ts` reads `enable-change-safety` into `Project.enableChangeSafety` (default **false**); `internal/powershell-declarations.ts` adds the `IDynamicParameters` declaration.

## Gating
All change-safety output — parameters, proxy `dynamicparam`, and the VTable plumbing — is gated on `enable-change-safety` (management-plane only). **Flag off (default): zero generated-code diff.** The proxy `dynamicparam` is additionally self-gated on `IDynamicParameters`, so cmdlets without dynamic parameters are unaffected. The only unconditional change is to the two build-time proxy runtime sources (`PsProxyOutputs.cs`, `ExportProxyCmdlet.cs`), which emit nothing extra for cmdlets without dynamic parameters.

## Scope
Seven files: `powershell/cmdlets/class.ts`, `powershell/module/module-class.ts`, `powershell/generators/psm1.ts`, `powershell/internal/project.ts`, `powershell/internal/powershell-declarations.ts`, `powershell/resources/psruntime/BuildTime/Models/PsProxyOutputs.cs`, `powershell/resources/psruntime/BuildTime/Cmdlets/ExportProxyCmdlet.cs`, plus refreshed `tests-emitter` baselines.

## Verification
- `npm run build`, `npm run eslint`, `npm test`, `tests-sdk1-support` (`-AllowList -SkipCsharp`): clean / all `Equal`.
- **`tests-emitter` baselines refreshed** for the 43 whitelisted cases: only the two build-time runtime sources change per case (no `Module.cs` / `.psm1` diff). The refresh also picks up a pre-existing stale `runtime/Context.cs` comment-typo baseline (fixed in the generator resource by #1514; 25 cases).

### Live end-to-end test (real Azure)
Validated the full flow on a real subscription with an opted-in module (`Az.ManagedServiceIdentity`, generated by this branch with `enable-change-safety`) plus the paired Az.Accounts build (Azure/azure-powershell#29840).

**Command**
```powershell
New-AzUserAssignedIdentity -ResourceGroupName rg-cs-e2e -Name mi-cs-e2e -Location eastus -AcquirePolicyToken -Confirm:$false
```
The **public proxy function** accepted `-AcquirePolicyToken` — surfaced via the generated `dynamicparam` forwarding block this PR adds — and the resource was created in ~3s. A read cmdlet does not surface the parameter.

**Pipeline trace** (temporary debug hook inside the acquirer step; no token value is ever logged)
```
[PolicyTokenAcquirer] Intercept PUT  .../userAssignedIdentities/mi-cs-e2e?api-version=2023-01-31
[PolicyTokenAcquirer] Payload prepared.
[PolicyTokenAcquirer] POST acquirePolicyToken  .../Microsoft.Authorization/acquirePolicyToken?api-version=2025-03-01
[PolicyTokenAcquirer] Response 200 OK
[PolicyTokenAcquirer] Token acquired and header added.
```

**HTTP result** (`-Debug`)
```
PUT https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/rg-cs-e2e/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-cs-e2e?api-version=2023-01-31
Body: { "location": "eastus" }

Status Code: OK
```

> Note: the AutoRest `-Debug` dump prints the request at `BeforeCall`, **before** the appended change-safety step runs, so `x-ms-policy-external-evaluations` is not visible in that dump. The trace above (captured inside the step) confirms the token was acquired and the header stamped on the wire, and the write returned `200 OK`. Test resources have since been deleted.

## Dependencies
- Pairs with Az.Accounts: Azure/azure-powershell#29840.
- Depends on shared core: Azure/azure-powershell-common#454.
- Design write-up: Azure/CLIPS#408.
- Kept **draft**: regenerated cmdlets take effect once this generator and Az.Accounts are released and modules opt in + regenerate.
